### PR TITLE
Pomupdates 2.6.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.rackspace.papi</groupId>
     <artifactId>papi</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
     
     <name>Repose</name>
     

--- a/project-set/commons/classloader/pom.xml
+++ b/project-set/commons/classloader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/project-set/commons/configuration/pom.xml
+++ b/project-set/commons/configuration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/project-set/commons/jetty/pom.xml
+++ b/project-set/commons/jetty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/project-set/commons/pom.xml
+++ b/project-set/commons/pom.xml
@@ -5,12 +5,12 @@
    <parent>
       <groupId>com.rackspace.papi</groupId>
       <artifactId>profile-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
    <groupId>com.rackspace.papi.commons</groupId>
    <artifactId>commons-support</artifactId>
-   <version>2.6.12</version>
+   <version>2.6.13-SNAPSHOT</version>
         
    <name>Repose Commons - Commons Support</name>
 
@@ -28,7 +28,7 @@
          <dependency>
             <groupId>com.rackspace.papi.external</groupId>
             <artifactId>jee6-schemas</artifactId>
-            <version>2.6.12</version>
+            <version>2.6.13-SNAPSHOT</version>
          </dependency>
             
          <dependency>

--- a/project-set/commons/utilities/pom.xml
+++ b/project-set/commons/utilities/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>com.rackspace.papi.commons</groupId>
       <artifactId>commons-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
    <groupId>com.rackspace.papi.commons</groupId>

--- a/project-set/components/cli-utils/pom.xml
+++ b/project-set/components/cli-utils/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>com.rackspace.papi.components</groupId>
       <artifactId>components-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
    <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/client-auth/pom.xml
+++ b/project-set/components/client-auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/client-authorization/pom.xml
+++ b/project-set/components/client-authorization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/client-ip-identity/pom.xml
+++ b/project-set/components/client-ip-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/content-identity-auth-1.1/pom.xml
+++ b/project-set/components/content-identity-auth-1.1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/content-identity-auth-2.0/pom.xml
+++ b/project-set/components/content-identity-auth-2.0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/content-normalization/pom.xml
+++ b/project-set/components/content-normalization/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/datastore/pom.xml
+++ b/project-set/components/datastore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/default-router/pom.xml
+++ b/project-set/components/default-router/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/destination-router/pom.xml
+++ b/project-set/components/destination-router/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>com.rackspace.papi.components</groupId>
       <artifactId>components-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
    <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/echo/pom.xml
+++ b/project-set/components/echo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/filter-bundle/pom.xml
+++ b/project-set/components/filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/flush-output/pom.xml
+++ b/project-set/components/flush-output/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>com.rackspace.papi.components</groupId>
       <artifactId>components-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
    <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/header-id-mapping/pom.xml
+++ b/project-set/components/header-id-mapping/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/header-identity/pom.xml
+++ b/project-set/components/header-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/header-normalization/pom.xml
+++ b/project-set/components/header-normalization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/http-logging/pom.xml
+++ b/project-set/components/http-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/pom.xml
+++ b/project-set/components/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/rate-limiting/pom.xml
+++ b/project-set/components/rate-limiting/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/replicated-datastore/pom.xml
+++ b/project-set/components/replicated-datastore/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>com.rackspace.papi.components</groupId>
       <artifactId>components-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
    <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/service-authentication/pom.xml
+++ b/project-set/components/service-authentication/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/translation/pom.xml
+++ b/project-set/components/translation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/uri-identity/pom.xml
+++ b/project-set/components/uri-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/uri-normalization/pom.xml
+++ b/project-set/components/uri-normalization/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/components/versioning/pom.xml
+++ b/project-set/components/versioning/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/project-set/core/core-lib/pom.xml
+++ b/project-set/core/core-lib/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>com.rackspace.papi.core</groupId>
       <artifactId>core-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
    <groupId>com.rackspace.papi.core</groupId>

--- a/project-set/core/pom.xml
+++ b/project-set/core/pom.xml
@@ -5,12 +5,12 @@
    <parent>
       <groupId>com.rackspace.papi</groupId>
       <artifactId>profile-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
    <groupId>com.rackspace.papi.core</groupId>
    <artifactId>core-support</artifactId>
