### PR TITLE
Remove quality from X-PP-Groups in client ip identity handler and update...

### DIFF
--- a/project-set/components/client-ip-identity/src/main/java/com/rackspace/papi/components/clientip/ClientIpIdentityHandler.java
+++ b/project-set/components/client-ip-identity/src/main/java/com/rackspace/papi/components/clientip/ClientIpIdentityHandler.java
@@ -39,7 +39,7 @@ public class ClientIpIdentityHandler extends AbstractFilterLogicHandler {
       if(!address.isEmpty()) {
          String group = new ClientGroupExtractor(request, config).determineIpGroup(address);
          headerManager.putHeader(PowerApiHeader.USER.getHeaderKey(), address + quality);
-         headerManager.putHeader(PowerApiHeader.GROUPS.getHeaderKey(), group + quality);
+         headerManager.putHeader(PowerApiHeader.GROUPS.getHeaderKey(), group);
       }
       
       return filterDirector;

--- a/test/jmeter-automation/src/test/jmeter/Power API - Client IP Tests.jmx
+++ b/test/jmeter-automation/src/test/jmeter/Power API - Client IP Tests.jmx
@@ -135,7 +135,7 @@
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="should return only ip address" enabled="true">
                     <collectionProp name="Asserion.test_strings">
                       <stringProp name="32561690">x-pp-user : ${ip1};q=</stringProp>
-                      <stringProp name="-1737561236">x-pp-groups : IP_Standard;q=</stringProp>
+                      <stringProp name="1154212879">x-pp-groups : ${group}</stringProp>
                     </collectionProp>
                     <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
                     <boolProp name="Assertion.assume_success">false</boolProp>
@@ -179,7 +179,7 @@
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="should return first ip address in the list" enabled="true">
                     <collectionProp name="Asserion.test_strings">
                       <stringProp name="33485211">x-pp-user : ${ip2};q=</stringProp>
-                      <stringProp name="-1737561236">x-pp-groups : IP_Standard;q=</stringProp>
+                      <stringProp name="1154212879">x-pp-groups : ${group}</stringProp>
                     </collectionProp>
                     <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
                     <boolProp name="Assertion.assume_success">false</boolProp>
@@ -249,7 +249,7 @@ vars.put(&apos;sourceIp&apos;, getSourceIp());</stringProp>
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="should return source ip" enabled="true">
                     <collectionProp name="Asserion.test_strings">
                       <stringProp name="-121316922">x-pp-user : ${sourceIp};q=</stringProp>
-                      <stringProp name="-352233224">x-pp-groups : ${group};q=</stringProp>
+                      <stringProp name="1154212879">x-pp-groups : ${group}</stringProp>
                     </collectionProp>
                     <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
                     <boolProp name="Assertion.assume_success">false</boolProp>
@@ -293,7 +293,7 @@ vars.put(&apos;sourceIp&apos;, getSourceIp());</stringProp>
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="should return source ip" enabled="true">
                     <collectionProp name="Asserion.test_strings">
                       <stringProp name="-121316922">x-pp-user : ${sourceIp};q=</stringProp>
-                      <stringProp name="-352233224">x-pp-groups : ${group};q=</stringProp>
+                      <stringProp name="1154212879">x-pp-groups : ${group}</stringProp>
                     </collectionProp>
                     <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
                     <boolProp name="Assertion.assume_success">false</boolProp>


### PR DESCRIPTION
... associated JMeter tests.  Based on our meeting yesterday we are not implementing quality for groups at this time.  If there are multiple groups the rate limiter will just use the first one.
