### PR TITLE
Remove sun-web.xml files.  We don't need those afterall to run in Glassf...

### DIFF
--- a/project-set/core/web-application/src/main/webapp/WEB-INF/sun-web.xml
+++ b/project-set/core/web-application/src/main/webapp/WEB-INF/sun-web.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD GlassFish Application Server 3.0 Servlet 3.0//EN" "http://www.sun.com/software/appserver/dtds/sun-web-app_3_0-0.dtd">        
-<sun-web-app>
-    <property name="crossContextAllowed" value="true"/>
-</sun-web-app>

--- a/project-set/external/testing/test-support/src/main/webapp/WEB-INF/sun-web.xml
+++ b/project-set/external/testing/test-support/src/main/webapp/WEB-INF/sun-web.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD GlassFish Application Server 3.0 Servlet 3.0//EN" "http://www.sun.com/software/appserver/dtds/sun-web-app_3_0-0.dtd">
-<sun-web-app>
-    <property name="crossContextAllowed" value="true"/>
-</sun-web-app>


### PR DESCRIPTION
...ish as the context.xml file we already have works for setting crossContext to true.  The problem with us running in Glassfish was not us.  It was the fact that Glassfish comes with a default-web.xml file in its domain config.  This default-web.xml comes with a default Servlet running at the root context.  Consequently, it was interferring and causing a 404.  When the default-web.xml file is removed from the config, Repose routes to the origin service as it should.  This has been documented in the ROOT.WAR section of our deployment wiki.
