### PR TITLE
B-50264 fixing spock test stability issues

### DIFF
--- a/test/spock-functional-test/src/test/groovy/features/core/powerfilter/ResponseCodeJMXTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/core/powerfilter/ResponseCodeJMXTest.groovy
@@ -31,6 +31,9 @@ class ResponseCodeJMXTest extends ReposeValveTest {
     def cleanup() {
         if (deproxy)
             deproxy.shutdown()
+
+        sleep(3000) //TODO: add a clean way to ensure deproxy has really shutdown all endpoints
+
         repose.stop()
     }
 

--- a/test/spock-functional-test/src/test/groovy/features/filters/apivalidator/ApiValidatorJMXTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/apivalidator/ApiValidatorJMXTest.groovy
@@ -20,6 +20,9 @@ class ApiValidatorJMXTest extends ReposeValveTest {
     }
 
     def cleanup() {
+        if (deproxy)
+            deproxy.shutdown()
+        sleep(3000) //TODO: add a clean way to ensure deproxy has really shutdown all endpoints
         repose.stop()
     }
 

--- a/test/spock-functional-test/src/test/groovy/framework/ReposeValveTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/framework/ReposeValveTest.groovy
@@ -38,6 +38,9 @@ abstract class ReposeValveTest extends Specification {
     }
 
     def teardownSpec() {
+        if (deproxy)
+            deproxy.shutdown()
+
         if (repose.isUp())
             repose.stop()
     }


### PR DESCRIPTION
Fixing the stability of the spock tests.  All are passing with this sleep between the deproxy shutdown and before the next test is run.

Also, added in dynamic port generation for the JMX port (to minimize issues with port collisions)
