### PR TITLE
Add xsl that translates auth 2.0/keystone schemas so xjc can use them.  A

### DIFF
--- a/project-set/components/client-auth/pom.xml
+++ b/project-set/components/client-auth/pom.xml
@@ -29,6 +29,12 @@
             <groupId>com.rackspace.cloud.services.clients</groupId>
             <artifactId>rackspace-auth-v1.1</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.rackspace.cloud.services.clients</groupId>
+            <artifactId>rackspace-auth-v2.0</artifactId>
+            <version>1.0.3-SNAPSHOT</version>
+        </dependency>
         
         <dependency>
             <groupId>net.sf.ehcache</groupId>

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/AccountUsernameExtractor.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/AccountUsernameExtractor.java
@@ -1,0 +1,48 @@
+package com.rackspace.papi.components.clientauth.rackspace.v1_1;
+
+import com.rackspace.auth.v1_1.Account;
+import com.rackspace.papi.commons.util.StringUtilities;
+import com.rackspace.papi.components.clientauth.rackspace.config.AccountMapping;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author fran
+ */
+public class AccountUsernameExtractor {
+    private final List<AccountMapping> accountMappings;    
+    private final Map<AccountMapping, Pattern> compiledAccountMappingRegexes;
+
+    public AccountUsernameExtractor(List<AccountMapping> accountMappings) {
+        this.accountMappings = accountMappings;
+        this.compiledAccountMappingRegexes = new HashMap<AccountMapping, Pattern>();
+
+        compileRegexCache();
+    }
+
+    private void compileRegexCache() {
+        for (AccountMapping mapping : accountMappings) {
+            compiledAccountMappingRegexes.put(mapping, Pattern.compile(mapping.getIdRegex()));
+        }
+    }
+
+    public Account extract(String uri) {
+        for (Map.Entry<AccountMapping, Pattern> entry : compiledAccountMappingRegexes.entrySet()) {
+            final Matcher accountIdMatcher = entry.getValue().matcher(uri);
+
+            if (accountIdMatcher.find()) {
+                final String accountUsername = accountIdMatcher.group(accountIdMatcher.groupCount());
+
+                if (!StringUtilities.isBlank(accountUsername)) {
+                    return new Account(entry.getKey().getType().name(), accountUsername);
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/RackspaceAuthenticationHandler.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/RackspaceAuthenticationHandler.java
@@ -1,4 +1,9 @@
-package com.rackspace.papi.components.clientauth.rackspace;
+package com.rackspace.papi.components.clientauth.rackspace.v1_1;
+
+import com.rackspace.papi.filter.logic.AbstractFilterLogicHandler;
+
+
+import com.rackspace.papi.components.clientauth.rackspace.IdentityStatus;
 
 import com.rackspace.auth.v1_1.Account;
 import com.rackspace.auth.v1_1.AuthenticationServiceClient;
@@ -11,11 +16,8 @@ import com.rackspace.papi.commons.util.StringUtilities;
 import com.rackspace.papi.commons.util.http.CommonHttpHeader;
 import com.rackspace.papi.commons.util.http.HttpStatusCode;
 import com.rackspace.papi.auth.AuthModule;
-import com.rackspace.papi.commons.util.servlet.http.MutableHttpServletRequest;
-import com.rackspace.papi.commons.util.servlet.http.MutableHttpServletResponse;
 import com.rackspace.papi.commons.util.servlet.http.ReadableHttpServletResponse;
 import com.rackspace.papi.components.clientauth.rackspace.config.RackspaceAuth;
-import com.rackspace.papi.filter.logic.AbstractFilterLogicHandler;
 import com.rackspace.papi.filter.logic.FilterAction;
 import com.rackspace.papi.filter.logic.FilterDirector;
 import com.rackspace.papi.filter.logic.impl.FilterDirectorImpl;
@@ -124,8 +126,6 @@ public class RackspaceAuthenticationHandler extends AbstractFilterLogicHandler i
 
          filterDirector.requestHeaderManager().putHeader(CommonHttpHeader.IDENTITY_STATUS.headerKey(), identityStatus.name());
       }
-
-
    }
 
    private String[] getGroupsListIds(String accountUsername) {
@@ -141,8 +141,9 @@ public class RackspaceAuthenticationHandler extends AbstractFilterLogicHandler i
       return groupsArray;
    }
 
-   public void handleResponse(MutableHttpServletRequest request, MutableHttpServletResponse response) {
-      /// The WWW Authenticate header can be used to communicate to the client
+    @Override
+    public FilterDirector handleResponse(HttpServletRequest request, ReadableHttpServletResponse response) {
+        /// The WWW Authenticate header can be used to communicate to the client
       // (since we are a proxy) how to correctly authenticate itself
       final String wwwAuthenticateHeader = response.getHeader(CommonHttpHeader.WWW_AUTHENTICATE.headerKey());
 
@@ -154,9 +155,12 @@ public class RackspaceAuthenticationHandler extends AbstractFilterLogicHandler i
             updateHttpResponse(response, wwwAuthenticateHeader);
             break;
       }
-   }
 
-   private void updateHttpResponse(MutableHttpServletResponse httpResponse, String wwwAuthenticateHeader) {
+      // TODO: Do we need to return a valid FilterDirector here? 
+      return null;
+    }
+
+   private void updateHttpResponse(ReadableHttpServletResponse httpResponse, String wwwAuthenticateHeader) {
 
       // If in the case that the origin service supports delegated authentication
       // we should then communicate to the client how to authenticate with us

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v2_0/AccountUsernameExtractor.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v2_0/AccountUsernameExtractor.java
@@ -1,8 +1,9 @@
-package com.rackspace.papi.components.clientauth.rackspace;
+package com.rackspace.papi.components.clientauth.rackspace.v2_0;
 
-import com.rackspace.auth.v1_1.Account;
+import com.rackspace.auth.v2_0.Account;
 import com.rackspace.papi.commons.util.StringUtilities;
 import com.rackspace.papi.components.clientauth.rackspace.config.AccountMapping;
+import com.rackspace.papi.components.clientauth.rackspace.config.AccountMapping20;
 
 import java.util.HashMap;
 import java.util.List;
@@ -14,31 +15,31 @@ import java.util.regex.Pattern;
  * @author fran
  */
 public class AccountUsernameExtractor {
-    private final List<AccountMapping> accountMappings;    
-    private final Map<AccountMapping, Pattern> compiledAccountMappingRegexes;
+    private final List<AccountMapping20> accountMappings;
+    private final Map<AccountMapping20, Pattern> compiledAccountMappingRegexes;
 
-    public AccountUsernameExtractor(List<AccountMapping> accountMappings) {
+    public AccountUsernameExtractor(List<AccountMapping20> accountMappings) {
         this.accountMappings = accountMappings;
-        this.compiledAccountMappingRegexes = new HashMap<AccountMapping, Pattern>();
+        this.compiledAccountMappingRegexes = new HashMap<AccountMapping20, Pattern>();
 
         compileRegexCache();
     }
 
     private void compileRegexCache() {
-        for (AccountMapping mapping : accountMappings) {
+        for (AccountMapping20 mapping : accountMappings) {
             compiledAccountMappingRegexes.put(mapping, Pattern.compile(mapping.getIdRegex()));
         }
     }
 
     public Account extract(String uri) {
-        for (Map.Entry<AccountMapping, Pattern> entry : compiledAccountMappingRegexes.entrySet()) {
+        for (Map.Entry<AccountMapping20, Pattern> entry : compiledAccountMappingRegexes.entrySet()) {
             final Matcher accountIdMatcher = entry.getValue().matcher(uri);
 
             if (accountIdMatcher.find()) {
                 final String accountUsername = accountIdMatcher.group(accountIdMatcher.groupCount());
 
                 if (!StringUtilities.isBlank(accountUsername)) {
-                    return new Account(entry.getKey().getType().name(), accountUsername);
+                    return new Account(null, accountUsername);
                 }
             }
         }

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v2_0/AuthenticationHeaderManager.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v2_0/AuthenticationHeaderManager.java
@@ -1,0 +1,83 @@
+package com.rackspace.papi.components.clientauth.rackspace.v2_0;
+
+import com.rackspace.papi.commons.util.http.CommonHttpHeader;
+import com.rackspace.papi.commons.util.http.PowerApiHeader;
+import com.rackspace.papi.components.clientauth.rackspace.IdentityStatus;
+import com.rackspace.papi.components.clientauth.rackspace.config.User;
+import com.rackspace.papi.components.clientauth.rackspace.config.UserRoles;
+import com.rackspace.papi.filter.logic.FilterAction;
+import com.rackspace.papi.filter.logic.FilterDirector;
+import org.openstack.docs.identity.api.v2.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author fran
+ */
+public class AuthenticationHeaderManager {
+    private final Token token;
+    private final Boolean isDelegatable;
+    private final FilterDirector filterDirector;
+    private final String tenantId;
+
+    public AuthenticationHeaderManager(Token token, Boolean isDelegatable, FilterDirector filterDirector, String tenantId) {
+        this.token = token;
+        this.isDelegatable = isDelegatable;
+        this.filterDirector = filterDirector;
+        this.tenantId = tenantId;
+    }
+
+    public void setFilterDirectorValues() {
+      Boolean validToken = false;
+      if (token.getId() != null) {
+        validToken = true;
+      }
+      filterDirector.requestHeaderManager().putHeader(CommonHttpHeader.EXTENDED_AUTHORIZATION.headerKey(), "proxy " + tenantId);
+
+      if (validToken || isDelegatable) {
+         filterDirector.setFilterAction(FilterAction.PASS);
+      }
+
+      if (validToken) {
+//         filterDirector.requestHeaderManager().putHeader(PowerApiHeader.GROUPS.headerKey(), getGroupsListIds(tenantId));
+         filterDirector.requestHeaderManager().putHeader(PowerApiHeader.USER.headerKey(), tenantId);
+
+         // This is temporary to support roles until we integrate with Auth 2.0
+            filterDirector.requestHeaderManager().putHeader(PowerApiHeader.TENANT.headerKey(), tenantId);
+            filterDirector.requestHeaderManager().putHeader(PowerApiHeader.TENANT_ID.headerKey(), tenantId);
+
+//            List<String> roleList = new ArrayList<String>();
+//
+//            for (String r : userRoles.getDefault().getRoles().getRole()) {
+//               roleList.add(r);
+//            }
+//
+//            for (User user : userRoles.getUser()) {
+//               if (user.getName().equalsIgnoreCase(accountUsername)) {
+//                  for (String r : user.getRoles().getRole()) {
+//                     roleList.add(r);
+//                  }
+//               }
+//            }
+//
+//            if (roleList.size() > 0) {
+//               filterDirector.requestHeaderManager().putHeader(PowerApiHeader.ROLES.headerKey(), roleList.toArray(new String[0]));
+//            }
+
+         //  end temporary keystone support
+      }
+
+      if (isDelegatable) {
+         IdentityStatus identityStatus = IdentityStatus.Confirmed;
+
+         if (!validToken) {
+            identityStatus = IdentityStatus.Indeterminate;
+         }
+
+         filterDirector.requestHeaderManager().putHeader(CommonHttpHeader.IDENTITY_STATUS.headerKey(), identityStatus.name());
+      }
+
+
+   }
+}

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v2_0/RackspaceAuthenticationHandler.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v2_0/RackspaceAuthenticationHandler.java
@@ -1,0 +1,117 @@
+package com.rackspace.papi.components.clientauth.rackspace.v2_0;
+
+import com.rackspace.auth.v2_0.Account;
+import com.rackspace.auth.v2_0.AuthenticationServiceClient;
+import com.rackspace.docs.identity.api.ext.rax_ksgrp.v1.Groups;
+import com.rackspace.papi.components.clientauth.rackspace.config.RackspaceAuthV20;
+import com.rackspace.papi.filter.logic.AbstractFilterLogicHandler;
+
+import com.rackspace.papi.auth.AuthModule;
+import com.rackspace.papi.commons.util.StringUtilities;
+import com.rackspace.papi.commons.util.http.CommonHttpHeader;
+import com.rackspace.papi.commons.util.http.HttpStatusCode;
+import com.rackspace.papi.commons.util.servlet.http.ReadableHttpServletResponse;
+import com.rackspace.papi.filter.logic.FilterAction;
+import com.rackspace.papi.filter.logic.FilterDirector;
+import com.rackspace.papi.filter.logic.impl.FilterDirectorImpl;
+import org.openstack.docs.identity.api.v2.Token;
+import org.slf4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author fran
+ */
+public class RackspaceAuthenticationHandler extends AbstractFilterLogicHandler implements AuthModule {
+
+    private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(RackspaceAuthenticationHandler.class);
+   private final AuthenticationServiceClient authenticationService;
+   private final RackspaceAuthV20 cfg;
+   private final AccountUsernameExtractor accountUsernameExtractor;
+
+   public RackspaceAuthenticationHandler(RackspaceAuthV20 cfg) {
+      this.authenticationService = new AuthenticationServiceClient(cfg.getAuthenticationServer().getUri(), cfg.getAuthenticationServer().getUsername(), cfg.getAuthenticationServer().getPassword());
+      this.cfg = cfg;
+      this.accountUsernameExtractor = new AccountUsernameExtractor(cfg.getAccountMapping());
+   }
+
+    @Override
+    public String getWWWAuthenticateHeaderContents() {
+        return "TODO: What should this be for Cloud Auth 2.0?";
+    }
+
+    @Override
+    public FilterDirector handleRequest(HttpServletRequest request, ReadableHttpServletResponse response) {
+        return this.authenticate(request);
+    }
+
+    @Override
+    public FilterDirector authenticate(HttpServletRequest request) {
+        final FilterDirector filterDirector = new FilterDirectorImpl();
+      filterDirector.setResponseStatus(HttpStatusCode.UNAUTHORIZED);
+      filterDirector.setFilterAction(FilterAction.USE_MESSAGE_SERVICE);
+
+      final String authToken = request.getHeader(CommonHttpHeader.AUTH_TOKEN.headerKey());
+      final Account account = accountUsernameExtractor.extract(request.getRequestURL().toString());
+
+      try {
+        Token token = authenticationService.validateToken(account, authToken);
+        AuthenticationHeaderManager headerManager = new AuthenticationHeaderManager(token, cfg.isDelegatable(), filterDirector, account.getUsername());
+        headerManager.setFilterDirectorValues();  
+          
+      } catch (Exception ex) {
+        LOG.error("Failure in auth: " + ex.getMessage(), ex);
+        filterDirector.setResponseStatus(HttpStatusCode.INTERNAL_SERVER_ERROR);    
+      }
+
+      return filterDirector;
+    }
+
+    private Groups getGroups(String userId, FilterDirector filterDirector) {
+        Groups groups = null;
+
+        try {
+            groups = authenticationService.getGroups(userId);
+        } catch (Exception ex) {
+            LOG.error("Failure in auth: " + ex.getMessage(), ex);
+            filterDirector.setResponseStatus(HttpStatusCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return groups;
+    }
+
+    @Override
+    public FilterDirector handleResponse(HttpServletRequest request, ReadableHttpServletResponse response) {
+        /// The WWW Authenticate header can be used to communicate to the client
+      // (since we are a proxy) how to correctly authenticate itself
+      final String wwwAuthenticateHeader = response.getHeader(CommonHttpHeader.WWW_AUTHENTICATE.headerKey());
+
+      switch (HttpStatusCode.fromInt(response.getStatus())) {
+         // NOTE: We should only mutate the WWW-Authenticate header on a
+         // 401 (unauthorized) or 403 (forbidden) response from the origin service
+         case UNAUTHORIZED:
+         case FORBIDDEN:
+            updateHttpResponse(response, wwwAuthenticateHeader);
+            break;
+      }
+
+      // TODO: Do we need to return a valid FilterDirector here?
+      return null;
+    }
+
+    private void updateHttpResponse(ReadableHttpServletResponse httpResponse, String wwwAuthenticateHeader) {
+
+      // If in the case that the origin service supports delegated authentication
+      // we should then communicate to the client how to authenticate with us
+      if (!StringUtilities.isBlank(wwwAuthenticateHeader) && wwwAuthenticateHeader.contains("Delegated")) {
+         final String replacementWwwAuthenticateHeader = getWWWAuthenticateHeaderContents();
+         httpResponse.setHeader(CommonHttpHeader.WWW_AUTHENTICATE.headerKey(), replacementWwwAuthenticateHeader);
+      } else {
+         // In the case where authentication has failed and we did not receive
+         // a delegated WWW-Authenticate header, this means that our own authentication
+         // with the origin service has failed and must then be communicated as
+         // a 500 (internal server error) to the client
+         httpResponse.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.intValue());
+      }
+   }
+}

--- a/project-set/components/client-auth/src/main/resources/META-INF/schema/config/client-auth-n-configuration.xsd
+++ b/project-set/components/client-auth/src/main/resources/META-INF/schema/config/client-auth-n-configuration.xsd
@@ -4,15 +4,19 @@
            targetNamespace="http://docs.rackspacecloud.com/power-api/client-auth/v1.0"
            xmlns:auth="http://docs.rackspacecloud.com/power-api/client-auth/v1.0"
            xmlns:auth-1.1="http://docs.rackspacecloud.com/power-api/client-auth/rs-auth-1.1/v1.0"
+           xmlns:auth-2.0="http://docs.rackspacecloud.com/power-api/client-auth/rs-auth-2.0/v2.0"
            xmlns:auth-http-basic="http://docs.rackspacecloud.com/power-api/client-auth/http-basic/v1.0"
            xmlns:html="http://www.w3.org/1999/xhtml"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
     
     <!-- Rackspace Cloud Auth v1.1 -->
     <xs:import namespace="http://docs.rackspacecloud.com/power-api/client-auth/rs-auth-1.1/v1.0" schemaLocation="./rackspace-auth-v1.1/rackspace-auth-v1.1.xsd" />
+
+    <!-- Rackspace Cloud Auth v2.0 -->
+    <xs:import namespace="http://docs.rackspacecloud.com/power-api/client-auth/rs-auth-2.0/v2.0" schemaLocation="./rackspace-auth-v2.0/rackspace-auth-v2.0.xsd" />
     
     <!-- HTTP Basic Authentication -->
-    <xs:import namespace="http://docs.rackspacecloud.com/power-api/client-auth/http-basic/v1.0" schemaLocation="./http-basic/http-basic.xsd" />
+    <xs:import namespace="http://docs.rackspacecloud.com/power-api/client-auth/http-basic/v1.0" schemaLocation="./http-basic/http-basic.xsd" />    
     
     <!-- Configuration -->
     <xs:element name="client-auth" type="auth:clientAuthConfig" />
@@ -20,15 +24,17 @@
     <xs:complexType name="clientAuthConfig">
         <xs:annotation>
             <xs:documentation>
-                <html:p>Describes a collection of filter modules that should be loaded and configured at runtime start-up</html:p>
+                <html:p>Describes a collection of filter modules that should be loaded and configured at runtime start-up.</html:p>
             </xs:documentation>
         </xs:annotation>
 
         <xs:sequence>
             <xs:choice>
                 <xs:element ref="auth-1.1:rackspace-auth" />
+                <xs:element ref="auth-2.0:rackspace-auth-v2.0" />
                 <xs:element ref="auth-http-basic:http-basic-auth" />
             </xs:choice>
         </xs:sequence>
+
     </xs:complexType>
 </xs:schema>

--- a/project-set/components/client-auth/src/main/resources/META-INF/schema/config/rackspace-auth-v2.0/bindings.xjb
+++ b/project-set/components/client-auth/src/main/resources/META-INF/schema/config/rackspace-auth-v2.0/bindings.xjb
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" version="2.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+        schemaLocation="rackspace-auth-v2.0.xsd">
+
+    <schemaBindings>
+        <package name="com.rackspace.papi.components.clientauth.rackspace.config" />
+    </schemaBindings>
+</bindings>

--- a/project-set/components/client-auth/src/main/resources/META-INF/schema/config/rackspace-auth-v2.0/rackspace-auth-v2.0.xsd
+++ b/project-set/components/client-auth/src/main/resources/META-INF/schema/config/rackspace-auth-v2.0/rackspace-auth-v2.0.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified"
+           targetNamespace="http://docs.rackspacecloud.com/power-api/client-auth/rs-auth-2.0/v2.0"
+           xmlns:auth-2.0="http://docs.rackspacecloud.com/power-api/client-auth/rs-auth-2.0/v2.0"
+           xmlns:html="http://www.w3.org/1999/xhtml"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">    
+
+    <!-- Configuration -->
+    <xs:element name="rackspace-auth-v2.0">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Defines a Rackspace Cloud Auth version 2.0 configuration</html:p>
+                </xs:documentation>
+            </xs:annotation>
+
+            <xs:sequence>
+                <xs:element name="authentication-server" type="auth-2.0:authenticationServer2.0" minOccurs="1" maxOccurs="1" />
+                <xs:element name="account-mapping" type="auth-2.0:accountMapping2.0" minOccurs="1" maxOccurs="unbounded" />
+            </xs:sequence>
+
+            <xs:attribute name="delegatable" type="xs:boolean" use="optional" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        <html:p>Tells the service whether or not to support auth delegation.</html:p>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="authenticationServer2.0">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>Describes an authentication 2.0 endpoint</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:attribute name="username" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Username to use (Basic Auth Only)</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="password" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Password to use (Basic Auth Only)</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="uri" type="xs:anyURI" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Target URI for authentication requests</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="accountMapping2.0">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>Describes how to extract the account id from a given URI</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:attribute name="id-regex" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Regex used to extract the account id from a given URI</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/project-set/components/client-auth/src/main/resources/META-INF/schema/examples/client-auth-n-2-0.cfg.xml
+++ b/project-set/components/client-auth/src/main/resources/META-INF/schema/examples/client-auth-n-2-0.cfg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<client-auth xmlns="http://docs.rackspacecloud.com/power-api/client-auth/v1.0">
+    <rackspace-auth-v2.0 delegatable="true" xmlns="http://docs.rackspacecloud.com/power-api/client-auth/rs-auth-2.0/v2.0">
+        <authentication-server username="auth" password="auth123" uri="http://auth-n02.dev.us.ccp.rackspace.net/v2.0/" />
+
+        <account-mapping id-regex=".*/servers/(\w*)/.*"/>        
+    </rackspace-auth-v2.0>
+</client-auth>

--- a/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/rackspace/AccountUsernameExtractorTest.java
+++ b/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/rackspace/AccountUsernameExtractorTest.java
@@ -3,6 +3,7 @@ package com.rackspace.papi.components.clientauth.rackspace;
 import com.rackspace.auth.v1_1.Account;
 import com.rackspace.papi.components.clientauth.rackspace.config.AccountMapping;
 import com.rackspace.papi.components.clientauth.rackspace.config.AccountType;
+import com.rackspace.papi.components.clientauth.rackspace.v1_1.AccountUsernameExtractor;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;

--- a/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/rackspace/RackspaceAuthenticationModuleTest.java
+++ b/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/rackspace/RackspaceAuthenticationModuleTest.java
@@ -2,6 +2,7 @@ package com.rackspace.papi.components.clientauth.rackspace;
 
 import com.rackspace.papi.components.clientauth.rackspace.config.AuthenticationServer;
 import com.rackspace.papi.components.clientauth.rackspace.config.RackspaceAuth;
+import com.rackspace.papi.components.clientauth.rackspace.v1_1.RackspaceAuthenticationHandler;
 import net.sf.ehcache.CacheManager;
 import org.junit.Before;
 import org.junit.Test;

--- a/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/rackspace/SchemaTest.java
+++ b/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/rackspace/SchemaTest.java
@@ -39,6 +39,7 @@ public class SchemaTest {
             jaxbUnmarshaller.setSchema(SCHEMA_FACTORY.newSchema(
                     new StreamSource[]{
                         new StreamSource(SchemaTest.class.getResourceAsStream("/META-INF/schema/config/rackspace-auth-v1.1/rackspace-auth-v1.1.xsd")),
+                        new StreamSource(SchemaTest.class.getResourceAsStream("/META-INF/schema/config/rackspace-auth-v2.0/rackspace-auth-v2.0.xsd")),                            
                         new StreamSource(SchemaTest.class.getResourceAsStream("/META-INF/schema/config/http-basic/http-basic.xsd")),
                         new StreamSource(SchemaTest.class.getResourceAsStream("/META-INF/schema/config/client-auth-n-configuration.xsd"))
                     }));

--- a/project-set/external/service-clients/rackspace-auth-v2.0/pom.xml
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/pom.xml
@@ -39,27 +39,42 @@
         </dependency>
     </dependencies>
 
-    <!--<build>-->
-        <!--<plugins>-->
-            <!--<plugin>-->
-                <!--<groupId>com.sun.tools.xjc.maven2</groupId>-->
-                <!--<artifactId>maven-jaxb-plugin</artifactId>-->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>transform</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                    </execution>
+                </executions>
 
-                <!--<configuration>-->
-                    <!--<includeSchemas>-->
-                        <!--<includeSchema>**/*.xsd</includeSchema>-->
-                    <!--</includeSchemas>-->
+                <configuration>
+                    <transformationSets>
+                        <transformationSet>
+                            <dir>src/main/resources/META-INF/schema/auth-2.0-service</dir>
+                            <stylesheet>src/main/resources/META-INF/schema/xsl/s1.0p.xsl</stylesheet>
+                        </transformationSet>
+                    </transformationSets>                    
 
-                    <!--<includeBindings>-->
-                        <!--<includeBinding>**/*.xjb</includeBinding>-->
-                    <!--</includeBindings>-->
+                </configuration>
+            </plugin>
 
-                    <!--<strict>true</strict>-->
-                    <!--<verbose>false</verbose>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-        <!--</plugins>-->
-    <!--</build>-->
+            <plugin>
+                <groupId>com.sun.tools.xjc.maven2</groupId>
+                <artifactId>maven-jaxb-plugin</artifactId>
 
+                <configuration>
+                    <schemaDirectory>${basedir}/target/generated-resources/xml/xslt</schemaDirectory>                
+                    <strict>true</strict>
+                    <verbose>false</verbose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/Account.java
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/Account.java
@@ -1,0 +1,42 @@
+package com.rackspace.auth.v2_0;
+
+/*
+ *  Copyright 2010 Rackspace.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  under the License.
+ */
+
+
+/**
+ *
+ * @author jhopper
+ */
+public class Account {
+    private final String type;
+    private final String username;
+
+    public Account(String type, String username) {
+        this.type = type;
+        this.username = username;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getType() {
+        return type;
+    }
+}
+

--- a/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/AuthenticationCache.java
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/AuthenticationCache.java
@@ -1,0 +1,32 @@
+package com.rackspace.auth.v2_0;
+
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
+
+/**
+ * @author fran
+ *
+ *
+ */
+public class AuthenticationCache {
+    private final TokenCache authTokenCache;
+
+    public AuthenticationCache(CacheManager cache) {
+        this.authTokenCache = new TokenCache(cache);
+    }
+
+    public void cacheUserAuthToken(String accountUsername, int ttl, String authToken) {
+        final Element newCacheElement = new Element(accountUsername, authToken);
+        newCacheElement.setTimeToLive(ttl);
+
+        authTokenCache.put(newCacheElement);
+    }
+
+    public boolean tokenIsCached(String accountUsername, String headerAuthToken) {
+        final Element cachedTokenElement = authTokenCache.get(accountUsername);
+
+        return cachedTokenElement != null && !cachedTokenElement.isExpired() &&
+               cachedTokenElement.getValue().equals(headerAuthToken);
+    }
+}

--- a/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/AuthenticationServiceClient.java
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/AuthenticationServiceClient.java
@@ -1,0 +1,66 @@
+package com.rackspace.auth.v2_0;
+
+import com.rackspace.docs.identity.api.ext.rax_ksgrp.v1.Groups;
+import net.sf.ehcache.CacheManager;
+import org.openstack.docs.identity.api.v2.Token;
+
+/**
+ * @author fran
+ */
+public class AuthenticationServiceClient {
+
+    private final String targetHostUri;
+    private final GenericServiceClient serviceClient;
+    private final ResponseUnmarshaller responseUnmarshaller;
+    private final CacheManager cacheManager;
+    private final AuthenticationCache authenticationCache;
+    private String adminToken = null;
+
+    public AuthenticationServiceClient(String targetHostUri, String username, String password) {
+        this.responseUnmarshaller = new ResponseUnmarshaller();
+        this.serviceClient = new GenericServiceClient(username, password);
+        this.targetHostUri = targetHostUri;
+        this.cacheManager = new CacheManager();
+        this.authenticationCache = new AuthenticationCache(cacheManager);
+        this.adminToken = getAdminToken(username, password);
+    }
+
+    private String getAdminToken(String username, String password) {
+        final ServiceClientResponse<Token> serviceResponse = serviceClient.getAdminToken(targetHostUri + "/tokens", username, password);
+        final int response = serviceResponse.getStatusCode();
+        Token token = null;
+
+        switch (response) {
+            case 200:
+                token = responseUnmarshaller.unmarshall(serviceResponse.getData(), Token.class);
+        }
+
+        return token.getId();
+    }
+
+    public Token validateToken(Account account, String userToken) {
+        final ServiceClientResponse<Groups> serviceResponse = serviceClient.get(targetHostUri + "/tokens/" + userToken, adminToken);
+        final int response = serviceResponse.getStatusCode();
+        Token token = null;
+
+        switch (response) {
+            case 200:
+                token = responseUnmarshaller.unmarshall(serviceResponse.getData(), Token.class);
+        }
+
+        return token;
+    }    
+
+    public Groups getGroups(String userId) {
+        final ServiceClientResponse<Groups> serviceResponse = serviceClient.get(targetHostUri + "/users/" + userId + "/RAX-KSGRP", adminToken);
+        final int response = serviceResponse.getStatusCode();
+        Groups groups = null;
+
+        switch (response) {
+            case 200:
+                groups = responseUnmarshaller.unmarshall(serviceResponse.getData(), Groups.class);
+        }
+
+        return groups;
+    }
+}

--- a/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/ResponseUnmarshaller.java
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/ResponseUnmarshaller.java
@@ -1,0 +1,128 @@
+package com.rackspace.auth.v2_0;
+
+import com.rackspace.docs.identity.api.ext.rax_ksgrp.v1.Groups;
+import com.rackspace.papi.commons.util.pooling.ConstructionStrategy;
+import com.rackspace.papi.commons.util.pooling.GenericBlockingResourcePool;
+import com.rackspace.papi.commons.util.pooling.ResourceConstructionException;
+import com.rackspace.papi.commons.util.pooling.ResourceContextException;
+
+
+//import com.rackspacecloud.docs.auth.api.v1.FullToken;
+import com.rackspace.papi.commons.util.pooling.Pool;
+import com.rackspace.papi.commons.util.pooling.ResourceContext;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+
+/**
+ * @author fran
+ */
+public class ResponseUnmarshaller {
+
+   private final JAXBContext jaxbContext;
+   private final Pool<Unmarshaller> pool;
+
+   public ResponseUnmarshaller() {
+      try {
+         jaxbContext = JAXBContext.newInstance(com.rackspace.docs.identity.api.ext.rax_ksgrp.v1.ObjectFactory.class);
+         pool = new GenericBlockingResourcePool<Unmarshaller>(new ConstructionStrategy<Unmarshaller>() {
+
+            @Override
+            public Unmarshaller construct() throws ResourceConstructionException {
+               try {
+                  return jaxbContext.createUnmarshaller();
+               } catch (JAXBException ex) {
+                  throw new ResourceConstructionException("Unable to build jaxb unmarhshaller", ex);
+               }
+            }
+         });
+      } catch (JAXBException jaxbe) {
+         throw new AuthServiceException(
+                 "Possible deployment problem! Unable to build JAXB Context for Auth v1.1 schema types. Reason: "
+                 + jaxbe.getMessage(), jaxbe);
+      }
+   }
+
+   /*
+   public <T> T unmarshall(final GetMethod method, final Class<T> expectedType) {
+      return pool.use(new ResourceContext<Unmarshaller, T>() {
+
+         @Override
+         public T perform(Unmarshaller resource) throws ResourceContextException {
+            try {
+               final Object o = resource.unmarshal(new StringReader(method.getResponseBodyAsString()));
+
+               if (o instanceof JAXBElement && ((JAXBElement) o).getDeclaredType().equals(expectedType)) {
+                  return ((JAXBElement<T>) o).getValue();
+               } else if (o instanceof FullToken) {
+                  return expectedType.cast(o);
+               } else {
+                  throw new AuthServiceException("Failed to unmarshall response body. Unexpected element encountered. Body output is in debug.");
+
+               }
+            } catch (IOException ioe) {
+               throw new AuthServiceException("Failed to get response body from response.", ioe);
+            } catch (JAXBException jaxbe) {
+               throw new AuthServiceException("Failed to unmarshall response body. Body output is in debug. Reason: "
+                       + jaxbe.getMessage(), jaxbe);
+            }
+         }
+      });
+   }
+    *
+    */
+
+   public <T> T unmarshall(final String data, final Class<T> expectedType) {
+      return pool.use(new ResourceContext<Unmarshaller, T>() {
+
+         @Override
+         public T perform(Unmarshaller resource) throws ResourceContextException {
+            try {
+               final Object o = resource.unmarshal(new StringReader(data));
+
+               if (o instanceof JAXBElement && ((JAXBElement) o).getDeclaredType().equals(expectedType)) {
+                  return ((JAXBElement<T>) o).getValue();
+               } else if (o instanceof Groups) {
+                  return expectedType.cast(o);
+               } else {
+                  throw new AuthServiceException("Failed to unmarshall response body. Unexpected element encountered. Body output is in debug.");
+
+               }
+            } catch (JAXBException jaxbe) {
+               throw new AuthServiceException("Failed to unmarshall response body. Body output is in debug. Reason: "
+                       + jaxbe.getMessage(), jaxbe);
+            }
+         }
+      });
+   }
+
+   public <T> T unmarshall(final InputStream data, final Class<T> expectedType) {
+      return pool.use(new ResourceContext<Unmarshaller, T>() {
+
+         @Override
+         public T perform(Unmarshaller resource) throws ResourceContextException {
+            try {
+               final Object o = resource.unmarshal(new InputStreamReader(data));
+
+               if (o instanceof JAXBElement && ((JAXBElement) o).getDeclaredType().equals(expectedType)) {
+                  return ((JAXBElement<T>) o).getValue();
+               } else if (o instanceof Groups) {
+                  return expectedType.cast(o);
+               } else {
+                  throw new AuthServiceException("Failed to unmarshall response body. Unexpected element encountered. Body output is in debug.");
+
+               }
+            } catch (JAXBException jaxbe) {
+               throw new AuthServiceException("Failed to unmarshall response body. Body output is in debug. Reason: "
+                       + jaxbe.getMessage(), jaxbe);
+            }
+         }
+      });
+   }
+}
+

--- a/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/ServiceClientResponse.java
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/ServiceClientResponse.java
@@ -28,20 +28,6 @@ public class ServiceClientResponse<EntityClass> {
       return data;
    }
 
-   /*
-   public String getDataAsString() throws IOException {
-      BufferedReader reader = new BufferedReader(new InputStreamReader(data));
-      StringBuilder sb = new StringBuilder();
-      String line = null;
-      while ((line = reader.readLine()) != null) {
-         sb.append(line + "\n");
-      }
-      reader.close();
-      return sb.toString();
-   }
-    *
-    */
-
    public EntityClass getEntity() {
       return entity;
    }

--- a/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/TokenCache.java
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/src/main/java/com/rackspace/auth/v2_0/TokenCache.java
@@ -1,0 +1,104 @@
+package com.rackspace.auth.v2_0;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheException;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
+
+import java.io.Serializable;
+
+/*
+ *  Copyright 2010 Rackspace.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  under the License.
+ */
+
+
+import java.io.Serializable;
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheException;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
+
+/**
+ *
+ * @author jhopper
+ */
+public class TokenCache {
+    private static final String CACHE_NAME = "Rackspace-Default-API-Auth-Token-Cache";
+
+    private final Cache tokenCache;
+
+    public TokenCache(CacheManager ehCacheManager) {
+        if (!ehCacheManager.cacheExists(CACHE_NAME)) {
+            tokenCache = new Cache(
+                    new CacheConfiguration()
+                        .name(CACHE_NAME)
+                        .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LFU)
+                        .overflowToDisk(false)
+                        .diskPersistent(false)
+                        .diskExpiryThreadIntervalSeconds(0)
+                        .eternal(false));
+
+            ehCacheManager.addCache(tokenCache);
+        } else {
+            tokenCache = ehCacheManager.getCache(CACHE_NAME);
+        }
+    }
+
+    public void removeAll(boolean doNotNotifyCacheReplicators) throws IllegalStateException, CacheException {
+        tokenCache.removeAll(doNotNotifyCacheReplicators);
+    }
+
+    public void removeAll() throws IllegalStateException, CacheException {
+        tokenCache.removeAll();
+    }
+
+    public final boolean remove(Object key, boolean doNotNotifyCacheReplicators) throws IllegalStateException {
+        return tokenCache.remove(key, doNotNotifyCacheReplicators);
+    }
+
+    public final boolean remove(Serializable key, boolean doNotNotifyCacheReplicators) throws IllegalStateException {
+        return tokenCache.remove(key, doNotNotifyCacheReplicators);
+    }
+
+    public final boolean remove(Object key) throws IllegalStateException {
+        return tokenCache.remove(key);
+    }
+
+    public final boolean remove(Serializable key) throws IllegalStateException {
+        return tokenCache.remove(key);
+    }
+
+    public final void put(Element element) throws IllegalArgumentException, IllegalStateException, CacheException {
+        tokenCache.put(element);
+    }
+
+    public synchronized void dispose() throws IllegalStateException {
+        tokenCache.dispose();
+    }
+
+    public final Element get(Object key) throws IllegalStateException, CacheException {
+        return tokenCache.get(key);
+    }
+
+    public final Element get(Serializable key) throws IllegalStateException, CacheException {
+        return tokenCache.get(key);
+    }
+}
+

--- a/project-set/external/service-clients/rackspace-auth-v2.0/src/main/resources/META-INF/schema/xsl/s1.0p.xsl
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/src/main/resources/META-INF/schema/xsl/s1.0p.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<transform xmlns="http://www.w3.org/1999/XSL/Transform"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           version="1.0"
+           >
+    <template match="node() | @*">
+        <copy>
+            <apply-templates select="node() | @*"/>
+        </copy>
+    </template>
+    <template match="xsd:*[@vc:minVersion &gt; 1.0]"/>
+</transform>

--- a/project-set/external/service-clients/rackspace-auth-v2.0/src/test/java/com/rackspace/auth/v2_0/GenericServiceClientTest.java
+++ b/project-set/external/service-clients/rackspace-auth-v2.0/src/test/java/com/rackspace/auth/v2_0/GenericServiceClientTest.java
@@ -1,9 +1,11 @@
 package com.rackspace.auth.v2_0;
 
+import com.rackspace.docs.identity.api.ext.rax_ksgrp.v1.Groups;
 import org.junit.Before;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openstack.docs.identity.api.v2.Token;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
@@ -20,14 +22,47 @@ import static org.mockito.Mockito.*;
  */
 @RunWith(Enclosed.class)
 public class GenericServiceClientTest {
-    String endpoint = "http://auth-n01.dev.us.ccp.rackspace.net/v2.0/tokens";    
-    String username = "auth";
-    String password = "auth123";
-    String tenant = "?";
-    String token = "?";
+    public static class WhenHittingAuth2_0 {
+        String endpoint = "http://auth-n01.dev.us.ccp.rackspace.net/v2.0";
+        String username = "auth";
+        String password = "auth123";
+        String tenant = "?";
+        String token = "?";
+        String userId = "102916";
 
-    @Test
-    public void shouldValidateToken() {
-        GenericServiceClient client = new GenericServiceClient(username, password);
-    }   
+//        @Test
+//        public void shouldValidateToken() {
+//            GenericServiceClient client = new GenericServiceClient(username, password);
+//
+//            final ServiceClientResponse<Groups> serviceResponse = client.get(endpoint + "/users/" + userId + "/RAX-KSGRP");
+//            final int response = serviceResponse.getStatusCode();
+//            Groups groups = null;
+//
+//            ResponseUnmarshaller responseUnmarshaller = new ResponseUnmarshaller();
+//
+//            switch (response) {
+//                case 200:
+//                    groups = responseUnmarshaller.unmarshall(serviceResponse.getData(), Groups.class);
+//            }
+//        }
+
+        @Test
+        public void shouldGetAuthToken() {
+//            GenericServiceClient client = new GenericServiceClient(username, password);
+//
+//            final ServiceClientResponse<Token> serviceResponse = client.getAdminToken(endpoint + "/token", "auth", "auth123");
+//            final int response = serviceResponse.getStatusCode();
+//            Token groups = null;
+//
+//            ResponseUnmarshaller responseUnmarshaller = new ResponseUnmarshaller();
+//
+//            switch (response) {
+//                case 200:
+//                    groups = responseUnmarshaller.unmarshall(serviceResponse.getData(), Token.class);
+//            }
+        }
+
+
+        
+    }
 }


### PR DESCRIPTION
Add xsl that translates auth 2.0/keystone schemas so xjc can use them.  Add auth 2.0 papi configuration schema; add initial auth 2.0 service client; add auth 2.0 handler.
