### PR TITLE
Update the mock service to add a POST /poststatus/{statusCode} call.  We...

### DIFF
--- a/project-set/external/testing/test-support/src/main/java/com/rackspace/papi/mocks/MockServiceResource.java
+++ b/project-set/external/testing/test-support/src/main/java/com/rackspace/papi/mocks/MockServiceResource.java
@@ -25,6 +25,14 @@ public class MockServiceResource {
       provider = new MockServiceProvider();
    }
 
+   @POST
+   @Path("/postcode/{statusCode}")
+   public Response postStatusCode(@PathParam("statusCode") String statusCode, String body, @Context HttpHeaders headers, @Context UriInfo uriInfo) throws MalformedURLException, URISyntaxException {
+      URI uri = uriInfo.getAbsolutePath();
+
+      return provider.postStatusCode(statusCode, uri.toURL().toExternalForm().replaceAll("/statuscode/", "/"), headers, uriInfo);
+   }
+
    @GET
    @Path("/statuscode/{statusCode}")
    public Response getStatusCode(@PathParam("statusCode") String statusCode, @Context HttpHeaders headers, @Context UriInfo uriInfo) throws MalformedURLException, URISyntaxException {

--- a/project-set/external/testing/test-support/src/main/java/com/rackspace/papi/mocks/providers/MockServiceProvider.java
+++ b/project-set/external/testing/test-support/src/main/java/com/rackspace/papi/mocks/providers/MockServiceProvider.java
@@ -9,6 +9,7 @@ import com.rackspace.papi.components.limits.schema.AbsoluteLimitList;
 import com.rackspace.papi.components.limits.schema.Limits;
 import com.rackspace.papi.components.limits.schema.ObjectFactory;
 import com.rackspace.papi.components.ratelimit.util.LimitsEntityTransformer;
+import com.rackspacecloud.docs.auth.api.v1.UnauthorizedFault;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
@@ -155,8 +156,48 @@ public class MockServiceProvider {
          return Response.status(status).header("Location", newLocation).entity(resp).build();
       }
 
+      if (status == 401) {
+//         final com.rackspace.api.common.fault.v1.ObjectFactory rax_of = new com.rackspace.api.common.fault.v1.ObjectFactory();
+         final com.rackspacecloud.docs.auth.api.v1.ObjectFactory of = new com.rackspacecloud.docs.auth.api.v1.ObjectFactory();
+
+         UnauthorizedFault fault = new UnauthorizedFault();
+            fault.setCode(Response.Status.UNAUTHORIZED.getStatusCode());
+            fault.setMessage("Beware!  You are unauthorized.");
+            return Response.ok(of.createUnauthorized(fault)).status(Response.Status.UNAUTHORIZED).build();
+      }
+
       return Response.status(status).entity(resp).build();
 
+   }
+
+   public Response postStatusCode(String statusCode, String location, HttpHeaders headers, UriInfo uri) throws URISyntaxException {
+
+      int status;
+      try {
+         status = Integer.parseInt(statusCode);
+      } catch (NumberFormatException e) {
+         status = 404;
+      }
+
+      String resp = getEchoBody(new String(), headers, uri);
+
+      if (status >= 300 && status < 400) {
+
+         URI newLocation = new URI(location);
+
+         return Response.status(status).header("Location", newLocation).entity(resp).build();
+      }
+
+      if (status == 401) {
+         final com.rackspacecloud.docs.auth.api.v1.ObjectFactory of = new com.rackspacecloud.docs.auth.api.v1.ObjectFactory();
+
+         UnauthorizedFault fault = new UnauthorizedFault();
+            fault.setCode(Response.Status.UNAUTHORIZED.getStatusCode());
+            fault.setMessage("Beware!  You are unauthorized.");
+            return Response.ok(of.createUnauthorized(fault)).status(Response.Status.UNAUTHORIZED).build();
+      }
+
+      return Response.status(status).entity(resp).build();
    }
 
    public Response getDelayedResponse(int time, HttpHeaders headers, UriInfo uri) {


### PR DESCRIPTION
Update the mock service to add a POST /poststatus/{statusCode} call.  We can use this call to reproduce the 401 bug GA is seeing.