-   <version>2.6.12</version>
+   <version>2.6.13-SNAPSHOT</version>
 
    <name>Repose Core - Core Support</name>
     
@@ -33,7 +33,7 @@
          <dependency>
             <groupId>org.openrepose.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.6.12</version>
+            <version>2.6.13-SNAPSHOT</version>
          </dependency>
 
          <dependency>
@@ -45,7 +45,7 @@
          <dependency>
             <groupId>com.rackspace.papi.external</groupId>
             <artifactId>jee6-schemas</artifactId>
-            <version>2.6.12</version>
+            <version>2.6.13-SNAPSHOT</version>
          </dependency>
         
          <dependency>
@@ -57,25 +57,25 @@
          <dependency>
             <groupId>com.rackspace.papi.commons</groupId>
             <artifactId>configuration</artifactId>
-            <version>2.6.12</version>
+            <version>2.6.13-SNAPSHOT</version>
          </dependency>
 
          <dependency>
             <groupId>com.rackspace.papi.commons</groupId>
             <artifactId>utilities</artifactId>
-            <version>2.6.12</version>
+            <version>2.6.13-SNAPSHOT</version>
          </dependency>
             
          <dependency>
             <groupId>com.rackspace.papi.commons</groupId>
             <artifactId>jetty-container</artifactId>
-            <version>2.6.12</version>
+            <version>2.6.13-SNAPSHOT</version>
          </dependency>
             
          <dependency>
             <groupId>com.rackspace.papi.commons</groupId>
             <artifactId>classloader</artifactId>
-            <version>2.6.12</version>
+            <version>2.6.13-SNAPSHOT</version>
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/project-set/core/valve/pom.xml
+++ b/project-set/core/valve/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.core</groupId>
         <artifactId>core-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/project-set/core/web-application/pom.xml
+++ b/project-set/core/web-application/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.core</groupId>
         <artifactId>core-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/project-set/extensions/api-validator/pom.xml
+++ b/project-set/extensions/api-validator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.extensions</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>

--- a/project-set/extensions/extensions-filter-bundle/pom.xml
+++ b/project-set/extensions/extensions-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.extensions</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.rackspace.papi.components.extensions</groupId>
             <artifactId>api-validator</artifactId>
-            <version>2.6.12</version>
+            <version>2.6.13-SNAPSHOT</version>
         </dependency>
        
     </dependencies>

--- a/project-set/extensions/pom.xml
+++ b/project-set/extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>

--- a/project-set/external/jee6-schemas/pom.xml
+++ b/project-set/external/jee6-schemas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/project-set/external/os-auth-schemas/pom.xml
+++ b/project-set/external/os-auth-schemas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external</groupId>

--- a/project-set/external/pom.xml
+++ b/project-set/external/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external</groupId>
     <artifactId>external-lib-support</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
 
     <name>Repose - External Library Support</name>
 

--- a/project-set/external/rs-auth-schemas/pom.xml
+++ b/project-set/external/rs-auth-schemas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external</groupId>

--- a/project-set/external/service-clients/auth/pom.xml
+++ b/project-set/external/service-clients/auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>service-client-support</artifactId>
         <groupId>com.rackspace.papi.external.clients</groupId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.cloud.services.clients</groupId>

--- a/project-set/external/service-clients/pom.xml
+++ b/project-set/external/service-clients/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.clients</groupId>
     <artifactId>service-client-support</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
 
     <name>Repose Service Clients - Service Clients Support</name>
     

--- a/project-set/external/servlet-api/pom.xml
+++ b/project-set/external/servlet-api/pom.xml
@@ -5,13 +5,13 @@
    <parent>
       <groupId>com.rackspace.papi</groupId>
       <artifactId>profile-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 
    <groupId>org.openrepose.servlet</groupId>
    <artifactId>servlet-api</artifactId>
-   <version>2.6.12</version>
+   <version>2.6.13-SNAPSHOT</version>
 
    <name>Repose - Servlet API Spec</name>
     

