### PR TITLE
B-05395: Update the translation configuration based on review meeting tod

### DIFF
--- a/project-set/components/translation/src/main/resources/META-INF/schema/config/translation-configuration.xsd
+++ b/project-set/components/translation/src/main/resources/META-INF/schema/config/translation-configuration.xsd
@@ -55,9 +55,6 @@
 
     <xs:complexType name="RequestTranslationProcess">
         <xs:sequence>
-            <!-- Since the xprc.xsd uses anonymous complexTypes for the pipeline we have to use ref instead of type
-                 here and when we do that XJC doesn't create the proper attributes of the Pipeline class.
-                 Compile the translation component and take a look at the Pipeline class in generated-sources/xjc -->
             <xs:element ref="p:pipeline" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
 

--- a/project-set/components/translation/src/main/resources/META-INF/schema/config/xproc/xproc.xsd
+++ b/project-set/components/translation/src/main/resources/META-INF/schema/config/xproc/xproc.xsd
@@ -201,8 +201,6 @@
   </sequence>
  </group>
 
-    <!-- They use an anonymous complexType for the pipeline.  This doesn't gives us the class hierarchy we
-         need in XJC to easily work with the pipeline information.  -->
  <element name="pipeline">
   <complexType>
    <complexContent>


### PR DESCRIPTION
B-05395: Update the translation configuration based on review meeting today and so it uses the xproc schema.
