### PR TITLE
B-51366 change shutdown port on spock tests

### DIFF
--- a/test/spock-functional-test/pom.xml
+++ b/test/spock-functional-test/pom.xml
@@ -136,7 +136,7 @@
 
                 <repose_port>8888</repose_port>
                 <repose_jmx_port>9001</repose_jmx_port>
-                <repose_shutdown_port>9999</repose_shutdown_port>
+                <repose_shutdown_port>10009</repose_shutdown_port>
                 <target_hostname>localhost</target_hostname>
                 <target_port>10001</target_port>
                 <identity_port>12200</identity_port>


### PR DESCRIPTION
Changing the shutdown port for repose in the spock tests.  There is a port conflict on 9999 preventing the tests from shutting down successfully.
