### PR TITLE
Update the container configuration schema documentation to indicate the ...

### DIFF
--- a/project-set/core/core-lib/src/main/resources/META-INF/schema/container/container-configuration.xsd
+++ b/project-set/core/core-lib/src/main/resources/META-INF/schema/container/container-configuration.xsd
@@ -38,7 +38,7 @@
                 <xs:attribute name="check-interval" type="xs:int" use="optional" default="15">
                     <xs:annotation>
                         <xs:documentation>
-                            <html:p>Directory check interval in seconds</html:p>
+                            <html:p>Directory check interval in milliseconds</html:p>
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>


### PR DESCRIPTION
...check-interval is in milliseconds (not seconds).
