### PR TITLE
Fix rate limiting bug so that when a single rate limit has multiple http...

### DIFF
--- a/project-set/components/rate-limiting/src/test/java/com/rackspace/papi/components/ratelimit/RateLimitingTestSupport.java
+++ b/project-set/components/rate-limiting/src/test/java/com/rackspace/papi/components/ratelimit/RateLimitingTestSupport.java
@@ -7,6 +7,7 @@ import com.rackspace.papi.components.ratelimit.config.ConfiguredRatelimit;
 import com.rackspace.papi.components.ratelimit.config.RateLimitingConfiguration;
 import com.rackspace.papi.components.ratelimit.config.RequestEndpoint;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,56 +15,85 @@ import java.util.regex.Pattern;
 
 public abstract class RateLimitingTestSupport {
 
-    public static final String DEFAULT_URI = "/v1.0/*", DEFAULT_USER_ROLE = "group", DEFAULT_URI_REGEX = "/v1.0/([^/]*)/.*", DEFAULT_LIMIT_GROUP_ID = "testing-group";
-    
-    public static RateLimitingConfiguration defaultRateLimitingConfiguration() {
-        final RateLimitingConfiguration newCfg = new RateLimitingConfiguration();
+   public static final String DEFAULT_URI = "/v1.0/*", DEFAULT_USER_ROLE = "group", DEFAULT_URI_REGEX = "/v1.0/([^/]*)/.*", DEFAULT_LIMIT_GROUP_ID = "testing-group";
+   public static final String MULTI_METHOD_URI = "/v2.0/*", MULTI_METHOD_URI_REGEX = "/v2.0/([^/]*)/.*", MULTI_METHOD_LIMIT_GROUP_ID = "multi-group";
 
-        final RequestEndpoint endpoint = new RequestEndpoint();
-        endpoint.setIncludeAbsoluteLimits(Boolean.TRUE);
-        endpoint.setUriRegex("/v1.0/limits/?");
 
-        newCfg.setRequestEndpoint(endpoint);
+   public static RateLimitingConfiguration defaultRateLimitingConfiguration() {
+      final RateLimitingConfiguration newCfg = new RateLimitingConfiguration();
 
-        newCfg.getLimitGroup().add(newConfiguredLimitGroup(DEFAULT_USER_ROLE, DEFAULT_URI, DEFAULT_URI_REGEX, DEFAULT_LIMIT_GROUP_ID));
+      final RequestEndpoint endpoint = new RequestEndpoint();
+      endpoint.setIncludeAbsoluteLimits(Boolean.TRUE);
+      endpoint.setUriRegex("/v1.0/limits/?");
 
-        return newCfg;
-    }
+      newCfg.setRequestEndpoint(endpoint);
 
-    public static ConfiguredLimitGroup newConfiguredLimitGroup(String userRole, String rateLimitUri, String uriRegex, String limitGroupId) {
-        final ConfiguredLimitGroup limitGroup = new ConfiguredLimitGroup();
-        limitGroup.setDefault(Boolean.TRUE);
-        limitGroup.setId(limitGroupId);
-        limitGroup.getGroups().add(userRole);
+      newCfg.getLimitGroup().add(newConfiguredLimitGroup(DEFAULT_USER_ROLE, DEFAULT_URI, DEFAULT_URI_REGEX, DEFAULT_LIMIT_GROUP_ID));
+      newCfg.getLimitGroup().add(newMultiMethodConfiguredLimitGroup(DEFAULT_USER_ROLE, MULTI_METHOD_URI, MULTI_METHOD_URI_REGEX, MULTI_METHOD_LIMIT_GROUP_ID));
 
-        final ConfiguredRatelimit rateLimit = new ConfiguredRatelimit();
-        rateLimit.setUnit(TimeUnit.MINUTE);
-        rateLimit.getHttpMethods().add(HttpMethod.GET);
-        rateLimit.getHttpMethods().add(HttpMethod.PUT);
-        rateLimit.getHttpMethods().add(HttpMethod.POST);
-        rateLimit.getHttpMethods().add(HttpMethod.DELETE);
-        rateLimit.setUri(rateLimitUri);
-        rateLimit.setUriRegex(uriRegex);
-        rateLimit.setValue(3);
+      return newCfg;
+   }
 
-        limitGroup.getLimit().add(rateLimit);
+   public static ConfiguredLimitGroup newConfiguredLimitGroup(String userRole, String rateLimitUri, String uriRegex, String limitGroupId) {
+      final int VALUE = 3;
+      final ConfiguredLimitGroup limitGroup = new ConfiguredLimitGroup();
+      limitGroup.setDefault(Boolean.TRUE);
+      limitGroup.setId(limitGroupId);
+      limitGroup.getGroups().add(userRole);
 
-        return limitGroup;
-    }
+      limitGroup.getLimit().add(newConfiguredRateLimit(TimeUnit.MINUTE, new ArrayList<HttpMethod>(){{ add(HttpMethod.GET);}}, rateLimitUri, uriRegex, VALUE));
+      limitGroup.getLimit().add(newConfiguredRateLimit(TimeUnit.MINUTE, new ArrayList<HttpMethod>(){{ add(HttpMethod.PUT);}}, rateLimitUri, uriRegex, VALUE));
+      limitGroup.getLimit().add(newConfiguredRateLimit(TimeUnit.MINUTE, new ArrayList<HttpMethod>(){{ add(HttpMethod.POST);}}, rateLimitUri, uriRegex, VALUE));
+      limitGroup.getLimit().add(newConfiguredRateLimit(TimeUnit.MINUTE, new ArrayList<HttpMethod>(){{ add(HttpMethod.DELETE);}}, rateLimitUri, uriRegex, VALUE));
 
-    public static Map<String, Map<String, Pattern>> newRegexCache(List<ConfiguredLimitGroup> clgList) {
-        final Map<String, Map<String, Pattern>> regexCache = new HashMap<String, Map<String, Pattern>>();
+      return limitGroup;
+   }
 
-        for (ConfiguredLimitGroup clg : clgList) {
-            final Map<String, Pattern> limitGroupRegexCache = new HashMap<String, Pattern>();
+   public static ConfiguredLimitGroup newMultiMethodConfiguredLimitGroup(String userRole, String rateLimitUri, String uriRegex, String limitGroupId) {
+      final int VALUE = 3;
+      final ConfiguredLimitGroup limitGroup = new ConfiguredLimitGroup();
+      limitGroup.setDefault(Boolean.TRUE);
+      limitGroup.setId(limitGroupId);
+      limitGroup.getGroups().add(userRole);
 
-            for (ConfiguredRatelimit crl : clg.getLimit()) {
-                limitGroupRegexCache.put(crl.getUri(), Pattern.compile(crl.getUriRegex()));
-            }
+      limitGroup.getLimit().add(newConfiguredRateLimit(TimeUnit.MINUTE,
+                                                       new ArrayList<HttpMethod>(){{ add(HttpMethod.GET);
+                                                                                     add(HttpMethod.PUT);
+                                                                                     add(HttpMethod.POST);
+                                                                                     add(HttpMethod.DELETE);}},
+                                                       rateLimitUri, uriRegex, VALUE));
 
-            regexCache.put(clg.getId(), limitGroupRegexCache);
-        }
-        
-        return regexCache;
-    }
+      return limitGroup;
+   }
+
+   public static ConfiguredRatelimit newConfiguredRateLimit(TimeUnit unit, List<HttpMethod> methods, String rateLimitUri, String uriRegex, int value) {
+      final ConfiguredRatelimit rateLimit = new ConfiguredRatelimit();
+
+      rateLimit.setUnit(unit);
+      rateLimit.setUri(rateLimitUri);
+      rateLimit.setUriRegex(uriRegex);
+      rateLimit.setValue(value);
+
+      for (HttpMethod method : methods) {
+         rateLimit.getHttpMethods().add(method);
+      }
+
+      return rateLimit;
+   }
+
+   public static Map<String, Map<String, Pattern>> newRegexCache(List<ConfiguredLimitGroup> clgList) {
+      final Map<String, Map<String, Pattern>> regexCache = new HashMap<String, Map<String, Pattern>>();
+
+      for (ConfiguredLimitGroup clg : clgList) {
+         final Map<String, Pattern> limitGroupRegexCache = new HashMap<String, Pattern>();
+
+         for (ConfiguredRatelimit crl : clg.getLimit()) {
+            limitGroupRegexCache.put(crl.getUri(), Pattern.compile(crl.getUriRegex()));
+         }
+
+         regexCache.put(clg.getId(), limitGroupRegexCache);
+      }
+
+      return regexCache;
+   }
 }


### PR DESCRIPTION
Fix rate limiting bug so that when a single rate limit has multiple http methods they are treated like a single limit.  That is, when any of the http methods are used the rate limit amounts for each of the http methods in that rate limit are updated.
