### PR TITLE
Use gdeproxy 0.11

### DIFF
--- a/test/spock-functional-test/pom.xml
+++ b/test/spock-functional-test/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.rackspace</groupId>
             <artifactId>gdeproxy</artifactId>
-            <version>0.11-SNAPSHOT</version>
+            <version>0.11</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Versions 0.10 and 0.11 add support for binary data (with simple auto Content-Type), PortFinder, query parameters, and Delay handlers. 

This upgrade is needed to work on tests for compression.
