### PR TITLE
Add region, name, and type to client authorization configuration.  Updat...

### DIFF
--- a/project-set/components/client-authorization/src/main/java/org/openrepose/components/rackspace/authz/RequestAuthorizationHandler.java
+++ b/project-set/components/client-authorization/src/main/java/org/openrepose/components/rackspace/authz/RequestAuthorizationHandler.java
@@ -65,12 +65,25 @@ public class RequestAuthorizationHandler extends AbstractFilterLogicHandler {
    public void checkTenantEndpoints(FilterDirector director, String userToken) {
       final List<CachedEndpoint> authorizedEndpoints = getEndpointsForToken(userToken);
 
+      if (isEndpointAuthorized(authorizedEndpoints)) {
+         director.setFilterAction(FilterAction.PASS);
+      }
+   }
+
+   private boolean isEndpointAuthorized(final List<CachedEndpoint> authorizedEndpoints){
+      boolean authorized = false;
+
       for (CachedEndpoint authorizedEndpoint : authorizedEndpoints) {
-         if (authorizedEndpoint.getPublicUrl().startsWith(myEndpoint.getHref())) {
-            director.setFilterAction(FilterAction.PASS);
+         if (authorizedEndpoint.getPublicUrl().startsWith(myEndpoint.getHref()) &&
+             authorizedEndpoint.getType().equalsIgnoreCase(myEndpoint.getType()) &&
+             StringUtilities.nullSafeEqualsIgnoreCase(authorizedEndpoint.getRegion(), myEndpoint.getRegion()) &&
+             StringUtilities.nullSafeEqualsIgnoreCase(authorizedEndpoint.getName(), myEndpoint.getName())) {
+            authorized = true;
             break;
          }
       }
+
+      return authorized;
    }
 
    private List<CachedEndpoint> getEndpointsForToken(String userToken) {
@@ -94,7 +107,7 @@ public class RequestAuthorizationHandler extends AbstractFilterLogicHandler {
       final LinkedList<CachedEndpoint> serializable = new LinkedList<CachedEndpoint>();
 
       for (Endpoint ep : authorizedEndpoints) {
-         serializable.add(new CachedEndpoint(ep.getPublicURL()));
+         serializable.add(new CachedEndpoint(ep.getPublicURL(), ep.getRegion(), ep.getName(), ep.getType()));
       }
 
       return serializable;

--- a/project-set/components/client-authorization/src/main/java/org/openrepose/components/rackspace/authz/cache/CachedEndpoint.java
+++ b/project-set/components/client-authorization/src/main/java/org/openrepose/components/rackspace/authz/cache/CachedEndpoint.java
@@ -9,12 +9,30 @@ import java.io.Serializable;
 public final class CachedEndpoint implements Serializable {
 
    private final String publicUrl;
+   private final String region;
+   private final String name;
+   private final String type;
 
-   public CachedEndpoint(String publicUrl) {
+   public CachedEndpoint(String publicUrl, String region, String name, String type) {
       this.publicUrl = publicUrl;
+      this.region = region;
+      this.name = name;
+      this.type = type;
    }
 
    public String getPublicUrl() {
       return publicUrl;
+   }
+
+   public String getRegion() {
+      return region;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getType() {
+      return type;
    }
 }

--- a/project-set/components/client-authorization/src/main/resources/META-INF/schema/config/openstack-authorization-configuration.xsd
+++ b/project-set/components/client-authorization/src/main/resources/META-INF/schema/config/openstack-authorization-configuration.xsd
@@ -76,5 +76,29 @@
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+
+      <xs:attribute name="region" type="xs:string" use="required">
+         <xs:annotation>
+            <xs:documentation>
+               <html:p>Service Mapping for the Origin Service</html:p>
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+
+      <xs:attribute name="name" type="xs:string" use="required">
+         <xs:annotation>
+            <xs:documentation>
+               <html:p>Service Mapping for the Origin Service</html:p>
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+
+      <xs:attribute name="type" type="xs:string" use="required">
+         <xs:annotation>
+            <xs:documentation>
+               <html:p>Service Mapping for the Origin Service</html:p>
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 </xs:schema>

--- a/project-set/components/client-authorization/src/main/resources/META-INF/schema/examples/openstack-authorization.cfg.xml
+++ b/project-set/components/client-authorization/src/main/resources/META-INF/schema/examples/openstack-authorization.cfg.xml
@@ -2,7 +2,5 @@
 
 <rackspace-authorization xmlns='http://openrepose.org/components/openstack-identity/auth-z/v1.0'>
    <authentication-server username="" password="" href="" endpoint-list-ttl="300" />
-   <service-endpoint href="https://service.api.rackspacecloud.com/v1.0/" />
-   
-   <my-service type="compute" name="Compute" region="" />
+   <service-endpoint href="https://service.api.rackspacecloud.com/v1.0/" region="ORD" name="" type="compute"/>   
 </rackspace-authorization>

--- a/project-set/components/client-authorization/src/test/java/org/openrepose/components/rackspace/authz/RequestAuthorizationHandlerTest.java
+++ b/project-set/components/client-authorization/src/test/java/org/openrepose/components/rackspace/authz/RequestAuthorizationHandlerTest.java
@@ -31,7 +31,7 @@ import org.openrepose.components.rackspace.authz.cache.EndpointListCache;
 public class RequestAuthorizationHandlerTest {
 
    private static final String UNAUTHORIZED_TOKEN = "abcdef-abcdef-abcdef-abcdef", AUTHORIZED_TOKEN = "authorized", CACHED_TOKEN = "cached";
-   private static final String PUBLIC_URL = "http://service.api.f.com/v1.1";
+   private static final String PUBLIC_URL = "http://service.api.f.com/v1.1", REGION = "ORD", NAME = "Nova", TYPE = "compute";
 
    @Ignore
    public static class TestParent {
@@ -47,7 +47,7 @@ public class RequestAuthorizationHandlerTest {
          mockedCache = mock(EndpointListCache.class);
 
          final List<CachedEndpoint> cachedEndpointList = new LinkedList<CachedEndpoint>();
-         cachedEndpointList.add(new CachedEndpoint(PUBLIC_URL));
+         cachedEndpointList.add(new CachedEndpoint(PUBLIC_URL, REGION, NAME, TYPE));
 
          when(mockedCache.getCachedEndpointsForToken(AUTHORIZED_TOKEN)).thenReturn(null);
          when(mockedCache.getCachedEndpointsForToken(CACHED_TOKEN)).thenReturn(cachedEndpointList);
@@ -57,6 +57,9 @@ public class RequestAuthorizationHandlerTest {
 
          Endpoint endpoint = new Endpoint();
          endpoint.setPublicURL(PUBLIC_URL);
+         endpoint.setRegion(REGION);
+         endpoint.setName(NAME);
+         endpoint.setType(TYPE);
 
          endpointList.add(endpoint);
 
@@ -67,6 +70,9 @@ public class RequestAuthorizationHandlerTest {
 
          final ServiceEndpoint myServiceEndpoint = new ServiceEndpoint();
          myServiceEndpoint.setHref(PUBLIC_URL);
+         myServiceEndpoint.setRegion(REGION);
+         myServiceEndpoint.setName(NAME);
+         myServiceEndpoint.setType(TYPE);
 
          handler = new RequestAuthorizationHandler(mockedAuthService, mockedCache, myServiceEndpoint);
 

--- a/project-set/components/client-authorization/src/test/java/org/openrepose/components/rackspace/authz/cache/EndpointListCacheImplTest.java
+++ b/project-set/components/client-authorization/src/test/java/org/openrepose/components/rackspace/authz/cache/EndpointListCacheImplTest.java
@@ -24,7 +24,11 @@ public class EndpointListCacheImplTest {
            NON_CACHED_TOKEN_FULLNAME = EndpointListCacheImpl.getCacheNameForToken(NON_CACHED_TOKEN),
            CACHED_TOKEN = "cached",
            CACHED_TOKEN_FULLNAME = EndpointListCacheImpl.getCacheNameForToken(CACHED_TOKEN),
-           PUBLIC_URL = "http://f.com";
+           PUBLIC_URL = "http://f.com",
+           REGION = "ORD",
+           NAME = "Nova",
+           TYPE = "compute";
+
 
    public static class WhenGettingCachedEndpointLists {
 
@@ -34,7 +38,7 @@ public class EndpointListCacheImplTest {
       @Before
       public void standUp() throws Exception {
          final LinkedList<CachedEndpoint> endpointList = new LinkedList<CachedEndpoint>();
-         endpointList.add(new CachedEndpoint(PUBLIC_URL));
+         endpointList.add(new CachedEndpoint(PUBLIC_URL, REGION, NAME, TYPE));
 
          mockedDatastore = mock(Datastore.class);
          when(mockedDatastore.get(eq(CACHED_TOKEN_FULLNAME))).thenReturn(new StoredElementImpl(CACHED_TOKEN, ObjectSerializer.instance().writeObject(endpointList)));
@@ -66,7 +70,7 @@ public class EndpointListCacheImplTest {
       @Test
       public void shouldCacheEndpointList() throws Exception {
          final LinkedList<CachedEndpoint> endpointList = new LinkedList<CachedEndpoint>();
-         endpointList.add(new CachedEndpoint(PUBLIC_URL));
+         endpointList.add(new CachedEndpoint(PUBLIC_URL, REGION, NAME, TYPE));
          
          cache.cacheEndpointsForToken(NON_CACHED_TOKEN, endpointList);
          


### PR DESCRIPTION
...e handler code to check that the endpoint, name, and type returned in the service catalog match what is in the repose client authorization configuration.  If they match then assume the client is authorized and let the request pass thru repose to the origin service.
