### PR TITLE
D-14493

### DIFF
--- a/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/proxy/httpcomponent/HttpComponentRequestProcessor.java
+++ b/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/proxy/httpcomponent/HttpComponentRequestProcessor.java
@@ -22,109 +22,108 @@ import java.util.Enumeration;
  */
 class HttpComponentRequestProcessor extends AbstractRequestProcessor {
 
-  private static final String ENCODING = "UTF-8";
-  private final HttpServletRequest sourceRequest;
-  private final URI targetHost;
-  private final boolean rewriteHostHeader;
+    private static final String ENCODING = "UTF-8";
+    private final HttpServletRequest sourceRequest;
+    private final URI targetHost;
+    private final boolean rewriteHostHeader;
 
-  public HttpComponentRequestProcessor(HttpServletRequest request, URI host, boolean rewriteHostHeader) {
-    this.sourceRequest = request;
-    this.targetHost = host;
-    this.rewriteHostHeader = rewriteHostHeader;
-  }
+    public HttpComponentRequestProcessor(HttpServletRequest request, URI host, boolean rewriteHostHeader) {
+        this.sourceRequest = request;
+        this.targetHost = host;
+        this.rewriteHostHeader = rewriteHostHeader;
+    }
 
-  private void setRequestParameters(URIBuilder builder) throws URISyntaxException {
-    Enumeration<String> names = sourceRequest.getParameterNames();
+    private void setRequestParameters(URIBuilder builder) throws URISyntaxException {
+        Enumeration<String> names = sourceRequest.getParameterNames();
 
-    while (names.hasMoreElements()) {
-      String name = names.nextElement();
-      if (StringUtilities.isBlank(name)) {
-          continue;
-      }
-      String[] values = sourceRequest.getParameterValues(name);
+        while (names.hasMoreElements()) {
+            String name = names.nextElement();
+            if (StringUtilities.isBlank(name)) {
+                continue;
+            }
+            String[] values = sourceRequest.getParameterValues(name);
 
-      for (String value : values) {
-        try {
-          builder.addParameter(name, URLDecoder.decode(value, ENCODING));
-        } catch (UnsupportedEncodingException ex) {
-          throw new URISyntaxException(value, "Invalid value for query parameter: " + name);
+            for (String value : values) {
+                try {
+                    builder.addParameter(name, URLDecoder.decode(value, ENCODING));
+                } catch (UnsupportedEncodingException ex) {
+                    throw new URISyntaxException(value, "Invalid value for query parameter: " + name);
+                }
+            }
         }
-      }
-    }
-  }
-
-  public URI getUri(String target) throws URISyntaxException {
-    URIBuilder builder = new URIBuilder(target);
-    setRequestParameters(builder);
-    return builder.build();
-  }
-
-  /**
-   * Scan header values and manipulate as necessary. Host header, if provided, may need to be updated.
-   *
-   * @param headerName
-   * @param headerValue
-   * @return
-   */
-  private String processHeaderValue(String headerName, String headerValue) {
-    String result = headerValue;
-
-    // In case the proxy host is running multiple virtual servers,
-    // rewrite the Host header to ensure that we get content from
-    // the correct virtual server
-    if (rewriteHostHeader && headerName.equalsIgnoreCase(CommonHttpHeader.HOST.toString())) {
-      result = targetHost.getHost() + ":" + targetHost.getPort();
     }
 
-    return result;
-  }
-
-  /**
-   * Copy header values from source request to the http method.
-   *
-   * @param method
-   */
-  private void setHeaders(HttpRequestBase method) {
-    final Enumeration<String> headerNames = sourceRequest.getHeaderNames();
-
-    while (headerNames.hasMoreElements()) {
-      final String headerName = headerNames.nextElement();
-
-      if (excludeHeader(headerName)) {
-        continue;
-      }
-
-      final Enumeration<String> headerValues = sourceRequest.getHeaders(headerName);
-
-      while (headerValues.hasMoreElements()) {
-        String headerValue = headerValues.nextElement();
-        method.addHeader(headerName, processHeaderValue(headerName, headerValue));
-      }
+    public URI getUri(String target) throws URISyntaxException {
+        URIBuilder builder = new URIBuilder(target);
+        setRequestParameters(builder);
+        return builder.build();
     }
-  }
 
-  /**
-   * Process a base http request. Base http methods will not contain a message body.
-   *
-   * @param method
-   * @return
-   */
-  public HttpRequestBase process(HttpRequestBase method) {
-    setHeaders(method);
-    return method;
+    /**
+    * Scan header values and manipulate as necessary. Host header, if provided, may need to be updated.
+    *
+    * @param headerName
+    * @param headerValue
+    * @return
+    */
+    private String processHeaderValue(String headerName, String headerValue) {
+        String result = headerValue;
 
-  }
+        // In case the proxy host is running multiple virtual servers,
+        // rewrite the Host header to ensure that we get content from
+        // the correct virtual server
+        if (rewriteHostHeader && headerName.equalsIgnoreCase(CommonHttpHeader.HOST.toString())) {
+            result = targetHost.getHost() + ":" + targetHost.getPort();
+        }
 
-  /**
-   * Process an entity enclosing http method. These methods can handle a request body.
-   *
-   * @param method
-   * @return
-   * @throws IOException
-   */
-  public HttpRequestBase process(HttpEntityEnclosingRequestBase method) throws IOException {
-    setHeaders(method);
-    method.setEntity(new InputStreamEntity(sourceRequest.getInputStream(), -1));
-    return method;
-  }
+        return result;
+    }
+
+    /**
+    * Copy header values from source request to the http method.
+    *
+    * @param method
+    */
+    private void setHeaders(HttpRequestBase method) {
+        final Enumeration<String> headerNames = sourceRequest.getHeaderNames();
+
+        while (headerNames.hasMoreElements()) {
+            final String headerName = headerNames.nextElement();
+
+            if (excludeHeader(headerName)) {
+                continue;
+            }
+
+            final Enumeration<String> headerValues = sourceRequest.getHeaders(headerName);
+
+            while (headerValues.hasMoreElements()) {
+                String headerValue = headerValues.nextElement();
+                method.addHeader(headerName, processHeaderValue(headerName, headerValue));
+            }
+        }
+    }
+
+    /**
+    * Process a base http request. Base http methods will not contain a message body.
+    *
+    * @param method
+    * @return
+    */
+    public HttpRequestBase process(HttpRequestBase method) {
+        setHeaders(method);
+        return method;
+    }
+
+    /**
+    * Process an entity enclosing http method. These methods can handle a request body.
+    *
+    * @param method
+    * @return
+    * @throws IOException
+    */
+    public HttpRequestBase process(HttpEntityEnclosingRequestBase method) throws IOException {
+        setHeaders(method);
+        method.setEntity(new InputStreamEntity(sourceRequest.getInputStream(), -1));
+        return method;
+    }
 }

--- a/test/spock-functional-test/src/test/groovy/features/core/proxy/RequestQueryParamTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/core/proxy/RequestQueryParamTest.groovy
@@ -4,6 +4,7 @@ import framework.ReposeValveTest
 import org.rackspace.gdeproxy.Deproxy
 import org.rackspace.gdeproxy.Handling
 import org.rackspace.gdeproxy.MessageChain
+import spock.lang.Unroll
 
 class RequestQueryParamTest extends ReposeValveTest {
 
@@ -25,6 +26,7 @@ class RequestQueryParamTest extends ReposeValveTest {
         deproxy.shutdown()
     }
 
+    @Unroll("When client requests: #uriSuffixGiven, repose should normalize to: #uriSuffixExpected")
     def "when given a query param list, Repose should forward a valid query param list"() {
 
         when: "the client makes a request through Repose"


### PR DESCRIPTION
Description:
If a user sends a query string through repose that starts with an '&' (e.g. http://service.api.com/path/to/resource?&t=1375304890) Repose forwards out a mangled query string (http://service.api.com/path/to/resource?=&t=1375304890)which might cause and origin service to throw a 500 error.

Acceptance Criteria: 
Invalid query parameters are removed from the request before the request is sent to the origin service. 
(we will remove the first ampersand)
The exact query parameter above is in a test case that fails prior to coding and passes after coding.

To clarify, the query parameters we were seeing weren't technically invalid, just meaningless. The code change below removes any query parameter which uses an empty string as a key.
