### PR TITLE
TK33612: Move git-commit plugin up another level to installation so debs...

### DIFF
--- a/project-set/installation/deb/pom.xml
+++ b/project-set/installation/deb/pom.xml
@@ -40,46 +40,6 @@
                 <pluginManagement>
                     <plugins>
                         <plugin>
-                            <groupId>pl.project13.maven</groupId>
-                            <artifactId>git-commit-id-plugin</artifactId>
-                            <version>2.0.3</version>
-                            <executions>
-                                <execution>
-                                    <goals>
-                                        <goal>revision</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <prefix>git</prefix>
-                                <verbose>false</verbose>
-                                <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                                <skipPoms>false</skipPoms>
-                                <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                                <generateGitPropertiesFilename>target/git.properties</generateGitPropertiesFilename>
-                            </configuration>
-                        </plugin>
-
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>properties-maven-plugin</artifactId>
-                            <version>1.0-alpha-2</version>
-                            <executions>
-                                <execution>
-                                    <phase>process-resources</phase>
-                                    <goals>
-                                        <goal>read-project-properties</goal>
-                                    </goals>
-                                    <configuration>
-                                        <files>
-                                            <file>${basedir}/target/git.properties</file>
-                                        </files>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                        </plugin>
-
-                        <plugin>
                             <groupId>org.vafer</groupId>
                             <artifactId>jdeb</artifactId>
                             <version>0.9</version>

--- a/project-set/installation/pom.xml
+++ b/project-set/installation/pom.xml
@@ -24,5 +24,63 @@
         <module>rpm</module>
         <module>deb</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>Installation Build Support</id>
+
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <build>
+                <!-- Having these here configures the plugin execution goals and configurations used by all children poms -->
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>pl.project13.maven</groupId>
+                            <artifactId>git-commit-id-plugin</artifactId>
+                            <version>2.0.3</version>
+                            <executions>
+                                <execution>
+                                    <goals>
+                                        <goal>revision</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <prefix>git</prefix>
+                                <verbose>false</verbose>
+                                <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                                <skipPoms>false</skipPoms>
+                                <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                                <generateGitPropertiesFilename>target/git.properties</generateGitPropertiesFilename>
+                            </configuration>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>properties-maven-plugin</artifactId>
+                            <version>1.0-alpha-2</version>
+                            <executions>
+                                <execution>
+                                    <phase>process-resources</phase>
+                                    <goals>
+                                        <goal>read-project-properties</goal>
+                                    </goals>
+                                    <configuration>
+                                        <files>
+                                            <file>${basedir}/target/git.properties</file>
+                                        </files>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>                        
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+    </profiles>
     
 </project>

--- a/project-set/installation/rpm/cli-utils/pom.xml
+++ b/project-set/installation/rpm/cli-utils/pom.xml
@@ -35,16 +35,10 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
-                        <version>2.1-alpha-1</version>
 
                         <configuration>
 
                             <name>cli-utils</name>
-
-                            <!-- _tmppath is not set correctly on al OSs so it is forced here -->
-                            <defineStatements>
-                                <defineStatement>_tmppath /tmp</defineStatement>
-                            </defineStatements>
 
                             <mappings>
                                 <mapping>

--- a/project-set/installation/rpm/pom.xml
+++ b/project-set/installation/rpm/pom.xml
@@ -59,6 +59,11 @@
                             </executions>
 
                             <configuration>
+                                <!-- _tmppath is not set correctly on al OSs so it is forced here -->
+                                <defineStatements>
+                                    <defineStatement>_tmppath /tmp</defineStatement>
+                                </defineStatements>
+
                                 <group>Rackspace Repose</group>
                                 <packager>Rackspace - Cloud Integration Team</packager>
 

--- a/project-set/installation/rpm/repose-filters/pom.xml
+++ b/project-set/installation/rpm/repose-filters/pom.xml
@@ -33,12 +33,12 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
-                        <version>2.1-alpha-1</version>
 
                         <configuration>
                             <!-- WARNING!!!! DON"T EVER CHANGE THIS NAME.  Ops uses this in Puppet to refer
                                  to this RPM.-->
                             <name>repose-filters</name>
+                            
                             <mappings>
                                 <mapping>
                                     <directory>/usr/share/repose/filters</directory>

--- a/project-set/installation/rpm/repose-war/pom.xml
+++ b/project-set/installation/rpm/repose-war/pom.xml
@@ -34,17 +34,11 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
-                        <version>2.1-alpha-1</version>
 
                         <configuration>
                             <!-- WARNING!!!! DON"T EVER CHANGE THIS NAME.  Ops uses this in Puppet to refer
                                  to this RPM.-->
                             <name>repose-war</name>
-
-                            <!-- _tmppath is not set correctly on al OSs so it is forced here -->
-                            <defineStatements>
-                                <defineStatement>_tmppath /tmp</defineStatement>
-                            </defineStatements>
 
                             <mappings>
                                 <mapping>

