### PR TITLE
D-12341 api validator mbean memory leak

### DIFF
--- a/project-set/extensions/api-validator/src/main/java/org/openrepose/components/apivalidator/filter/ApiValidatorHandlerFactory.java
+++ b/project-set/extensions/api-validator/src/main/java/org/openrepose/components/apivalidator/filter/ApiValidatorHandlerFactory.java
@@ -55,6 +55,9 @@ public class ApiValidatorHandlerFactory extends AbstractConfiguredFilterHandlerF
                 if (StringUtilities.isNotBlank(info.getUri())) {
                     manager.unsubscribeFrom(info.getUri(), wadlListener);
                 }
+                if (info.getValidator() != null) {
+                    info.getValidator().destroy();
+                }
             }
         }
     }


### PR DESCRIPTION
Bugfix to address the issue of MBeans not being unregistered when the APIValidation filter is reconfigured.
