### PR TITLE
Add support for URI content negotiation in Repose Management API.

### DIFF
--- a/project-set/management/src/main/java/com/rackspace/repose/management/filters/MediaTypeFilter.java
+++ b/project-set/management/src/main/java/com/rackspace/repose/management/filters/MediaTypeFilter.java
@@ -1,0 +1,27 @@
+package com.rackspace.repose.management.filters;
+
+import com.sun.jersey.api.container.filter.UriConnegFilter;
+
+import javax.ws.rs.core.MediaType;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: fran
+ * Date: Oct 26, 2012
+ * Time: 2:09:54 PM
+ */
+public class MediaTypeFilter extends UriConnegFilter {
+
+    private static final Map<String, MediaType> mappedMediaTypes = new HashMap<String, MediaType>(2);
+
+    static {
+        mappedMediaTypes.put("json", MediaType.APPLICATION_JSON_TYPE);
+        mappedMediaTypes.put("xml", MediaType.APPLICATION_XML_TYPE);
+    }
+
+    public MediaTypeFilter() {
+        super(mappedMediaTypes);
+    }
+}

--- a/project-set/management/src/main/webapp/WEB-INF/web.xml
+++ b/project-set/management/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,8 @@
         </init-param>
         <init-param>
             <param-name>com.sun.jersey.spi.container.ContainerRequestFilters</param-name>
-            <param-value>com.sun.jersey.api.container.filter.LoggingFilter</param-value>
+            <param-value>com.sun.jersey.api.container.filter.LoggingFilter;
+                         com.rackspace.repose.management.filters.MediaTypeFilter</param-value>
         </init-param>
         <init-param>
             <param-name>com.sun.jersey.spi.container.ContainerResponseFilters</param-name>


### PR DESCRIPTION
Pull requesting so someone can peer review this small change.  Added a Jersey Filter that supports requesting xml and json content in the URI for the Repose Management API. 
