### PR TITLE
D-14212 fixing package name for DEB extensions filter bundle

### DIFF
--- a/project-set/installation/deb/repose-extension-filters/pom.xml
+++ b/project-set/installation/deb/repose-extension-filters/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.rackspace.repose.installation.deb.filters.extensions</groupId>
-    <artifactId>repose-extension-filters</artifactId>
+    <artifactId>repose-extensions-filter-bundle</artifactId>
 
     <name>Repose - Installation Extension Filters DEB</name>
 

--- a/project-set/installation/deb/repose-extension-filters/src/deb/control/control
+++ b/project-set/installation/deb/repose-extension-filters/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: repose-extensions-filter-bundle
+Package: [[artifactId]]
 Version: [[version]]
 Section: misc
 Priority: optional

--- a/project-set/installation/deb/repose-filter-bundle/src/deb/control/control
+++ b/project-set/installation/deb/repose-filter-bundle/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: repose-filter-bundle
+Package: [[artifactId]]
 Version: [[version]]
 Section: misc
 Priority: optional


### PR DESCRIPTION
This issue has caused a duplicate package entry to exist for "repose-filter-bundle" on our Debian server for our 2.8.0 and 2.8.1 builds.  This change should fix the issue going forward.
