### PR TITLE
B-50264 up rev gdeproxy to 0.9.4

### DIFF
--- a/test/spock-functional-test/pom.xml
+++ b/test/spock-functional-test/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.rackspace</groupId>
             <artifactId>gdeproxy</artifactId>
-            <version>0.9.4-SNAPSHOT</version>
+            <version>0.9.4</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
I left the build depending on a gdeproxy snapshot.  Uprevving to use the official 0.9.4.
