### PR TITLE
Initial stab at adding support for SaxonEE

### DIFF
--- a/project-set/components/translation/pom.xml
+++ b/project-set/components/translation/pom.xml
@@ -32,15 +32,18 @@
         </dependency>
 
         <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>saxon-ee</artifactId>
+            <version>9.4.0.6</version>
+        </dependency>
+
+        <dependency>
            <groupId>com.xmlcalabash</groupId>
            <artifactId>calabash</artifactId>
            <version>0.9.38</version>
+           <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>net.sf.saxon</groupId>
-            <artifactId>saxon</artifactId>
-            <version>9.3</version>
-        </dependency>
+
         <!--
         <dependency>
           <groupId>net.sf.joost</groupId>

--- a/project-set/components/translation/src/main/resources/META-INF/schema/config/translation-configuration.xsd
+++ b/project-set/components/translation/src/main/resources/META-INF/schema/config/translation-configuration.xsd
@@ -40,6 +40,19 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
+        <xs:attribute name="use-saxon" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        If true then the translation component will
+                        attempt to use SaxonEE features -- including
+                        initial support for XSLT 3.0. A Saxon license
+                        is required to use this feature.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="RequestTranslations">

--- a/project-set/core/core-lib/pom.xml
+++ b/project-set/core/core-lib/pom.xml
@@ -88,10 +88,10 @@
       </dependency>
 
       <dependency>
-         <groupId>net.sf.saxon</groupId>
-         <artifactId>saxon</artifactId>
-         <version>9.3</version>
-         <scope>test</scope>
+          <groupId>net.sf.saxon</groupId>
+          <artifactId>saxon-ee</artifactId>
+          <version>9.4.0.6</version>
+          <scope>test</scope>
       </dependency>
 
       <!-- Required for @Configuration annotation -->

--- a/project-set/extensions/api-validator/src/main/java/org/openrepose/components/apivalidator/filter/ApiValidatorHandler.java
+++ b/project-set/extensions/api-validator/src/main/java/org/openrepose/components/apivalidator/filter/ApiValidatorHandler.java
@@ -2,7 +2,6 @@ package org.openrepose.components.apivalidator.filter;
 
 import com.rackspace.com.papi.components.checker.Validator;
 import com.rackspace.com.papi.components.checker.step.ErrorResult;
-import com.rackspace.com.papi.components.checker.step.MultiFailResult;
 import com.rackspace.com.papi.components.checker.step.Result;
 import com.rackspace.papi.commons.util.http.HttpStatusCode;
 import com.rackspace.papi.commons.util.http.OpenStackServiceHeader;


### PR DESCRIPTION
The following takes an initial stab at adding support for SaxonEE.  Had to upgrade the api-validator component as well because of the class loader issue.

Haven't had a chance to add tests so consider this WIP, but have tested manually and SaxonEE features like XSLT 3.0 support work.

You must set "use-saxon" to true on the config for the feature to take effect.  If use-saxon is false (or not specified) we revert back to using open source saxon -- without the EE features.

One issue with testing is that we don't want to require a saxon license to run tests.  In the API checker lib -- we have a sperate profile that runs saxon specific tests so that's something we could try.
