### PR TITLE
Fail gracefully, if the absolute limit URL cannot be retrived correctly.

### DIFF
--- a/project-set/components/rate-limiting/src/main/resources/META-INF/xslt/limits-combine.xsl
+++ b/project-set/components/rate-limiting/src/main/resources/META-INF/xslt/limits-combine.xsl
@@ -26,7 +26,7 @@
         </if>
         
         <if test="count($absoluteDoc)!=1">
-            <message terminate="yes">Could not load <value-of select="$absoluteURL"/></message>
+            <message>Could not load <value-of select="$absoluteURL"/></message>
         </if>
         
         <limits xmlns="http://docs.openstack.org/common/api/v1.0">


### PR DESCRIPTION
We don't want to blow up in cases where we can't access the absolute limit URL when combining limits.
