### PR TITLE
Add code to check if port servlet context attribute is not available. Fo...

### DIFF
--- a/project-set/components/servlet-context-router/src/main/java/org/openrepose/components/routing/servlet/RoutingTagger.java
+++ b/project-set/components/servlet-context-router/src/main/java/org/openrepose/components/routing/servlet/RoutingTagger.java
@@ -1,29 +1,21 @@
 package org.openrepose.components.routing.servlet;
 
 import com.rackspace.papi.commons.util.http.PowerApiHeader;
-import com.rackspace.papi.commons.util.http.header.HeaderValue;
-import com.rackspace.papi.commons.util.http.header.HeaderValueImpl;
 import com.rackspace.papi.commons.util.servlet.http.ReadableHttpServletResponse;
 import com.rackspace.papi.filter.logic.common.AbstractFilterLogicHandler;
 import com.rackspace.papi.filter.logic.FilterAction;
 import com.rackspace.papi.filter.logic.FilterDirector;
 import com.rackspace.papi.filter.logic.impl.FilterDirectorImpl;
-import java.util.LinkedList;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.openrepose.components.routing.servlet.config.ContextPathRoute;
-import org.slf4j.LoggerFactory;
 
 public class RoutingTagger extends AbstractFilterLogicHandler {
 
-   private final List<HeaderValue> headerValues;
+   private final List<ContextPathRoute> routes;
 
    public RoutingTagger(List<ContextPathRoute> routes) {
-      headerValues = new LinkedList<HeaderValue>();
-      
-      for (ContextPathRoute route : routes) {
-         headerValues.add(new HeaderValueImpl(route.getValue(), route.getQualityFactor()));
-      }
+      this.routes = routes;
    }
 
    @Override
@@ -31,8 +23,8 @@ public class RoutingTagger extends AbstractFilterLogicHandler {
       final FilterDirector myDirector = new FilterDirectorImpl();
       myDirector.setFilterAction(FilterAction.PASS);
 
-      for (HeaderValue route : headerValues) {
-         myDirector.requestHeaderManager().appendHeader(PowerApiHeader.NEXT_ROUTE.toString(), route.toString());
+      for (ContextPathRoute route : routes) {
+         myDirector.requestHeaderManager().appendHeader(PowerApiHeader.NEXT_ROUTE.toString(), route.getValue());
       }
       
       return myDirector;

--- a/project-set/components/servlet-context-router/src/main/resources/META-INF/schema/config/servlet-ctx-router-configuration.xsd
+++ b/project-set/components/servlet-context-router/src/main/resources/META-INF/schema/config/servlet-ctx-router-configuration.xsd
@@ -35,18 +35,6 @@
                   </html:p>
                </xs:documentation>
             </xs:annotation>
-
-            <xs:attribute name="quality-factor" type="xs:double" use="required">
-               <xs:annotation>
-                  <xs:documentation>
-                     <html:p>
-                        The context path quality factor determines how desirable this
-                        potential route is. The higher the quality factor, the more
-                        desirable the route.
-                     </html:p>
-                  </xs:documentation>
-               </xs:annotation>
-            </xs:attribute>
          </xs:extension>
       </xs:simpleContent>
    </xs:complexType>

--- a/project-set/components/servlet-context-router/src/main/resources/META-INF/schema/examples/servlet-context-router.cfg.xml
+++ b/project-set/components/servlet-context-router/src/main/resources/META-INF/schema/examples/servlet-context-router.cfg.xml
@@ -3,5 +3,5 @@
 <servlet-context-router xmlns='http://openrepose.org/repose/servlet-context-router/v1.0'>
    
    <!-- This defines a context path route to the context '/protected/servlet/*' -->
-   <context-paths quality-factor="0.1">/protected/servlet/*</context-paths>
+   <context-paths>/protected/servlet/*</context-paths>
 </servlet-context-router>

--- a/project-set/components/servlet-context-router/src/test/java/org/openrepose/components/routing/servlet/RoutingTaggerTest.java
+++ b/project-set/components/servlet-context-router/src/test/java/org/openrepose/components/routing/servlet/RoutingTaggerTest.java
@@ -8,6 +8,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -23,15 +25,17 @@ import static org.junit.Assert.*;
 public class RoutingTaggerTest {
 
    public static class WhenRoutingToServletContexts {
+      // TODO: Add this back in when we add quality in
 
       @Test
+      @Ignore
       public void shouldAddRoutesWithCorrectQualityFactors() {
          final List<ContextPathRoute> configuredContextRoutes = new LinkedList<ContextPathRoute>();
          configuredContextRoutes.add(newContextPathRoute("/protected", 0.5));
          configuredContextRoutes.add(newContextPathRoute("/_secrete", 0.3));
          configuredContextRoutes.add(newContextPathRoute("/_v1", 0.1));
          configuredContextRoutes.add(newContextPathRoute("/_v2", 0.1));
-         
+
          final RoutingTagger tagger = new RoutingTagger(configuredContextRoutes);
          final FilterDirector filterDirector = tagger.handleRequest(null, null);
 
@@ -39,30 +43,30 @@ public class RoutingTaggerTest {
 
          assertNotNull("Next route header must not be null", writtenRoutes);
          assertEquals("Next route header must have 4 values", (Integer)4, (Integer)writtenRoutes.size());
-         
+
          for (String headerValue : writtenRoutes) {
             final HeaderValue actualWrittenRoute = new HeaderValueParser(headerValue).parse();
 
             for (Iterator<ContextPathRoute> routeIterator = configuredContextRoutes.iterator(); routeIterator.hasNext();) {
                final ContextPathRoute expectedRoute = routeIterator.next();
-               
+
                if (expectedRoute.getValue().equals(actualWrittenRoute.getValue())) {
-                  assertEquals("Quality value of matched context routes must be equal", (Double)expectedRoute.getQualityFactor(), (Double)actualWrittenRoute.getQualityFactor());
+//                  assertEquals("Quality value of matched context routes must be equal", (Double)expectedRoute.getQualityFactor(), (Double)actualWrittenRoute.getQualityFactor());
                   routeIterator.remove();
                   break;
                }
             }
          }
-         
+
          assertTrue("All configured context routes must be added to incoming request", configuredContextRoutes.isEmpty());
       }
    }
-   
+
    public static ContextPathRoute newContextPathRoute(String path, double qualityFactor) {
       final ContextPathRoute contextPathRoute = new ContextPathRoute();
       contextPathRoute.setValue(path);
-      contextPathRoute.setQualityFactor(qualityFactor);
-      
+//      contextPathRoute.setQualityFactor(qualityFactor);
+
       return contextPathRoute;
    }
 }

--- a/project-set/core/core-lib/src/main/java/com/rackspace/papi/filter/SystemModelInterrogator.java
+++ b/project-set/core/core-lib/src/main/java/com/rackspace/papi/filter/SystemModelInterrogator.java
@@ -6,13 +6,14 @@ import com.rackspace.papi.model.PowerProxy;
 import com.rackspace.papi.commons.util.net.NetworkInterfaceProvider;
 import com.rackspace.papi.commons.util.net.NetworkNameResolver;
 import com.rackspace.papi.commons.util.net.StaticNetworkInterfaceProvider;
+
 import java.net.InetAddress;
-import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class SystemModelInterrogator {
 
    private static final Logger LOG = LoggerFactory.getLogger(SystemModelInterrogator.class);
-   
+
    private final NetworkInterfaceProvider networkInterfaceProvider;
    private final NetworkNameResolver nameResolver;
    private final PowerProxy systemModel;
@@ -44,16 +45,26 @@ public class SystemModelInterrogator {
 
       final List<Host> possibleHosts = new LinkedList<Host>();
 
-      for (Host powerProxyHost : systemModel.getHost()) {
-         if (powerProxyHost.getServicePort() == localPort) {
-            possibleHosts.add(powerProxyHost);
+      if (localPort > 0) {
+         for (Host powerProxyHost : systemModel.getHost()) {
+            if (powerProxyHost.getServicePort() == localPort) {
+               possibleHosts.add(powerProxyHost);
+            }
          }
+      } else {
+         // This is the case where we are running ROOT.war so we
+         // don't have easy programmatic access to the port on which
+         // the local Repose is running.  So, just use the hostname to
+         // resolve which is the local Repose node.
+         possibleHosts.addAll(systemModel.getHost());
+
+         LOG.warn("Could not find the port on which Repose is running: repose-bound-port context parameter is not configured in web.xml.  Defaulting to assumption that first host in power-proxy.cfg.xml is the local Repose host.");
       }
 
       try {
          for (Host powerProxyHost : possibleHosts) {
             final InetAddress hostAddress = nameResolver.lookupName(powerProxyHost.getHostname());
-            
+
             if (networkInterfaceProvider.hasInterfaceFor(hostAddress)) {
                localHost = powerProxyHost;
                break;
@@ -69,6 +80,7 @@ public class SystemModelInterrogator {
    }
 
    // TODO: Enhancement - Explore using service domains to better handle routing identification logic
+
    public Host getNextRoutableHost() {
       final Host localHost = getLocalHost();
 

--- a/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/context/jndi/ServletContextHelper.java
+++ b/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/context/jndi/ServletContextHelper.java
@@ -1,43 +1,50 @@
 package com.rackspace.papi.service.context.jndi;
 
 import com.rackspace.papi.servlet.InitParameter;
+
 import javax.naming.Context;
 import javax.servlet.ServletContext;
 
 public final class ServletContextHelper {
 
-    public static final String SERVLET_CONTEXT_ATTRIBUTE_NAME = "PAPI_ServletContext";
+   public static final String SERVLET_CONTEXT_ATTRIBUTE_NAME = "PAPI_ServletContext";
 
-    private ServletContextHelper() {
-    }
+   private ServletContextHelper() {
+   }
 
-    public static Context namingContext(ServletContext ctx) {
-        final Object o = ctx.getAttribute(SERVLET_CONTEXT_ATTRIBUTE_NAME);
+   public static Context namingContext(ServletContext ctx) {
+      final Object o = ctx.getAttribute(SERVLET_CONTEXT_ATTRIBUTE_NAME);
 
-        if (o == null) {
-            throw new IllegalArgumentException("Servlet Context attribute \""
-                    + SERVLET_CONTEXT_ATTRIBUTE_NAME
-                    + "\" appears to not be set. Has the PowerApiContextManager been set as a servlet context listener");
-        }
+      if (o == null) {
+         throw new IllegalArgumentException("Servlet Context attribute \""
+                 + SERVLET_CONTEXT_ATTRIBUTE_NAME
+                 + "\" appears to not be set. Has the PowerApiContextManager been set as a servlet context listener");
+      }
 
-        if (!(o instanceof Context)) {
-            throw new IllegalStateException("Servlet Context attribute \""
-                    + SERVLET_CONTEXT_ATTRIBUTE_NAME
-                    + "\" is not a valid jndi naming context.");
-        }
+      if (!(o instanceof Context)) {
+         throw new IllegalStateException("Servlet Context attribute \""
+                 + SERVLET_CONTEXT_ATTRIBUTE_NAME
+                 + "\" is not a valid jndi naming context.");
+      }
 
-        return (Context) o;
-    }
+      return (Context) o;
+   }
 
-    public static ContextAdapter getPowerApiContext(ServletContext ctx) {
-        return new JndiContextAdapter(namingContext(ctx));
-    }
+   public static ContextAdapter getPowerApiContext(ServletContext ctx) {
+      return new JndiContextAdapter(namingContext(ctx));
+   }
 
-    public static void setPowerApiContext(ServletContext ctx, Context namingContext) {
-        ctx.setAttribute(SERVLET_CONTEXT_ATTRIBUTE_NAME, namingContext);
-    }
-    
-    public static int getServerPort(ServletContext ctx) {
-       return (Integer) ctx.getAttribute(InitParameter.PORT.getParameterName());
-    }
+   public static void setPowerApiContext(ServletContext ctx, Context namingContext) {
+      ctx.setAttribute(SERVLET_CONTEXT_ATTRIBUTE_NAME, namingContext);
+   }
+
+   public static int getServerPort(ServletContext ctx) {
+      Object port = ctx.getAttribute(InitParameter.PORT.getParameterName());
+
+      if (port != null) {
+         return (Integer) ctx.getAttribute(InitParameter.PORT.getParameterName());
+      } else {
+         return -1;
+      }
+   }
 }


### PR DESCRIPTION
...r now, if port is not available then just assume the first host in power-proxy.cfg.xml that matches the the local box is the local repose node.  At some point we might want to change this.  I know we could add a parameter to the web.xml for the port.  However, then the customer would have to explode our WAR file to update the port.  After talking to Theresa, that's not the way we want to go.  Also updated the servlet context router example config to have the correct element name and update the servlet context router to get rid of quality until we are ready to handle it in the router.  If we were to leave it in then repose would not route correctly as the Power Filter routing code does not understand quality yet.
