### PR TITLE
found two bugs

### DIFF
--- a/project-set/commons/classloader/src/main/java/com/rackspace/papi/commons/util/classloader/ear/DefaultEarArchiveEntryListener.java
+++ b/project-set/commons/classloader/src/main/java/com/rackspace/papi/commons/util/classloader/ear/DefaultEarArchiveEntryListener.java
@@ -34,8 +34,6 @@ public class DefaultEarArchiveEntryListener implements EarArchiveEntryListener {
     private static final ConfigurationObjectParser<ApplicationType> APPLICATION_XML_PARSER;
     private static final ConfigurationObjectParser<WebFragmentType> WEB_FRAGMENT_XML_PARSER;
 
-    private static final String REGEX_SINGLE_SPACE = "[ \\s]";
-
 
     static {
         ConfigurationObjectParser<ApplicationType> applicationXmlParser = null;

--- a/project-set/commons/classloader/src/test/java/com/rackspace/papi/commons/util/classloader/jar/test/EmptyClass.java
+++ b/project-set/commons/classloader/src/test/java/com/rackspace/papi/commons/util/classloader/jar/test/EmptyClass.java
@@ -2,8 +2,11 @@ package com.rackspace.papi.commons.util.classloader.jar.test;
 
 /**
  *
- * 
+ *
  */
 public class EmptyClass {
 
+    public EmptyClass() {
+        System.exit(100);
+    }
 }

--- a/project-set/components/datastore/src/test/java/com/rackspace/papi/components/datastore/DatastoreFilterLogicHandlerFactoryTest.java
+++ b/project-set/components/datastore/src/test/java/com/rackspace/papi/components/datastore/DatastoreFilterLogicHandlerFactoryTest.java
@@ -1,0 +1,56 @@
+package com.rackspace.papi.components.datastore;
+
+import com.rackspace.papi.components.datastore.hash.HashRingDatastoreManager;
+import com.rackspace.papi.model.PowerProxy;
+import com.rackspace.papi.service.datastore.DatastoreManager;
+import com.rackspace.papi.service.datastore.DatastoreService;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(Enclosed.class)
+public class DatastoreFilterLogicHandlerFactoryTest {
+
+    public static class WhenRegisteringDatastore {
+
+        private DatastoreFilterLogicHandlerFactory factory;
+        private DatastoreService datastoreService;
+        private PowerProxy powerProxy;
+
+        @Before
+        public void standUp() {
+            powerProxy = new PowerProxy();
+            
+            datastoreService = mock(DatastoreService.class);
+            factory = new DatastoreFilterLogicHandlerFactory(datastoreService);
+        }
+
+        @Test
+        public void shouldRegisterDatastore() throws Exception {
+            factory.configurationUpdated(powerProxy);
+
+            verify(datastoreService).registerDatastoreManager(eq(HashRingDatastoreManager.DATASTORE_MANAGER_NAME), any(DatastoreManager.class));
+        }
+
+        @Test
+        public void shouldNotReRegisterDatastore() throws Exception {
+            factory.configurationUpdated(powerProxy);
+            factory.configurationUpdated(powerProxy);
+            
+            verify(datastoreService, times(1)).registerDatastoreManager(eq(HashRingDatastoreManager.DATASTORE_MANAGER_NAME), any(DatastoreManager.class));
+        }
+
+        @Test @Ignore
+        public void shouldUnRegisterDatastore() throws Exception {
+            factory.configurationUpdated(powerProxy);
+            // Not implemented
+            
+            verify(datastoreService, times(1)).registerDatastoreManager(eq(HashRingDatastoreManager.DATASTORE_MANAGER_NAME), any(DatastoreManager.class));
+            verify(datastoreService, times(1)).unregisterDatastoreManager(HashRingDatastoreManager.DATASTORE_MANAGER_NAME);
+        }
+    }
+}

--- a/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/datastore/DatastoreService.java
+++ b/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/datastore/DatastoreService.java
@@ -14,5 +14,7 @@ public interface DatastoreService {
 
     Datastore getDatastore(String datastoreName);
     
+    void unregisterDatastoreManager(String datastoreManagerName) throws NamingException;
+    
     void registerDatastoreManager(String datastoreManagerName, DatastoreManager manager) throws NamingException;
 }

--- a/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/datastore/impl/PowerApiDatastoreService.java
+++ b/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/datastore/impl/PowerApiDatastoreService.java
@@ -41,6 +41,18 @@ public class PowerApiDatastoreService implements DatastoreService {
     }
 
     @Override
+    public void unregisterDatastoreManager(String datastoreManagerName) throws NamingException {
+        final String nameInContext = servicePrefix + datastoreManagerName;
+        
+        try {
+            namingContext.unbind(nameInContext);
+        } catch (NamingException ex) {
+            LOG.error(ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    @Override
     public void registerDatastoreManager(String datastoreManagerName, DatastoreManager manager) throws NamingException {
         final String nameInContext = servicePrefix + datastoreManagerName;
         

--- a/project-set/core/core-lib/src/test/java/com/rackspace/papi/filter/PowerFilterTest.java
+++ b/project-set/core/core-lib/src/test/java/com/rackspace/papi/filter/PowerFilterTest.java
@@ -40,8 +40,6 @@ public class PowerFilterTest {
         }
 
         @Test
-        @Ignore
-        // TODO: Fix this test
         public void shouldDoFilter() throws IOException, ServletException, NamingException {
             ResponseMessageService mockedResponseMessageService = mock(ResponseMessageService.class);
             Context mockedContext = mock(Context.class);
@@ -50,6 +48,8 @@ public class PowerFilterTest {
             ServletContext mockedServletContext = mock(ServletContext.class);
             FakeFilterRegistration mockedFilterRegistration = new FakeFilterRegistration();
 
+            when(mockedServiceContext.getService()).thenReturn(mockedResponseMessageService);
+            
             when(mockedContext.lookup("powerapi:/services/rms")).thenReturn(mockedServiceContext);
             when(mockedFilterConfig.getServletContext()).thenReturn(mockedServletContext);
             when(mockedServletContext.addFilter(any(String.class), any(Filter.class))).thenReturn(mockedFilterRegistration);


### PR DESCRIPTION
Resource management bug in dist-datastore regarding not unregistering datastore from service.
Classloader allows system calls, meaning filter code can crash system.
