### PR TITLE
Update unit test for auth service client time to live (ttl) to make it m...

### DIFF
--- a/project-set/external/service-clients/rackspace-auth-v1.1/src/test/java/com/rackspace/auth/v1_1/AuthenticationServiceClientTest.java
+++ b/project-set/external/service-clients/rackspace-auth-v1.1/src/test/java/com/rackspace/auth/v1_1/AuthenticationServiceClientTest.java
@@ -1,6 +1,5 @@
 package com.rackspace.auth.v1_1;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -9,6 +8,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -21,14 +21,39 @@ public class AuthenticationServiceClientTest {
 
     public static class WhenGettingExpireTtl {
         @Test
-        @Ignore
+        public void shouldReturnMaxJavaInt() throws DatatypeConfigurationException {
+            final long MOCK_CURRENT_SYS_TIME = 1000;
+            final long NUMBER_OF_MILLISECONDS_IN_A_SECOND = 1000;
+            final long long_one = 1;
+
+            final Calendar expirationTime = mock(GregorianCalendar.class);
+            long mockExpirationTime = MOCK_CURRENT_SYS_TIME;
+            mockExpirationTime += Integer.MAX_VALUE + long_one;
+            mockExpirationTime *= NUMBER_OF_MILLISECONDS_IN_A_SECOND;
+
+            when(expirationTime.getTimeInMillis()).thenReturn(mockExpirationTime);
+
+            final Calendar currentSystemTime = (mock(Calendar.class));
+            when(currentSystemTime.getTimeInMillis()).thenReturn(MOCK_CURRENT_SYS_TIME);
+
+            assertEquals(Integer.MAX_VALUE, AuthenticationServiceClient.getTtl((GregorianCalendar)expirationTime, currentSystemTime));
+        }
+
+        @Test
         public void shouldReturnPositiveTime() throws DatatypeConfigurationException {
+            final long MOCK_CURRENT_SYS_TIME = 1000;
+            final long long_one = 1;
 
-            final Calendar calendar = mock(GregorianCalendar.class);
-            when(calendar.getTimeInMillis()).thenReturn(Calendar.getInstance().getTimeInMillis() + (Integer.MAX_VALUE + 1000));
+            final Calendar expirationTime = mock(GregorianCalendar.class);
+            long mockExpirationTime = MOCK_CURRENT_SYS_TIME;
+            mockExpirationTime += Integer.MAX_VALUE + long_one;
+            when(expirationTime.getTimeInMillis()).thenReturn(mockExpirationTime);
 
-            assertTrue(AuthenticationServiceClient.getTtl((GregorianCalendar)calendar) > 0);
-        }        
+            final Calendar currentSystemTime = (mock(Calendar.class));
+            when(currentSystemTime.getTimeInMillis()).thenReturn(MOCK_CURRENT_SYS_TIME);
+
+            assertTrue(AuthenticationServiceClient.getTtl((GregorianCalendar)expirationTime, currentSystemTime) > 0);
+        }
     }
 
 


### PR DESCRIPTION
...ore robust.  Fix the time to live bug so that 1) the code converts to seconds for ehcache and 2) it uses Java max int for ttl if the expiration time is greater than Java Max int.  Since ehcache has ttl in seconds, the using max int would give about 68 years before the token expired.  That should be good enough :)
