### PR TITLE
B-51366 fixing response messaging test flakiness

### DIFF
--- a/test/spock-functional-test/src/test/groovy/features/filters/responseMessaging/ResponseMessagingTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/responseMessaging/ResponseMessagingTest.groovy
@@ -14,6 +14,7 @@ class ResponseMessagingTest extends ReposeValveTest {
 
         repose.applyConfigs("features/filters/responsemessaging")
         repose.start()
+        waitUntilReadyToServiceRequests()
     }
 
     def cleanupSpec() {
@@ -26,14 +27,9 @@ class ResponseMessagingTest extends ReposeValveTest {
         }
     }
 
-
-    def "when starting repose with the response messaging service, it should start"() {
-        repose.isUp()
-    }
-
     def "when endpoint returns a 413 response code, then repose should return the expected response body"() {
+
         when:
-        sleep(10000)
         def messageChain = deproxy.makeRequest([url: reposeEndpoint, defaultHandler: handler413])
 
         then:


### PR DESCRIPTION
Handling test flakiness issues with the ResponseMessaging spock test.  Removed a hard coded sleep.  Using the startup check to ensure Repose can service requests before starting the test.