--- a/project-set/installation/rpm/ug-repose-filters/pom.xml
+++ b/project-set/installation/rpm/ug-repose-filters/pom.xml
@@ -34,56 +34,20 @@
                 <plugins>
                     <plugin>
                         <groupId>pl.project13.maven</groupId>
-                        <artifactId>git-commit-id-plugin</artifactId>
-                        <version>1.9</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <prefix>git</prefix>
-                            <verbose>true</verbose>
-                            <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                            <!--<skipPomProjects>false</skipPomProjects>-->
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            <generateGitPropertiesFilename>target/git.properties</generateGitPropertiesFilename>
-                        </configuration>
+                        <artifactId>git-commit-id-plugin</artifactId>                        
                     </plugin>
 
-                    <!--<plugin>-->
-                    <!--<groupId>org.codehaus.mojo</groupId>-->
-                    <!--<artifactId>properties-maven-plugin</artifactId>-->
-                    <!--<version>1.0-alpha-2</version>-->
-                    <!--<executions>-->
-                    <!--<execution>-->
-                    <!--<phase>process-resources</phase>-->
-                    <!--<goals>-->
-                    <!--<goal>read-project-properties</goal>-->
-                    <!--</goals>-->
-                    <!--<configuration>-->
-                    <!--<files>-->
-                    <!--<file>${basedir}/target/git.properties</file>-->
-                    <!--</files>-->
-                    <!--</configuration>-->
-                    <!--</execution>-->
-                    <!--</executions>-->
-                    <!--</plugin>-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                    </plugin>
 
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
-                        <version>2.1-alpha-1</version>
 
                         <configuration>
                             <name>ug-repose-filters</name>
-
-                            <!-- _tmppath is not set correctly on al OSs so it is forced here -->
-                            <defineStatements>
-                                <defineStatement>_tmppath /tmp</defineStatement>
-                            </defineStatements>
 
                             <mappings>
                                 <mapping>
@@ -107,11 +71,11 @@
                                     <groupname>root</groupname>
                                     <filemode>644</filemode>
 
-                                    <!--<sources>-->
-                                    <!--<source>-->
-                                    <!--<location>${basedir}/target/git.properties</location>-->
-                                    <!--</source>-->
-                                    <!--</sources>-->
+                                    <sources>
+                                        <source>
+                                            <location>${basedir}/target/git.properties</location>
+                                        </source>
+                                    </sources>
                                 </mapping>
 
                                 <mapping>

--- a/project-set/installation/rpm/ug-repose-valve/pom.xml
+++ b/project-set/installation/rpm/ug-repose-valve/pom.xml
@@ -35,55 +35,19 @@
                     <plugin>
                         <groupId>pl.project13.maven</groupId>
                         <artifactId>git-commit-id-plugin</artifactId>
-                        <version>1.9</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <prefix>git</prefix>
-                            <verbose>false</verbose>
-                            <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                            <!--<skipPomProjects>false</skipPomProjects>-->
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            <generateGitPropertiesFilename>target/git.properties</generateGitPropertiesFilename>
-                        </configuration>
                     </plugin>
 
-                    <!--<plugin>-->
-                    <!--<groupId>org.codehaus.mojo</groupId>-->
-                    <!--<artifactId>properties-maven-plugin</artifactId>-->
-                    <!--<version>1.0-alpha-2</version>-->
-                    <!--<executions>-->
-                    <!--<execution>-->
-                    <!--<phase>process-resources</phase>-->
-                    <!--<goals>-->
-                    <!--<goal>read-project-properties</goal>-->
-                    <!--</goals>-->
-                    <!--<configuration>-->
-                    <!--<files>-->
-                    <!--<file>${basedir}/target/git.properties</file>-->
-                    <!--</files>-->
-                    <!--</configuration>-->
-                    <!--</execution>-->
-                    <!--</executions>-->
-                    <!--</plugin>-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>                        
+                    </plugin>
 
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
-                        <version>2.1-alpha-1</version>
 
                         <configuration>
-                            <name>ug-repose-valve</name>
-                            
-                            <!-- _tmppath is not set correctly on al OSs so it is forced here -->
-                            <defineStatements>
-                                <defineStatement>_tmppath /tmp</defineStatement>
-                            </defineStatements>
+                            <name>ug-repose-valve</name>                            
 
                             <mappings>
                                 <mapping>
@@ -105,11 +69,11 @@
                                     <groupname>root</groupname>
                                     <filemode>644</filemode>
 
-                                    <!--<sources>-->
-                                    <!--<source>-->
-                                    <!--<location>${basedir}/target/git.properties</location>-->
-                                    <!--</source>-->
-                                    <!--</sources>-->
+                                    <sources>
+                                        <source>
+                                            <location>${basedir}/target/git.properties</location>
+                                        </source>
+                                    </sources>
                                 </mapping>
 
                                 <mapping>


### PR DESCRIPTION
TK33612: Move git-commit plugin up another level to installation so debs and rpms can use the common plugin version and configs.  Update rpm poms accordingly to consume the git.properties information.
