### PR TITLE
Remove temporary keystone and roles solution for RS Auth 1.1.  This was ...

### DIFF
--- a/automation/rcman/includes/chef-solo/cookbooks/powerapi-valve/files/default/auth1.1/client-auth-n.cfg.xml
+++ b/automation/rcman/includes/chef-solo/cookbooks/powerapi-valve/files/default/auth1.1/client-auth-n.cfg.xml
@@ -1,45 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <client-auth xmlns="http://docs.rackspacecloud.com/repose/client-auth/v1.0">
-    <rackspace-auth delegable="false" keystone-active="true" xmlns="http://docs.rackspacecloud.com/repose/client-auth/rs-auth-1.1/v1.0">
+    <rackspace-auth delegable="false" xmlns="http://docs.rackspacecloud.com/repose/client-auth/rs-auth-1.1/v1.0">
         <authentication-server username="auth" password="auth123" uri="http://50.57.189.15:8080/v1.1" />
         <account-mapping id-regex="/v\d/([\w-]+)/?" type="CLOUD"/>
         <account-mapping id-regex="/([a-zA-Z\-][a-zA-Z\-]+\d+)[^\w]/?" type="CLOUD"/>
-        <user-roles>
-            <default>
-                <roles>
-                    <role>sysadmin</role>
-                    <role>netadmin</role>
-                    <role>developer</role>
-                </roles>
-            </default>
-            <user name="usertest1">
-                <roles>
-                    <role>cloudadmin</role>
-                    <role>testuser1</role>
-                    <role>superuser</role>
-                </roles>
-            </user>
-            <user name="usertest2">
-                <roles>
-                    <role>cloudadmin</role>
-                    <role>testuser2</role>
-                    <role>regularuser</role>
-                </roles>
-            </user>
-            <user name="usertest3">
-                <roles>
-                    <role>cloudadmin</role>
-                    <role>testuser3</role>
-                </roles>
-            </user>
-            <user name="usertest4">
-                <roles>
-                    <role>cloudadmin</role>
-                    <role>testuser4</role>
-                </roles>
-            </user>
-        </user-roles>
-
     </rackspace-auth>
 </client-auth>

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/AuthenticationHeaderManager.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/AuthenticationHeaderManager.java
@@ -5,9 +5,6 @@ import com.rackspace.papi.commons.util.StringUtilities;
 import com.rackspace.papi.commons.util.http.IdentityStatus;
 import com.rackspace.papi.commons.util.http.OpenStackServiceHeader;
 import com.rackspace.papi.commons.util.http.PowerApiHeader;
-import com.rackspace.papi.components.clientauth.rackspace.config.RackspaceAuth;
-import com.rackspace.papi.components.clientauth.rackspace.config.User;
-import com.rackspace.papi.components.clientauth.rackspace.config.UserRoles;
 import com.rackspace.papi.filter.logic.FilterAction;
 import com.rackspace.papi.filter.logic.FilterDirector;
 
