### PR TITLE
Updated URI resolvers to set the system ID for the streams they return

### DIFF
--- a/project-set/components/translation/pom.xml
+++ b/project-set/components/translation/pom.xml
@@ -32,6 +32,12 @@
         </dependency>
 
         <dependency>
+            <artifactId>spring-web</artifactId>
+            <groupId>org.springframework</groupId>
+            <type>jar</type>
+        </dependency>
+
+        <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>saxon-ee</artifactId>
             <version>9.4.0.6</version>

--- a/project-set/components/translation/src/main/java/com/rackspace/papi/components/translation/resolvers/ClassPathUriResolver.java
+++ b/project-set/components/translation/src/main/java/com/rackspace/papi/components/translation/resolvers/ClassPathUriResolver.java
@@ -5,6 +5,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 
 public class ClassPathUriResolver extends SourceUriResolver {
 
@@ -27,8 +28,12 @@ public class ClassPathUriResolver extends SourceUriResolver {
             if (resource == null) {
                 return null;
             }
-            
-            return new StreamSource(resource);
+
+            try {
+                return new StreamSource(resource, getClass().getResource(path).toURI().toString());
+            } catch (URISyntaxException ex) {
+                return new StreamSource(resource);
+            }
         }
         
         return super.resolve(href, base);

--- a/project-set/components/translation/src/main/java/com/rackspace/papi/components/translation/resolvers/InputStreamUriParameterResolver.java
+++ b/project-set/components/translation/src/main/java/com/rackspace/papi/components/translation/resolvers/InputStreamUriParameterResolver.java
@@ -5,10 +5,14 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.web.util.UriUtils;
 
 public class InputStreamUriParameterResolver extends SourceUriResolver {
 
@@ -50,7 +54,11 @@ public class InputStreamUriParameterResolver extends SourceUriResolver {
     }
 
     public String getHref(InputStream inputStreamReference) {
-        return PREFIX + inputStreamReference.toString();
+        try {
+            return PREFIX + UriUtils.encodePathSegment(inputStreamReference.toString(), "utf-8");
+        } catch (UnsupportedEncodingException ex) {
+            return PREFIX + inputStreamReference.toString();
+        }
     }
 
     public String getHref(String name) {
@@ -65,7 +73,11 @@ public class InputStreamUriParameterResolver extends SourceUriResolver {
     public Source resolve(String href, String base) throws TransformerException {
         InputStream stream = streams.get(href);
         if (stream != null) {
-            return new StreamSource(stream);
+            try {
+                return new StreamSource(stream, new URI(href).toString());
+            } catch (URISyntaxException ex) {
+                return new StreamSource(stream);
+            }
         }
 
         if (!resolvers.isEmpty()) {

--- a/project-set/components/translation/src/test/java/com/rackspace/papi/components/translation/resolvers/ClassPathUriResolverTest.java
+++ b/project-set/components/translation/src/test/java/com/rackspace/papi/components/translation/resolvers/ClassPathUriResolverTest.java
@@ -9,6 +9,7 @@ import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
@@ -30,6 +31,8 @@ public class ClassPathUriResolverTest {
         public void shouldFindResource() throws TransformerException {
             Source resource = resolver.resolve(ClassPathUriResolver.CLASSPATH_PREFIX + "/style.xsl", "");
             assertNotNull("Should find resource", resource);
+            assertNotNull("Resource should contain the source path", resource.getSystemId());
+            assertFalse("Resource path should not be empty", resource.getSystemId().isEmpty());
         }
         
         @Test

--- a/project-set/components/translation/src/test/java/com/rackspace/papi/components/translation/resolvers/InputStreamUriParameterResolverTest.java
+++ b/project-set/components/translation/src/test/java/com/rackspace/papi/components/translation/resolvers/InputStreamUriParameterResolverTest.java
@@ -37,7 +37,9 @@ public class InputStreamUriParameterResolverTest {
             
             assertEquals("HREFs should be equal", href, actualHref);
             StreamSource source = (StreamSource) resolver.resolve(href, "base");
-            assertNotNull("Shoudl find source stream", source);
+            assertNotNull("Should find source stream", source);
+            assertNotNull("Source stream should include a path", source.getSystemId());
+            assertFalse("Source stream path should not be empty", source.getSystemId().isEmpty());
             assertTrue("Streams should be the same", input == source.getInputStream());
         }
         
@@ -49,7 +51,9 @@ public class InputStreamUriParameterResolverTest {
             
             assertEquals("HREFs should be equal", href, actualHref);
             StreamSource source = (StreamSource) resolver.resolve(href, "base");
-            assertNotNull("Shoudl find source stream", source);
+            assertNotNull("Should find source stream", source);
+            assertNotNull("Source stream should include a path", source.getSystemId());
+            assertFalse("Source stream path should not be empty", source.getSystemId().isEmpty());
             assertTrue("Streams should be the same", input == source.getInputStream());
             resolver.removeStream(href);
             source = (StreamSource) resolver.resolve(href, "base");
@@ -63,7 +67,9 @@ public class InputStreamUriParameterResolverTest {
             String actualHref = resolver.addStream(input);
             
             StreamSource source = (StreamSource) resolver.resolve(href, "base");
-            assertNotNull("Shoudl find source stream", source);
+            assertNotNull("Should find source stream", source);
+            assertNotNull("Source stream should include a path", source.getSystemId());
+            assertFalse("Source stream path should not be empty", source.getSystemId().isEmpty());
             assertTrue("Streams should be the same", input == source.getInputStream());
             resolver.removeStream(input);
             source = (StreamSource) resolver.resolve(href, "base");

--- a/project-set/components/translation/src/test/java/com/rackspace/papi/components/translation/resolvers/OutputStreamUriParameterResolverTest.java
+++ b/project-set/components/translation/src/test/java/com/rackspace/papi/components/translation/resolvers/OutputStreamUriParameterResolverTest.java
@@ -11,6 +11,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamResult;
 import java.io.OutputStream;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -42,6 +43,8 @@ public class OutputStreamUriParameterResolverTest {
             assertNotNull("Should return the href for our output stream", href);
             StreamResult result = (StreamResult)resolver.resolve(href, "");
             assertNotNull("Should return a StreamResult which wraps our output stream", result);
+            assertNotNull("Source stream should include a path", result.getSystemId());
+            assertFalse("Source stream path should not be empty", result.getSystemId().isEmpty());
             assertTrue("Should return our output stream", output == result.getOutputStream());
         }
         


### PR DESCRIPTION
The `getSystemId()` method was returning `null` for all streams returned by the URI resolvers in the translations artifact. This impacted XSLT transforms in the clouddocs-maven-plugin (external project) by preventing the reporting mechanisms from including source locations in the output.

This following reflects the status of each `URIResolver` and `OutputURIResolver` in the translations artifact following this change.

| Resolver Name | Status | Comment |
| --- | --- | --- |
| `ClassPathUriResolver` | Updated + Tests |  |
| `InputStreamUriParameterResolver` | Updated + Tests |  |
| `OutputStreamUriParameterResolver` | Updated + Tests |  |
| `HttpxUriInputParameterResolver` | **NOT** updated | No immediate access to code using this class, and no unit tests were included in the artifact, so I could not confirm correct behavior for the update. |
| `SourceUriResolver` | Not applicable | Does not create any `Source` objects directly |
| `SourceUriResolverChain` | Not applicable | Does not create any `Source` objects directly |