--- a/project-set/external/testing/test-support/pom.xml
+++ b/project-set/external/testing/test-support/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>com.rackspace.papi.external</groupId>
       <artifactId>external-lib-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/project-set/installation/deb/cli-utils/pom.xml
+++ b/project-set/installation/deb/cli-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.cli-utils</groupId>

--- a/project-set/installation/deb/pom.xml
+++ b/project-set/installation/deb/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.rackspace.repose.installation</groupId>
         <artifactId>installation</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb</groupId>
     <artifactId>deb</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
 
     <name>Repose - Installation DEB</name>
 

--- a/project-set/installation/deb/repose-filter-bundle/pom.xml
+++ b/project-set/installation/deb/repose-filter-bundle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>deb</artifactId>
         <groupId>com.rackspace.repose.installation.deb</groupId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/project-set/installation/deb/repose-valve/pom.xml
+++ b/project-set/installation/deb/repose-valve/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>deb</artifactId>
         <groupId>com.rackspace.repose.installation.deb</groupId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/project-set/installation/pom.xml
+++ b/project-set/installation/pom.xml
@@ -5,12 +5,12 @@
     <parent>
       <groupId>com.rackspace.papi</groupId>
       <artifactId>profile-support</artifactId>
-      <version>2.6.12</version>
+      <version>2.6.13-SNAPSHOT</version>
    </parent>
 
     <groupId>com.rackspace.repose.installation</groupId>
     <artifactId>installation</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
 
     <name>Repose - Installation</name>
 

--- a/project-set/installation/rpm/cli-utils/pom.xml
+++ b/project-set/installation/rpm/cli-utils/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.cli-utils</groupId>
     <artifactId>cli-utils</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
 
     <name>Repose - Installation Cloud Integration CLI-Utils RPM</name>
 

--- a/project-set/installation/rpm/pom.xml
+++ b/project-set/installation/rpm/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.rackspace.repose.installation</groupId>
         <artifactId>installation</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm</groupId>
     <artifactId>rpm</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
 
     <name>Repose - Installation RPM</name>
 

--- a/project-set/installation/rpm/repose-extension-filters/pom.xml
+++ b/project-set/installation/rpm/repose-extension-filters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.filters.extensions</groupId>

--- a/project-set/installation/rpm/repose-filters/pom.xml
+++ b/project-set/installation/rpm/repose-filters/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
     <groupId>com.rackspace.repose.installation.rpm.filters</groupId>
     <artifactId>repose-filters</artifactId>

--- a/project-set/installation/rpm/repose-valve/pom.xml
+++ b/project-set/installation/rpm/repose-valve/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
     <groupId>com.rackspace.repose.installation.rpm.valve</groupId>
     <artifactId>repose-valve</artifactId>

--- a/project-set/installation/rpm/repose-war/pom.xml
+++ b/project-set/installation/rpm/repose-war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.war</groupId>

--- a/project-set/installation/rpm/ug-repose-filters/pom.xml
+++ b/project-set/installation/rpm/ug-repose-filters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>rpm</artifactId>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/project-set/installation/rpm/ug-repose-valve/pom.xml
+++ b/project-set/installation/rpm/ug-repose-valve/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>rpm</artifactId>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/project-set/management/pom.xml
+++ b/project-set/management/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose</groupId>
     <artifactId>management</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
 
     <name>Repose - Management</name>
 

--- a/project-set/pom.xml
+++ b/project-set/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>papi</artifactId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi</groupId>
     <artifactId>profile-support</artifactId>
-    <version>2.6.12</version>
+    <version>2.6.13-SNAPSHOT</version>
 
     <name>Repose - Build Support Profiles</name>
 

--- a/project-set/services/pom.xml
+++ b/project-set/services/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>profile-support</artifactId>
         <groupId>com.rackspace.papi</groupId>
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.services</groupId>

--- a/project-set/services/rate-limiting-service/pom.xml
+++ b/project-set/services/rate-limiting-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>        
-        <version>2.6.12</version>
+        <version>2.6.13-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Jenkins release - updating all poms to 2.6.13-SNAPSHOT

NOTE: the Jenkins release did NOT update the docbook pom.  I'm leaving that one on hold until I chat with Kari/Theresa on the current docbook deployment process.
