### PR TITLE
TK34792: Start refactoring auth service clients:

### DIFF
--- a/project-set/core/valve/pom.xml
+++ b/project-set/core/valve/pom.xml
@@ -47,11 +47,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-client</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.rackspace.papi.commons</groupId>
             <artifactId>jetty-container</artifactId>
         </dependency>

--- a/project-set/external/service-clients/openstack-ids/pom.xml
+++ b/project-set/external/service-clients/openstack-ids/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,12 +18,12 @@
     <packaging>jar</packaging>
 
     <dependencies>
-        <!--
+
+        <!-- Due to an issue between javax.mail and another java dependency, this needs to be here for junit to work -->
         <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache-core</artifactId>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
         </dependency>
-        -->
 
         <dependency>
             <groupId>com.rackspace.papi.commons</groupId>
@@ -56,7 +57,7 @@
                 </configuration>
             </plugin>
 
-            
+
             <plugin>
                 <groupId>com.sun.tools.xjc.maven2</groupId>
                 <artifactId>maven-jaxb-plugin</artifactId>
@@ -89,42 +90,42 @@
             </plugin>
 
             <!--<plugin>-->
-                <!--<groupId>org.jvnet.jaxb2.maven2</groupId>-->
-                <!--<artifactId>maven-jaxb2-plugin</artifactId>-->
+            <!--<groupId>org.jvnet.jaxb2.maven2</groupId>-->
+            <!--<artifactId>maven-jaxb2-plugin</artifactId>-->
 
-                <!--<configuration>-->
-                    <!--<specVersion>2.1</specVersion>-->
-                    <!--<schemaDirectory>target/generated-resources/xml/xslt/</schemaDirectory>-->
+            <!--<configuration>-->
+            <!--<specVersion>2.1</specVersion>-->
+            <!--<schemaDirectory>target/generated-resources/xml/xslt/</schemaDirectory>-->
 
-                    <!--<schemaIncludes>-->
-                        <!--<schemaInclude>atom/atom.xsd</schemaInclude>-->
-                        <!--<schemaInclude>atom/xml.xsd</schemaInclude>-->
-                        <!--<schemaInclude>api-common.xsd</schemaInclude>-->
-                        <!--<schemaInclude>api.xsd</schemaInclude>-->
-                        <!--<schemaInclude>credentials.xsd</schemaInclude>-->
-                        <!--<schemaInclude>endpoints.xsd</schemaInclude>-->
-                        <!--<schemaInclude>extensions.xsd</schemaInclude>-->
-                        <!--<schemaInclude>fault.xsd</schemaInclude>-->
-                        <!--<schemaInclude>OS-KSADM.xsd</schemaInclude>-->
-                        <!--<schemaInclude>OS-KSCATALOG.xsd</schemaInclude>-->
-                        <!--<schemaInclude>OS-KSEC2-credentials.xsd</schemaInclude>-->
-                        <!--<schemaInclude>RAX-KSADM-credentials.xsd</schemaInclude>-->
-                        <!--<schemaInclude>RAX-KSADM-users.xsd</schemaInclude>-->
-                        <!--<schemaInclude>RAX-KSGRP-groups.xsd</schemaInclude>-->
-                        <!--<schemaInclude>RAX-KSKEY-credentials.xsd</schemaInclude>-->
-                        <!--<schemaInclude>RAX-KSQA-secretQA.xsd</schemaInclude>-->
-                        <!--<schemaInclude>roles.xsd</schemaInclude>-->
-                        <!--<schemaInclude>services.xsd</schemaInclude>-->
-                        <!--<schemaInclude>tenant.xsd</schemaInclude>-->
-                        <!--<schemaInclude>token.xsd</schemaInclude>-->
-                        <!--<schemaInclude>user.xsd</schemaInclude>-->
-                        <!--<schemaInclude>version.xsd</schemaInclude>-->
+            <!--<schemaIncludes>-->
+            <!--<schemaInclude>atom/atom.xsd</schemaInclude>-->
+            <!--<schemaInclude>atom/xml.xsd</schemaInclude>-->
+            <!--<schemaInclude>api-common.xsd</schemaInclude>-->
+            <!--<schemaInclude>api.xsd</schemaInclude>-->
+            <!--<schemaInclude>credentials.xsd</schemaInclude>-->
+            <!--<schemaInclude>endpoints.xsd</schemaInclude>-->
+            <!--<schemaInclude>extensions.xsd</schemaInclude>-->
+            <!--<schemaInclude>fault.xsd</schemaInclude>-->
+            <!--<schemaInclude>OS-KSADM.xsd</schemaInclude>-->
+            <!--<schemaInclude>OS-KSCATALOG.xsd</schemaInclude>-->
+            <!--<schemaInclude>OS-KSEC2-credentials.xsd</schemaInclude>-->
+            <!--<schemaInclude>RAX-KSADM-credentials.xsd</schemaInclude>-->
+            <!--<schemaInclude>RAX-KSADM-users.xsd</schemaInclude>-->
+            <!--<schemaInclude>RAX-KSGRP-groups.xsd</schemaInclude>-->
+            <!--<schemaInclude>RAX-KSKEY-credentials.xsd</schemaInclude>-->
+            <!--<schemaInclude>RAX-KSQA-secretQA.xsd</schemaInclude>-->
+            <!--<schemaInclude>roles.xsd</schemaInclude>-->
+            <!--<schemaInclude>services.xsd</schemaInclude>-->
+            <!--<schemaInclude>tenant.xsd</schemaInclude>-->
+            <!--<schemaInclude>token.xsd</schemaInclude>-->
+            <!--<schemaInclude>user.xsd</schemaInclude>-->
+            <!--<schemaInclude>version.xsd</schemaInclude>-->
 