@@ -24,8 +21,6 @@ public class AuthenticationHeaderManager {
 
    private final boolean validToken;
    private final boolean isDelegatable;
-   private final boolean keystone;
-   private final UserRoles userRoles;
    private final FilterDirector filterDirector;
    private final String accountUsername;
    private final List<AuthGroup> groups;
@@ -34,11 +29,9 @@ public class AuthenticationHeaderManager {
    // the highest QUALITY in terms of using the user it supplies for rate limiting
    private static final String QUALITY = ";q=1";
 
-   public AuthenticationHeaderManager(boolean validToken, RackspaceAuth cfg, FilterDirector filterDirector, String accountUsername, List<AuthGroup> groups) {
+   public AuthenticationHeaderManager(boolean validToken, boolean delegatable, FilterDirector filterDirector, String accountUsername, List<AuthGroup> groups) {
       this.validToken = validToken;
-      this.isDelegatable = cfg.isDelegable();
-      this.keystone = cfg.isKeystoneActive();
-      this.userRoles = cfg.getUserRoles();
+      this.isDelegatable = delegatable;
       this.filterDirector = filterDirector;
       this.accountUsername = accountUsername;
       this.groups = groups;
@@ -55,7 +48,6 @@ public class AuthenticationHeaderManager {
       if (validToken) {
          getGroupsListIds();
          filterDirector.requestHeaderManager().appendHeader(PowerApiHeader.USER.toString(), accountUsername + QUALITY);
-         setRoles();
       }
    }
 
@@ -79,29 +71,6 @@ public class AuthenticationHeaderManager {
          }
 
          filterDirector.requestHeaderManager().putHeader(OpenStackServiceHeader.IDENTITY_STATUS.toString(), identityStatus.name());
-      }
-   }
-
-   /**
-    * Set Roles
-    * This is temporary to support roles until REPOSE supports the OpenStack Identity Service Specification
-    */
-   private void setRoles() {
-      if (keystone) {
-         filterDirector.requestHeaderManager().putHeader(OpenStackServiceHeader.TENANT_NAME.toString(), accountUsername);
-         filterDirector.requestHeaderManager().putHeader(OpenStackServiceHeader.TENANT_ID.toString(), accountUsername);
-
-         for (String r : userRoles.getDefault().getRoles().getRole()) {
-            filterDirector.requestHeaderManager().appendHeader(OpenStackServiceHeader.ROLES.toString(), r);
-         }
-
-         for (User user : userRoles.getUser()) {
-            if (user.getName().equalsIgnoreCase(accountUsername)) {
-               for (String r : user.getRoles().getRole()) {
-                  filterDirector.requestHeaderManager().appendHeader(OpenStackServiceHeader.ROLES.toString(), r);
-               }
-            }
-         }
       }
    }
 }

--- a/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/RackspaceAuthenticationHandler.java
+++ b/project-set/components/client-auth/src/main/java/com/rackspace/papi/components/clientauth/rackspace/v1_1/RackspaceAuthenticationHandler.java
@@ -32,7 +32,7 @@ public class RackspaceAuthenticationHandler extends AbstractFilterLogicHandler i
 
     private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(RackspaceAuthenticationHandler.class);
     private final AuthenticationService authenticationService;
-    private final RackspaceAuth cfg;
+    private boolean delegatable;
     private final KeyedRegexExtractor<String> keyedRegexExtractor;
     private final AuthTokenCache cache;
     private final UriMatcher uriMatcher;
@@ -40,7 +40,7 @@ public class RackspaceAuthenticationHandler extends AbstractFilterLogicHandler i
 
     public RackspaceAuthenticationHandler(RackspaceAuth cfg, AuthenticationService authServiceClient, KeyedRegexExtractor keyedRegexExtractor, AuthTokenCache cache, UriMatcher uriMatcher) {
         this.authenticationService = authServiceClient;
-        this.cfg = cfg;
+        this.delegatable = cfg.isDelegable();
         this.keyedRegexExtractor = keyedRegexExtractor;
         this.cache = cache;
         this.uriMatcher = uriMatcher;
@@ -104,7 +104,7 @@ public class RackspaceAuthenticationHandler extends AbstractFilterLogicHandler i
             groups = authenticationService.getGroups(token.getUserId());
         }
 
-        final AuthenticationHeaderManager headerManager = new AuthenticationHeaderManager(token != null, cfg, filterDirector, extractedResult == null ? "" : extractedResult.getResult(), groups);
+        final AuthenticationHeaderManager headerManager = new AuthenticationHeaderManager(token != null, delegatable, filterDirector, extractedResult == null ? "" : extractedResult.getResult(), groups);
         headerManager.setFilterDirectorValues();
 
         return filterDirector;

--- a/project-set/components/client-auth/src/main/resources/META-INF/schema/config/rackspace-auth-v1.1/rackspace-auth-v1.1.xsd
+++ b/project-set/components/client-auth/src/main/resources/META-INF/schema/config/rackspace-auth-v1.1/rackspace-auth-v1.1.xsd
@@ -34,20 +34,12 @@
             <xs:sequence>
                 <xs:element name="authentication-server" type="auth-1.1:authenticationServer" minOccurs="1" maxOccurs="1" />
                 <xs:element name="account-mapping" type="auth-1.1:accountMapping" minOccurs="1" maxOccurs="unbounded" />
-                <xs:element name="user-roles" type="auth-1.1:user-roles" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             
             <xs:attribute name="delegable" type="xs:boolean" use="optional" default="false">
                 <xs:annotation>
                     <xs:documentation>
                         <html:p>Tells the service whether or not to support auth delegation.</html:p>
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="keystone-active" type="xs:boolean" use="optional" default="false">
-                <xs:annotation>
-                    <xs:documentation>
-                        <html:p>Tells power api to set request headers required by keystone.</html:p>
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
@@ -118,60 +110,4 @@
         </xs:attribute>
     </xs:complexType>
 
-    <xs:complexType name="user-roles">
-        <xs:annotation>
-            <xs:documentation>
-                <html:p>A list of default roles for all users and a list of specific users and their associated roles.</html:p>
-            </xs:documentation>
-        </xs:annotation>
-
-        <xs:sequence>
-            <xs:element name="default" type="auth-1.1:default" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="user" type="auth-1.1:user" minOccurs="0" maxOccurs="unbounded"/>    
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="default">
-        <xs:annotation>
-            <xs:documentation>
-                <html:p>The default roles all users should have.</html:p>
-            </xs:documentation>
-        </xs:annotation>
-
-        <xs:sequence>
-            <xs:element name="roles" type="auth-1.1:roles" minOccurs="1" maxOccurs="1"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="user">
-        <xs:annotation>
-            <xs:documentation>
-                <html:p>A system user.</html:p>
-            </xs:documentation>
-        </xs:annotation>
-
-        <xs:sequence>
-            <xs:element name="roles" type="auth-1.1:roles" minOccurs="1" maxOccurs="1"/>
-        </xs:sequence>
-
-        <xs:attribute name="name" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation>
-                    <html:p>Some form of identifier for the user.</html:p>
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-
-    <xs:complexType name="roles">
-        <xs:annotation>
-            <xs:documentation>
-                <html:p>A list of roles.</html:p>
-            </xs:documentation>
-        </xs:annotation>
-
-        <xs:sequence>
-            <xs:element name="role" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
-        </xs:sequence>
-    </xs:complexType>
 </xs:schema>

--- a/project-set/components/client-auth/src/main/resources/META-INF/schema/examples/rackspace/client-auth-n.cfg.xml
+++ b/project-set/components/client-auth/src/main/resources/META-INF/schema/examples/rackspace/client-auth-n.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <client-auth xmlns="http://docs.rackspacecloud.com/repose/client-auth/v1.0">
-    <rackspace-auth delegable="true" keystone-active="true" xmlns="http://docs.rackspacecloud.com/repose/client-auth/rs-auth-1.1/v1.0">
+    <rackspace-auth delegable="true" xmlns="http://docs.rackspacecloud.com/repose/client-auth/rs-auth-1.1/v1.0">
         <authentication-server username="admin_username" password="admin_password" uri="http://184.106.208.75:8080/auth-mock/" />
 
         <!-- Example Regex to capture user identity in uri
@@ -18,26 +18,6 @@
             e.g: /service/reposeuser/action => x-pp-user=reposeuser
             -->
         <account-mapping id-regex=".*.com/service/([-|\w]+)/?.*" type="MOSSO"/>
-
-        <user-roles>
-            <default>
-                <roles>
-                    <role>sysadmin</role>
-                    <role>netadmin</role>
-                    <role>developer</role>
-                </roles>
-            </default>
-            <user name="cmarin1">
-                <roles>
-                    <role>cloudadmin</role>
-                    <role>itsec</role>
-                </roles>
-            </user>
-            <user name="username2">
-                <roles>
-                    <role>cloudadmin</role>
-                </roles>
-            </user>
-        </user-roles>
+        
     </rackspace-auth>
 </client-auth>


### PR DESCRIPTION
Remove temporary keystone and roles solution for RS Auth 1.1.  This was originally added to support Nova but Nova is now using the OpenStack Auth Filter.
