### PR TITLE
TK33612: Update deb poms to use newer version of git-commit plugin and t...

### DIFF
--- a/project-set/installation/deb/cli-utils/pom.xml
+++ b/project-set/installation/deb/cli-utils/pom.xml
@@ -35,57 +35,22 @@
                     <plugin>
                         <groupId>pl.project13.maven</groupId>
                         <artifactId>git-commit-id-plugin</artifactId>
-                        <version>1.9</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <prefix>git</prefix>
-                            <verbose>false</verbose>
-                            <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            <generateGitPropertiesFilename>target/git.properties</generateGitPropertiesFilename>
-                        </configuration>
                     </plugin>
 
-                    <!--<plugin>-->
-                        <!--<groupId>org.codehaus.mojo</groupId>-->
-                        <!--<artifactId>properties-maven-plugin</artifactId>-->
-                        <!--<version>1.0-alpha-2</version>-->
-                        <!--<executions>-->
-                            <!--<execution>-->
-                                <!--<phase>process-resources</phase>-->
-                                <!--<goals>-->
-                                    <!--<goal>read-project-properties</goal>-->
-                                <!--</goals>-->
-                                <!--<configuration>-->
-                                    <!--<files>-->
-                                        <!--<file>${basedir}/target/git.properties</file>-->
-                                    <!--</files>-->
-                                <!--</configuration>-->
-                            <!--</execution>-->
-                        <!--</executions>-->
-                    <!--</plugin>-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>                        
+                    </plugin>
                     
                     <plugin>
                         <groupId>org.vafer</groupId>
                         <artifactId>jdeb</artifactId>
-                        <version>0.9</version>
 
                         <executions>
                             <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jdeb</goal>
-                                </goals>
 
                                 <configuration>
-                                    <!--<deb>[[buildDir]]/repose-[[artifactId]]-[[version]]-${git.commit.id.abbrev}.deb</deb>-->
-                                    <deb>[[buildDir]]/repose-[[artifactId]]-[[version]].deb</deb>
+                                    <deb>[[buildDir]]/repose-[[artifactId]]-[[version]]-${git.commit.id.abbrev}.deb</deb>
                                     <timestamped>true</timestamped>
                                     
                                     <dataSet>

--- a/project-set/installation/deb/pom.xml
+++ b/project-set/installation/deb/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>com.rackspace.repose.installation</groupId>
-      <artifactId>installation</artifactId>
-      <version>2.0.1-SNAPSHOT</version>
-   </parent>
+        <groupId>com.rackspace.repose.installation</groupId>
+        <artifactId>installation</artifactId>
+        <version>2.0.1-SNAPSHOT</version>
+    </parent>
 
     <groupId>com.rackspace.repose.installation.deb</groupId>
     <artifactId>deb</artifactId>
@@ -25,5 +26,78 @@
         <module>repose-filter-bundle</module>
         <module>repose-valve</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>DEB Build Support</id>
+
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <build>
+                <!-- Having these here configures the plugin execution goals and configurations used by all children poms -->
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>pl.project13.maven</groupId>
+                            <artifactId>git-commit-id-plugin</artifactId>
+                            <version>2.0.3</version>
+                            <executions>
+                                <execution>
+                                    <goals>
+                                        <goal>revision</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <prefix>git</prefix>
+                                <verbose>false</verbose>
+                                <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                                <skipPoms>false</skipPoms>
+                                <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                                <generateGitPropertiesFilename>target/git.properties</generateGitPropertiesFilename>
+                            </configuration>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>properties-maven-plugin</artifactId>
+                            <version>1.0-alpha-2</version>
+                            <executions>
+                                <execution>
+                                    <phase>process-resources</phase>
+                                    <goals>
+                                        <goal>read-project-properties</goal>
+                                    </goals>
+                                    <configuration>
+                                        <files>
+                                            <file>${basedir}/target/git.properties</file>
+                                        </files>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.vafer</groupId>
+                            <artifactId>jdeb</artifactId>
+                            <version>0.9</version>
+
+                            <executions>
+                                <execution>
+                                    <phase>package</phase>
+                                    <goals>
+                                        <goal>jdeb</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>

--- a/project-set/installation/deb/repose-filter-bundle/pom.xml
+++ b/project-set/installation/deb/repose-filter-bundle/pom.xml
@@ -35,57 +35,22 @@
                     <plugin>
                         <groupId>pl.project13.maven</groupId>
                         <artifactId>git-commit-id-plugin</artifactId>
-                        <version>1.9</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <prefix>git</prefix>
-                            <verbose>false</verbose>
-                            <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            <generateGitPropertiesFilename>target/git.properties</generateGitPropertiesFilename>
-                        </configuration>
                     </plugin>
 
-                    <!--<plugin>-->
-                        <!--<groupId>org.codehaus.mojo</groupId>-->
-                        <!--<artifactId>properties-maven-plugin</artifactId>-->
-                        <!--<version>1.0-alpha-2</version>-->
-                        <!--<executions>-->
-                            <!--<execution>-->
-                                <!--<phase>process-resources</phase>-->
-                                <!--<goals>-->
-                                    <!--<goal>read-project-properties</goal>-->
-                                <!--</goals>-->
-                                <!--<configuration>-->
-                                    <!--<files>-->
-                                        <!--<file>${basedir}/target/git.properties</file>-->
-                                    <!--</files>-->
-                                <!--</configuration>-->
-                            <!--</execution>-->
-                        <!--</executions>-->
-                    <!--</plugin>-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>                        
+                    </plugin>
 
                     <plugin>
                         <groupId>org.vafer</groupId>
                         <artifactId>jdeb</artifactId>