-                    <!--</schemaIncludes>-->
+            <!--</schemaIncludes>-->
 
-                    <!--<strict>true</strict>-->
-                    <!--<verbose>false</verbose>-->
-                <!--</configuration>-->
+            <!--<strict>true</strict>-->
+            <!--<verbose>false</verbose>-->
+            <!--</configuration>-->
             <!--</plugin>-->
         </plugins>
     </build>

--- a/project-set/external/service-clients/openstack-ids/src/test/java/com/rackspace/auth/openstack/ids/GenericServiceClientTest.java
+++ b/project-set/external/service-clients/openstack-ids/src/test/java/com/rackspace/auth/openstack/ids/GenericServiceClientTest.java
@@ -1,8 +1,10 @@
 package com.rackspace.auth.openstack.ids;
 
+import com.rackspace.papi.commons.util.http.ServiceClientResponse;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openstack.docs.identity.api.v2.Token;
 
 /**
  * @author fran
@@ -10,12 +12,12 @@ import org.junit.runner.RunWith;
 @RunWith(Enclosed.class)
 public class GenericServiceClientTest {
     public static class WhenHittingAuth2_0 {
-        String endpoint = "http://auth-n01.dev.us.ccp.rackspace.net/v2.0";
-        String username = "auth";
-        String password = "auth123";
+        String endpoint = "";
+        String username = "";
+        String password = "";
         String tenant = "?";
         String token = "?";
-        String userId = "102916";
+        String userId = "";
 
 //        @Test
 //        public void shouldValidateToken() {
@@ -34,20 +36,22 @@ public class GenericServiceClientTest {
 //        }
 
         @Test
-        public void shouldGetAuthToken() {
+        public void shouldGetAdminAuthToken() {
 
 //            GenericServiceClient client = new GenericServiceClient(username, password);
 //
-//            final ServiceClientResponse<Token> serviceResponse = client.getAdminToken(endpoint + "/token", "auth", "auth123");
+//            final ServiceClientResponse<Token> serviceResponse = client.post(endpoint + "/token");
 //            final int response = serviceResponse.getStatusCode();
-//            Token groups = null;
+//            Token token = null;
 //
+//            System.out.println(Integer.toString(response));
 //            OpenStackCoreResponseUnmarshaller responseUnmarshaller = new OpenStackCoreResponseUnmarshaller();
 //
 //            switch (response) {
 //                case 200:
-//                    groups = responseUnmarshaller.unmarshall(serviceResponse.getData(), Token.class);
+//                    token = responseUnmarshaller.unmarshall(serviceResponse.getData(), Token.class);
 //            }
+
         }
 
 

--- a/project-set/pom.xml
+++ b/project-set/pom.xml
@@ -183,13 +183,13 @@
                     <dependency>
                         <groupId>com.sun.jersey</groupId>
                         <artifactId>jersey-client</artifactId>
-                        <version>1.9.1</version>
+                        <version>1.12</version>
                     </dependency>
 
                     <dependency>
                         <groupId>com.sun.jersey</groupId>
                         <artifactId>jersey-server</artifactId>
-                        <version>1.9.1</version>
+                        <version>1.12</version>
                     </dependency>
 
                     <dependency>


### PR DESCRIPTION
1.  Update jersey-client and jersey-server to version 1.12
2.  Remove jersey-client maven dependency from valve pom. Valve no longer uses Jersey directly.
3.  Add the javax mail dependency to the Openstack Service Client pom so junit testing will work in that module.
4.  Fix TODO's in OpenStack service client to use the ObjectFactory to create the JAXB Objects.
5.  Refactor Generic Service Client to make it more generic.
