### PR TITLE
Refactor location of OpenstackHeadr enums to a more common place to be u...

### DIFF
--- a/project-set/commons/utilities/src/main/java/com/rackspace/papi/commons/util/http/IdentityStatus.java
+++ b/project-set/commons/utilities/src/main/java/com/rackspace/papi/commons/util/http/IdentityStatus.java
@@ -1,0 +1,10 @@
+package com.rackspace.papi.commons.util.http;
+
+/**
+ * @author fran
+ */
+public enum IdentityStatus {
+    // The possible values for the X-Identity-Status header
+    Confirmed,
+    Indeterminate
+}

--- a/project-set/commons/utilities/src/main/java/com/rackspace/papi/commons/util/http/OpenStackServiceHeader.java
+++ b/project-set/commons/utilities/src/main/java/com/rackspace/papi/commons/util/http/OpenStackServiceHeader.java
@@ -1,6 +1,4 @@
-package com.rackspace.papi.components.clientauth.openstack.v1_0;
-
-import com.rackspace.papi.commons.util.http.HeaderConstant;
+package com.rackspace.papi.commons.util.http;
 
 /**
  * @author fran
@@ -13,7 +11,7 @@ public enum OpenStackServiceHeader implements HeaderConstant {
 
     /**
      *  'Confirmed' or 'Invalid'
-     *   The underlying service will only see a value of 'Invalid' if the PAPI
+     *   The underlying service will only see a value of 'Invalid' if PAPI
      *   is configured to run in 'delegatable' mode
      */
     IDENTITY_STATUS("X-Identity-Status"),

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/openstack/v1_0/AuthenticationHeaderManager.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/openstack/v1_0/AuthenticationHeaderManager.java
@@ -4,8 +4,9 @@ import com.rackspace.auth.openstack.ids.CachableUserInfo;
 import com.rackspace.docs.identity.api.ext.rax_ksgrp.v1.Group;
 import com.rackspace.docs.identity.api.ext.rax_ksgrp.v1.Groups;
 import com.rackspace.papi.commons.util.StringUtilities;
+import com.rackspace.papi.commons.util.http.IdentityStatus;
+import com.rackspace.papi.commons.util.http.OpenStackServiceHeader;
 import com.rackspace.papi.commons.util.http.PowerApiHeader;
-import com.rackspace.papi.components.clientauth.rackspace.IdentityStatus;
 import com.rackspace.papi.filter.logic.FilterAction;
 import com.rackspace.papi.filter.logic.FilterDirector;
 

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/IdentityStatus.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/IdentityStatus.java
@@ -1,9 +1,0 @@
-package com.rackspace.papi.components.clientauth.rackspace;
-
-/**
- * @author fran
- */
-public enum IdentityStatus {
-    Confirmed,
-    Indeterminate;
-}

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/AuthenticationHeaderManager.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/AuthenticationHeaderManager.java
@@ -1,9 +1,9 @@
 package com.rackspace.papi.components.clientauth.rackspace.v1_1;
 
 import com.rackspace.papi.commons.util.StringUtilities;
+import com.rackspace.papi.commons.util.http.IdentityStatus;
+import com.rackspace.papi.commons.util.http.OpenStackServiceHeader;
 import com.rackspace.papi.commons.util.http.PowerApiHeader;
-import com.rackspace.papi.components.clientauth.openstack.v1_0.OpenStackServiceHeader;
-import com.rackspace.papi.components.clientauth.rackspace.IdentityStatus;
 import com.rackspace.papi.components.clientauth.rackspace.config.RackspaceAuth;
 import com.rackspace.papi.components.clientauth.rackspace.config.User;
 import com.rackspace.papi.components.clientauth.rackspace.config.UserRoles;

--- a/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/RackspaceAuthenticationHandlerTest.java
+++ b/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/RackspaceAuthenticationHandlerTest.java
@@ -8,7 +8,7 @@ import com.rackspace.papi.commons.util.http.CommonHttpHeader;
 import com.rackspace.papi.commons.util.http.HttpStatusCode;
 import com.rackspace.papi.commons.util.http.PowerApiHeader;
 import com.rackspace.papi.commons.util.servlet.http.ReadableHttpServletResponse;
