### PR TITLE
B-43833 fix broken build due to rms xsd assert

### DIFF
--- a/project-set/core/core-lib/src/main/resources/META-INF/schema/response-messaging/response-messaging.xsd
+++ b/project-set/core/core-lib/src/main/resources/META-INF/schema/response-messaging/response-messaging.xsd
@@ -180,12 +180,14 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:assert vc:minVersion="1.1" test="if (text()) then not (@href) else true()"
-                    xerces:message="Cannot define message inline and reference to external message file"
-                    saxon:message="Cannot define message inline and reference to external message file"/>
-                <xs:assert vc:minVersion="1.1" test="if (@href) then not (text()) else true()"
-                    xerces:message="Cannot define message inline and reference to external message file"
-                    saxon:message="Cannot define message inline and reference to external message file"/>
+
+                <!-- Commenting out asserts as they are breaking our Jmeter regression tests -->
+                <!--<xs:assert vc:minVersion="1.1" test="if (text()) then not (@href) else true()"-->
+                    <!--xerces:message="Cannot define message inline and reference to external message file"-->
+                    <!--saxon:message="Cannot define message inline and reference to external message file"/>-->
+                <!--<xs:assert vc:minVersion="1.1" test="if (@href) then not (text()) else true()"-->
+                    <!--xerces:message="Cannot define message inline and reference to external message file"-->
+                    <!--saxon:message="Cannot define message inline and reference to external message file"/>-->
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
The JMeter regression tests are failing due to the new asserts added in the ResponseMessaging schema.  Jorge is reviewing these asserts and will log a bug/work with the xerces team to address why xerces is not supporting them.  In the interim, I've commented out these new asserts and kicked the story back to in progress and will add a blocker for the xerces issue.
