### PR TITLE
Update the mock service to remove the "body" input parameter on GET call...

### DIFF
--- a/project-set/external/testing/test-support/src/main/java/com/rackspace/papi/mocks/MockServiceResource.java
+++ b/project-set/external/testing/test-support/src/main/java/com/rackspace/papi/mocks/MockServiceResource.java
@@ -1,11 +1,10 @@
 package com.rackspace.papi.mocks;
 
 import com.rackspace.papi.mocks.providers.MockServiceProvider;
+
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
@@ -20,128 +19,129 @@ import javax.ws.rs.core.UriInfo;
 @Path("/")
 public class MockServiceResource {
 
-    private MockServiceProvider provider;
+   private MockServiceProvider provider;
 
-    public MockServiceResource() {
-        provider = new MockServiceProvider();
-    }
+   public MockServiceResource() {
+      provider = new MockServiceProvider();
+   }
 
-    @GET
-    @Path("{id : .*}")
-    public Response getEndService(String body, @Context HttpHeaders headers, @Context UriInfo uri) {
-        return provider.getEndService(body, headers, uri);
-    }
+   @GET
+   @Path("/statuscode/{statusCode}")
+   public Response getStatusCode(@PathParam("statusCode") String statusCode, @Context HttpHeaders headers, @Context UriInfo uriInfo) throws MalformedURLException, URISyntaxException {
+      URI uri = uriInfo.getAbsolutePath();
 
-    @GET
-    @Path("/")
-    public Response getService(String body, @Context HttpHeaders headers, @Context UriInfo uri) {
-        return provider.getEndService(body, headers, uri);
-    }
+      return provider.getStatusCode(statusCode, uri.toURL().toExternalForm().replaceAll("/statuscode/", "/"), headers, uriInfo);
+   }
 
-    @POST
-    @Path("{id : .*}")
-    public Response postEndService(String body, @Context HttpHeaders headers, @Context UriInfo uri) {
-        return provider.getEndService(body, headers, uri);
-    }
+   @GET
+   @Path("{id : .*}")
+   public Response getEndService(@Context HttpHeaders headers, @Context UriInfo uri) {
+      return provider.getEndService(new String(), headers, uri);
+   }
 
-    @POST
-    @Path("/")
-    public Response postService(String body, @Context HttpHeaders headers, @Context UriInfo uri) {
-        return provider.getEndService(body, headers, uri);
-    }
+   @GET
+   @Path("/")
+   public Response getService(@Context HttpHeaders headers, @Context UriInfo uri) {
+      return provider.getEndService(new String(), headers, uri);
+   }
 
-    @GET
-    @Path("/{service}/limits")
-    @Produces("application/json")
-    public Response getLimitsJson() {
-        return provider.getAbsoluteLimitsJSON();
-    }
+   @POST
+   @Path("{id : .*}")
+   public Response postEndService(String body, @Context HttpHeaders headers, @Context UriInfo uri) {
+      return provider.getEndService(body, headers, uri);
+   }
 
-    @GET
-    @Path("/{service}/limits")
-    @Produces("application/xml")
-    public Response getLimitsXml() {
-        return provider.getAbsoluteLimitsXML();
-    }
+   @POST
+   @Path("/")
+   public Response postService(String body, @Context HttpHeaders headers, @Context UriInfo uri) {
+      return provider.getEndService(body, headers, uri);
+   }
 
-    @GET
-    @Path("/{version}/{user}/limits")
-    @Produces("application/json")
-    public Response getAbsoluteLimitsJson() {
-        return provider.getAbsoluteLimitsJSON();
+   @GET
+   @Path("/{service}/limits")
+   @Produces("application/json")
+   public Response getLimitsJson() {
+      return provider.getAbsoluteLimitsJSON();
+   }
 
-    }
+   @GET
+   @Path("/{service}/limits")
+   @Produces("application/xml")
+   public Response getLimitsXml() {
+      return provider.getAbsoluteLimitsXML();
+   }
 
-    @GET
-    @Path("/{version}/{user}/limits")
-    @Produces("application/xml")
-    public Response getAbsoluteLimits() {
-        return provider.getAbsoluteLimitsXML();
-    }
+   @GET
+   @Path("/{version}/{user}/limits")
+   @Produces("application/json")
+   public Response getAbsoluteLimitsJson() {
+      return provider.getAbsoluteLimitsJSON();
 
-    @GET
-    @Path("*/statuscode/{statusCode}")
-    public Response getStatusCode(String body, @PathParam("statusCode") String statusCode, @Context HttpHeaders headers, @Context UriInfo uriInfo) throws MalformedURLException, URISyntaxException {
-        URI uri = uriInfo.getAbsolutePath();
-        return provider.getStatusCode(statusCode, uri.toURL().toExternalForm().replaceAll("/statuscode/", "/"), body, headers, uriInfo);
-    }
+   }
 
-    @GET
-    @Path("*/delayedresponse/{time}")
-    public Response getDelayedResponse(@PathParam("time") int time, @Context HttpHeaders headers, @Context UriInfo uri) {
-        return provider.getDelayedResponse(time, headers, uri);
-    }
+   @GET
+   @Path("/{version}/{user}/limits")
+   @Produces("application/xml")
+   public Response getAbsoluteLimits() {
+      return provider.getAbsoluteLimitsXML();
+   }
 
-    @GET
-    @Path("/nova/limits")
-    public Response getNovaLimits() {
+   @GET
+   @Path("/delayedresponse/{time}")
+   public Response getDelayedResponse(@PathParam("time") int time, @Context HttpHeaders headers, @Context UriInfo uri) {
+      return provider.getDelayedResponse(time, headers, uri);
+   }
 
-        StringBuilder limits = new StringBuilder();
+   @GET
+   @Path("/nova/limits")
+   public Response getNovaLimits() {
 
-        limits.append("<limits xmlns:atom=\"http://www.w3.org/2005/Atom\"");
-        limits.append(" xmlns=\"http://docs.openstack.org/common/api/v1.1\"><rates/><absolute><limit name=\"maxServerMeta\"");
-        limits.append(" value=\"5\"/><limit name=\"maxPersonality\" value=\"5\"/><limit name=\"maxImageMeta\" value=\"5\"/><limit name=\"maxPersonalitySize\"");
-        limits.append(" value=\"1000\"/><limit name=\"maxTotalInstances\" value=\"1000\"/><limit name=\"maxTotalRAMSize\" value=\"10240000\"/></absolute></limits>");
+      StringBuilder limits = new StringBuilder();
 
-        return Response.ok(limits.toString()).build();
-    }
+      limits.append("<limits xmlns:atom=\"http://www.w3.org/2005/Atom\"");
+      limits.append(" xmlns=\"http://docs.openstack.org/common/api/v1.1\"><rates/><absolute><limit name=\"maxServerMeta\"");
+      limits.append(" value=\"5\"/><limit name=\"maxPersonality\" value=\"5\"/><limit name=\"maxImageMeta\" value=\"5\"/><limit name=\"maxPersonalitySize\"");
+      limits.append(" value=\"1000\"/><limit name=\"maxTotalInstances\" value=\"1000\"/><limit name=\"maxTotalRAMSize\" value=\"10240000\"/></absolute></limits>");
 
-    @GET
-    @Path("*/loadbalancers/absolutelimits")
-    @Produces("application/xml")
-    public Response getLBaaSLimitsXml() {
+      return Response.ok(limits.toString()).build();
+   }
 
-        return provider.getLBaaSLimitsXml();
-    }
+   @GET
+   @Path("/loadbalancers/absolutelimits")
+   @Produces("application/xml")
+   public Response getLBaaSLimitsXml() {
 
-    @GET
-    @Path("*/loadbalancers/absolutelimits")
-    @Produces("application/json")
-    public Response getLBaaSLimitsJson() {
+      return provider.getLBaaSLimitsXml();
+   }
 
-        return provider.getLBaaSLimitsJson();
-    }
+   @GET
+   @Path("/loadbalancers/absolutelimits")
+   @Produces("application/json")
+   public Response getLBaaSLimitsJson() {
 
-    @GET
-    @Path("/{user}/loadbalancers/absolutelimits")
-    @Produces("application/xml")
-    public Response getLBaaSLimitsXmlUser() {
+      return provider.getLBaaSLimitsJson();
+   }
 
-        return provider.getLBaaSLimitsXml();
-    }
+   @GET
+   @Path("/{user}/loadbalancers/absolutelimits")
+   @Produces("application/xml")
+   public Response getLBaaSLimitsXmlUser() {
 
-    @GET
-    @Path("/{user}/loadbalancers/absolutelimits")
-    @Produces("application/json")
-    public Response getLBaaSLimitsJsonUser() {
+      return provider.getLBaaSLimitsXml();
+   }
 
-        return provider.getLBaaSLimitsJson();
-    }
+   @GET
+   @Path("/{user}/loadbalancers/absolutelimits")
+   @Produces("application/json")
+   public Response getLBaaSLimitsJsonUser() {
 
-    @GET
-    @Path("/whatismyip")
-    public Response getRequestingIp(@Context HttpServletRequest req) {
+      return provider.getLBaaSLimitsJson();
+   }
 
-        return provider.getRequestingIp(req);
-    }
+   @GET
+   @Path("/whatismyip")
+   public Response getRequestingIp(@Context HttpServletRequest req) {
+
+      return provider.getRequestingIp(req);
+   }
 }