-import com.rackspace.papi.components.clientauth.rackspace.IdentityStatus;
+import com.rackspace.papi.commons.util.http.IdentityStatus;
 import com.rackspace.papi.components.clientauth.rackspace.config.AccountMapping;
 import com.rackspace.papi.components.clientauth.rackspace.config.AccountType;
 import com.rackspace.papi.components.clientauth.rackspace.config.AuthenticationServer;

--- a/project-set/components/client-authorization/src/main/java/org/openrepose/components/rackspace/authz/RackspaceAuthorizationFilter.java
+++ b/project-set/components/client-authorization/src/main/java/org/openrepose/components/rackspace/authz/RackspaceAuthorizationFilter.java
@@ -6,7 +6,6 @@ import com.rackspace.papi.commons.util.servlet.http.MutableHttpServletResponse;
 import com.rackspace.papi.service.config.ConfigurationService;
 import com.rackspace.papi.service.context.jndi.ServletContextHelper;
 import com.rackspace.papi.filter.logic.FilterDirector;
-import com.rackspace.papi.service.datastore.Datastore;
 import com.rackspace.papi.service.datastore.DatastoreManager;
 import com.rackspace.papi.service.datastore.DatastoreService;
 import org.slf4j.Logger;
@@ -26,7 +25,7 @@ import org.slf4j.LoggerFactory;
 public class RackspaceAuthorizationFilter implements Filter {
 
    private static final Logger LOG = LoggerFactory.getLogger(RackspaceAuthorizationFilter.class);
-   private RequestAuthroizationHandlerFactory handlerFactory;
+   private RequestAuthorizationHandlerFactory handlerFactory;
 
    @Override
    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
@@ -60,8 +59,8 @@ public class RackspaceAuthorizationFilter implements Filter {
       final DatastoreManager defaultLocal = datastoreService.defaultDatastore();
 
       final ConfigurationService configurationService = ServletContextHelper.getPowerApiContext(filterConfig.getServletContext()).configurationService();
-      handlerFactory = new RequestAuthroizationHandlerFactory(defaultLocal.getDatastore());
+      handlerFactory = new RequestAuthorizationHandlerFactory(defaultLocal.getDatastore());
 
-      configurationService.subscribeTo("rackspace-authorization.cfg.xml", handlerFactory, RackspaceAuthorization.class);
+      configurationService.subscribeTo("openstack-authorization.cfg.xml", handlerFactory, RackspaceAuthorization.class);
    }
 }