-                        <version>0.9</version>
 
                         <executions>
                             <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jdeb</goal>
-                                </goals>
 
                                 <configuration>
-                                    <!--<deb>[[buildDir]]/repose-[[artifactId]]-[[version]]-${git.commit.id.abbrev}.deb</deb>-->
-                                    <deb>[[buildDir]]/[[artifactId]]-[[version]].deb</deb>
+                                    <deb>[[buildDir]]/[[artifactId]]-[[version]]-${git.commit.id.abbrev}.deb</deb>
                                     <timestamped>true</timestamped>
                                     <dataSet>
                                         <!-- The jar file -->
@@ -98,15 +63,15 @@
                                             </mapper>
                                         </data>
 
-                                        <!--<data>-->
-                                            <!--<src>${basedir}/target/git.properties</src>-->
-                                            <!--<type>file</type>-->
-                                            <!--<mapper>-->
-                                                <!--<type>perm</type>-->
-                                                <!--<prefix>/usr/share/doc/repose-filter-bundle</prefix>-->
-                                                <!--<filemode>644</filemode>-->
-                                            <!--</mapper>-->
-                                        <!--</data>-->
+                                        <data>
+                                            <src>${basedir}/target/git.properties</src>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>/usr/share/doc/repose-filter-bundle</prefix>
+                                                <filemode>644</filemode>
+                                            </mapper>
+                                        </data>
 
                                         <!-- The sample configuration files for the filters -->
                                         <data>

--- a/project-set/installation/deb/repose-valve/pom.xml
+++ b/project-set/installation/deb/repose-valve/pom.xml
@@ -35,69 +35,34 @@
                     <plugin>
                         <groupId>pl.project13.maven</groupId>
                         <artifactId>git-commit-id-plugin</artifactId>
-                        <version>1.9</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <prefix>git</prefix>
-                            <verbose>false</verbose>
-                            <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            <generateGitPropertiesFilename>target/git.properties</generateGitPropertiesFilename>
-                        </configuration>
                     </plugin>
 
-                    <!--<plugin>-->
-                        <!--<groupId>org.codehaus.mojo</groupId>-->
-                        <!--<artifactId>properties-maven-plugin</artifactId>-->
-                        <!--<version>1.0-alpha-2</version>-->
-                        <!--<executions>-->
-                            <!--<execution>-->
-                                <!--<phase>process-resources</phase>-->
-                                <!--<goals>-->
-                                    <!--<goal>read-project-properties</goal>-->
-                                <!--</goals>-->
-                                <!--<configuration>-->
-                                    <!--<files>-->
-                                        <!--<file>${basedir}/target/git.properties</file>-->
-                                    <!--</files>-->
-                                <!--</configuration>-->
-                            <!--</execution>-->
-                        <!--</executions>-->
-                    <!--</plugin>-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>                        
+                    </plugin>
 
                     <plugin>
                         <groupId>org.vafer</groupId>
                         <artifactId>jdeb</artifactId>
-                        <version>0.9</version>
 
                         <executions>
                             <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jdeb</goal>
-                                </goals>
 
                                 <configuration>
-                                    <!--<deb>[[buildDir]]/repose-[[artifactId]]-[[version]]-${git.commit.id.abbrev}.deb</deb>-->
-                                    <deb>[[buildDir]]/[[artifactId]]-[[version]].deb</deb>
+                                    <deb>[[buildDir]]/[[artifactId]]-[[version]]-${git.commit.id.abbrev}.deb</deb>
                                     <timestamped>true</timestamped>
                                     <dataSet>
                                         <!--The git.properties file -->
-                                        <!--<data>-->
-                                            <!--<src>${basedir}/target/git.properties</src>-->
-                                            <!--<type>file</type>-->
-                                            <!--<mapper>-->
-                                                <!--<type>perm</type>-->
-                                                <!--<prefix>/usr/share/doc/repose-valve</prefix>-->
-                                                <!--<filemode>644</filemode>-->
-                                            <!--</mapper>-->
-                                        <!--</data>-->
+                                        <data>
+                                            <src>${basedir}/target/git.properties</src>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>/usr/share/doc/repose-valve</prefix>
+                                                <filemode>644</filemode>
+                                            </mapper>
+                                        </data>
 
                                         <!-- The jar file -->
                                         <data>

--- a/project-set/installation/rpm/pom.xml
+++ b/project-set/installation/rpm/pom.xml
@@ -74,7 +74,5 @@
                 </pluginManagement>
             </build>
         </profile>
-
     </profiles>
-
 </project>


### PR DESCRIPTION
TK33612: Update deb poms to use newer version of git-commit plugin and to produce the git.properties even for pom projects.  Update the parent deb pom to contain the versions and common configurations for plugins that will be used by the child poms.
