### PR TITLE
B-16613: Fix NPE in ResponseMessageService when accept header is null.  ...

### DIFF
--- a/project-set/core/core-lib/src/main/resources/META-INF/schema/examples/response-messaging.cfg.xml
+++ b/project-set/core/core-lib/src/main/resources/META-INF/schema/examples/response-messaging.cfg.xml
@@ -8,7 +8,8 @@
     "overLimit" : {
         "code" : 413,
         "message" : "OverLimit Retry...",
-        "details" : "Error Details..."
+        "details" : "Error Details...",
+	    "retryAt" : "%{Retry-After}o"
     }
 }
         </message>
@@ -17,7 +18,8 @@
 <![CDATA[
 <overLimit
     xmlns="http://docs.openstack.org/compute/api/v1.1"
-    code="413">
+    code="413"
+    retryAt="%{Retry-After}o">
   <message>OverLimit Retry...</message>
   <details>Error Details...</details>
 </overLimit>


### PR DESCRIPTION
...If the accept header is null the RMS now assumes an accept type of _/_.  Also updated the sample RMS config to include a _/_ entry and a format string for the Retry-After header.