--- a/project-set/components/client-authorization/src/main/java/org/openrepose/components/rackspace/authz/RequestAuthorizationHandlerFactory.java
+++ b/project-set/components/client-authorization/src/main/java/org/openrepose/components/rackspace/authz/RequestAuthorizationHandlerFactory.java
@@ -14,14 +14,14 @@ import org.openrepose.components.rackspace.authz.cache.EndpointListCacheImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RequestAuthroizationHandlerFactory extends AbstractConfiguredFilterHandlerFactory<RequestAuthroizationHandler> {
+public class RequestAuthorizationHandlerFactory extends AbstractConfiguredFilterHandlerFactory<RequestAuthorizationHandler> {
 
-   private static final Logger LOG = LoggerFactory.getLogger(RequestAuthroizationHandlerFactory.class);
+   private static final Logger LOG = LoggerFactory.getLogger(RequestAuthorizationHandlerFactory.class);
    private final Datastore datastore;
    private RackspaceAuthorization authorizationConfiguration;
    private OpenStackAuthenticationService authenticationService;
 
-   public RequestAuthroizationHandlerFactory(Datastore datastore) {
+   public RequestAuthorizationHandlerFactory(Datastore datastore) {
       this.datastore = datastore;
    }
 
@@ -42,14 +42,14 @@ public class RequestAuthroizationHandlerFactory extends AbstractConfiguredFilter
    }
 
    @Override
-   protected RequestAuthroizationHandler buildHandler() {
+   protected RequestAuthorizationHandler buildHandler() {
       if (authenticationService == null) {
          LOG.error("Component has not been initialized yet. Please check your configurations.");
          throw new IllegalStateException("Component has not been initialized yet");
       }
 
       final EndpointListCache cache = new EndpointListCacheImpl(datastore, authorizationConfiguration.getAuthenticationServer().getEndpointListTtl());
-      return new RequestAuthroizationHandler(authenticationService, cache, authorizationConfiguration.getServiceEndpoint());
+      return new RequestAuthorizationHandler(authenticationService, cache, authorizationConfiguration.getServiceEndpoint());
    }
 
    @Override

--- a/project-set/components/client-authorization/src/test/java/org/openrepose/components/rackspace/authz/RequestAuthorizationHandlerTest.java
+++ b/project-set/components/client-authorization/src/test/java/org/openrepose/components/rackspace/authz/RequestAuthorizationHandlerTest.java
@@ -3,6 +3,7 @@ package org.openrepose.components.rackspace.authz;
 import com.rackspace.auth.openstack.ids.OpenStackAuthenticationService;
 import com.rackspace.papi.commons.util.http.CommonHttpHeader;
 import com.rackspace.papi.commons.util.http.HttpStatusCode;
+import com.rackspace.papi.commons.util.http.OpenStackServiceHeader;
 import com.rackspace.papi.filter.logic.FilterAction;
 import com.rackspace.papi.filter.logic.FilterDirector;
 import java.util.Collections;
@@ -27,7 +28,7 @@ import org.openrepose.components.rackspace.authz.cache.EndpointListCache;
  * @author zinic
  */
 @RunWith(Enclosed.class)
-public class RequestAuthroizationHandlerTest {
+public class RequestAuthorizationHandlerTest {
 
    private static final String UNAUTHORIZED_TOKEN = "abcdef-abcdef-abcdef-abcdef", AUTHORIZED_TOKEN = "authorized", CACHED_TOKEN = "cached";
    private static final String PUBLIC_URL = "http://service.api.f.com/v1.1";
@@ -36,7 +37,7 @@ public class RequestAuthroizationHandlerTest {
    public static class TestParent {
 
       protected OpenStackAuthenticationService mockedAuthService;
-      protected RequestAuthroizationHandler handler;
+      protected RequestAuthorizationHandler handler;
       protected EndpointListCache mockedCache;
       protected HttpServletRequest mockedRequest;
 
@@ -67,7 +68,7 @@ public class RequestAuthroizationHandlerTest {
          final ServiceEndpoint myServiceEndpoint = new ServiceEndpoint();
          myServiceEndpoint.setHref(PUBLIC_URL);
 
-         handler = new RequestAuthroizationHandler(mockedAuthService, mockedCache, myServiceEndpoint);
+         handler = new RequestAuthorizationHandler(mockedAuthService, mockedCache, myServiceEndpoint);
 
          mockedRequest = mock(HttpServletRequest.class);
       }
@@ -77,7 +78,7 @@ public class RequestAuthroizationHandlerTest {
 
       @Test
       public void shouldRejectDelegatedAuthentication() {
-         when(mockedRequest.getHeader(CommonHttpHeader.WWW_AUTHENTICATE.toString())).thenReturn("Delegated");
+         when(mockedRequest.getHeader(OpenStackServiceHeader.IDENTITY_STATUS.toString())).thenReturn("Confirmed");
 
          final FilterDirector director = handler.handleRequest(mockedRequest, null);
 


### PR DESCRIPTION
...sed across authentication and authorization filter.  Update authorization filter to subscribe to changes to openstack-authorization file instead of rackspace-authorization file. Update method for determining if in delegated mode in authorization by looking for X-Identity-Status instead of WWW-Authenticate.  Fix some minor mispellings.
