### PR TITLE
Json limit fixes

### DIFF
--- a/project-set/components/rate-limiting/src/main/resources/META-INF/xslt/limits-json.xsl
+++ b/project-set/components/rate-limiting/src/main/resources/META-INF/xslt/limits-json.xsl
@@ -55,9 +55,10 @@
         <if test="position() != 1">
             <text>,</text>
         </if>
-        <text>"</text>
-        <value-of select="@name"/>
-        <text>" : </text>
+        <call-template name="json-string">
+            <with-param name="in" select="@name"/>
+        </call-template>
+        <text> : </text>
         <value-of select="@value"/>
     </template>
 
@@ -65,9 +66,10 @@
         <if test="position() != 1">
             <text>,</text>
         </if>
-        <text>"</text>
-        <value-of select="name()"/>
-        <text>" : </text>
+        <call-template name="json-string">
+            <with-param name="in" select="name()"/>
+        </call-template>
+        <text> : </text>
         <value-of select="."/>
     </template>
 
@@ -75,10 +77,48 @@
         <if test="position() != 1">
             <text>,</text>
         </if>
-        <text>"</text>
-        <value-of select="name()"/>
-        <text>" : "</text>
-        <value-of select="."/>
-        <text>"</text>
+        <call-template name="json-string">
+            <with-param name="in" select="name()"/>
+        </call-template>
+        <text> : </text>
+        <call-template name="json-string">
+            <with-param name="in" select="."/>
+        </call-template>
+    </template>
+
+    <template name="json-string">
+        <param name="in"/>
+        <variable name="no-backslash">
+            <call-template name="escape-out">
+                <with-param name="in" select="$in"/>
+                <with-param name="char" select="'\'"/>
+            </call-template>
+        </variable>
+        <variable name="no-quote">
+            <call-template name="escape-out">
+                <with-param name="in" select="$no-backslash"/>
+                <with-param name="char" select="'&quot;'"/>
+            </call-template>
+        </variable>
+        <value-of select="concat('&quot;',$no-quote,'&quot;')"/>
+    </template>
+
+    <template name="escape-out">
+        <param name="in" />
+        <param name="char"/>
+        <variable name="before" select="substring-before($in, $char)"/>
+        <variable name="after" select="substring-after($in, $char)"/>
+        <choose>
+            <when test="string-length($before) &gt; 0 or string-length($after) &gt; 0">
+                <value-of select="concat($before,'\',$char)"/>
+                <call-template name="escape-out">
+                    <with-param name="in" select="$after"/>
+                    <with-param name="char" select="$char"/>
+                </call-template>
+            </when>
+            <otherwise>
+                <value-of select="$in"/>
+            </otherwise>
+        </choose>
     </template>
 </transform>


### PR DESCRIPTION
This pull request addresses a number of issues related to JSON handling of the rate-limit response.
1.  The JSON XSL file is in DOS mode -- not a big deal but hey,
2.  The JSON format is incorrect according to the contract defined in: http://docs.openstack.org/api/openstack-compute/2/content/ProgramaticLimits.html  The JSON format is older -- all future OpenStack services should use this format, however we need to track the fact that LB needs to use the older format -- the solution there may be to utilize the translation component.
3.  JSON strings were not encoded correctly.
