### PR TITLE
Fix bug found in deployment test case.  Add null check for ReposeCluster...

### DIFF
--- a/project-set/core/core-lib/src/main/java/com/rackspace/papi/filter/PowerFilterChain.java
+++ b/project-set/core/core-lib/src/main/java/com/rackspace/papi/filter/PowerFilterChain.java
@@ -68,11 +68,10 @@ public class PowerFilterChain implements FilterChain {
         this.routingService = ServletContextHelper.getInstance().getPowerApiContext(context).routingService();
         destinations = new HashMap<String, Destination>();
 
-        if (domain.getDestinations() != null) {
+        if (domain != null && domain.getDestinations() != null) {
             addDestinations(domain.getDestinations().getEndpoint());
             addDestinations(domain.getDestinations().getTarget());
         }
-
     }
 
     private void addDestinations(List<? extends Destination> destList) {


### PR DESCRIPTION
Fix bug found in deployment test case.  Add null check for ReposeCluster to handle the deployment case where Repose core is started but no filters are loaded and a request is sent to Repose.
