### PR TITLE
B-51378 adding maven module for HTTP connection pool

### DIFF
--- a/project-set/services/http-connection-pool/pom.xml
+++ b/project-set/services/http-connection-pool/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+          <groupId>com.rackspace.repose.services</groupId>
+          <artifactId>services-pom</artifactId>
+          <version>2.8.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.rackspace.papi.service</groupId>
+    <artifactId>http-connection-pool</artifactId>
+
+    <name>Repose Services - HTTP Connection Pool</name>
+
+    <packaging>jar</packaging>
+
+</project>


### PR DESCRIPTION
Adding a maven module to support the HTTP connection pool new service.  This module will house the XSD and XML samples, and eventually the service implementation for the HTTP connection pool apache http-client implementation of a connection pool.
