### PR TITLE
Fixing spock flakiness with log4j

### DIFF
--- a/test/spock-functional-test/src/test/configs/common/log4j.properties
+++ b/test/spock-functional-test/src/test/configs/common/log4j.properties
@@ -1,10 +1,5 @@
 # Set root logger level
-log4j.rootLogger=INFO, consoleOut, defaultFile
-
-# Console
-log4j.appender.consoleOut=org.apache.log4j.ConsoleAppender
-log4j.appender.consoleOut.layout=org.apache.log4j.PatternLayout
-log4j.appender.consoleOut.layout.ConversionPattern=%d %-4r [%t] %-5p %c %x - %m%n
+log4j.rootLogger=INFO, defaultFile
 
 #Jetty Loggin Turned Off
 #log4j.logger.org.eclipse.jetty=OFF


### PR DESCRIPTION
The test flakiness in spock when running making multiple requests via deproxy was due to console output logging in repose.  Why???  I dunno!  I have to still puzzle that one out, but I can say that when we stop console output logging in Repose, requests make it through without issue.
