### PR TITLE
Make integration pom only runnable when build-system-packages is set.

### DIFF
--- a/project-set/installation/rpm/integration/pom.xml
+++ b/project-set/installation/rpm/integration/pom.xml
@@ -31,8 +31,14 @@
         <profile>
             <id>RPM Build Support</id>
 
+            <!--<activation>-->
+                <!--<activeByDefault>true</activeByDefault>-->
+            <!--</activation>-->
+
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>build-system-packages</name>
+                </property>
             </activation>
 
             <build>


### PR DESCRIPTION
Make integration pom only runnable when build-system-packages is set.