--- a/project-set/external/testing/test-support/src/main/java/com/rackspace/papi/mocks/providers/MockServiceProvider.java
+++ b/project-set/external/testing/test-support/src/main/java/com/rackspace/papi/mocks/providers/MockServiceProvider.java
@@ -137,7 +137,7 @@ public class MockServiceProvider {
 
    }
 
-   public Response getStatusCode(String statusCode, String location, String body, HttpHeaders headers, UriInfo uri) throws URISyntaxException {
+   public Response getStatusCode(String statusCode, String location, HttpHeaders headers, UriInfo uri) throws URISyntaxException {
 
       int status;
       try {
@@ -146,16 +146,16 @@ public class MockServiceProvider {
          status = 404;
       }
 
-      if (status >= 300 && status < 400) {
+      String resp = getEchoBody(new String(), headers, uri);
 
-         String resp = getEchoBody(body, headers, uri);
+      if (status >= 300 && status < 400) {
 
          URI newLocation = new URI(location);
 
          return Response.status(status).header("Location", newLocation).entity(resp).build();
       }
 
-      return Response.status(status).entity(body).build();
+      return Response.status(status).entity(resp).build();
 
    }
 


### PR DESCRIPTION
Update the mock service to remove the "body" input parameter on GET calls.  This change allows us to deploy the mock service to Glassfish 3.0.1.
