### PR TITLE
Updating the doc pom to use the latest version of the clouddocs plugin

### DIFF
--- a/documentation/docbook/olink.xml
+++ b/documentation/docbook/olink.xml
@@ -1,0 +1,12 @@
+<books xmlns="http://docs.rackspace.com/olink">
+  <book path="src/resources/repose-apivalidation-deploy.xml"/>
+  <book path="src/resources/repose-authnauthz-deploy.xml"/>
+  <book path="src/resources/repose-deploy.xml"/>
+  <book path="src/resources/repose-glossary.xml"/> 	
+  <book path="src/resources/repose-intro.xml"/>
+  <book path="src/resources/repose-logging-deploy.xml"/>
+  <book path="src/resources/repose-ratelimiting-deploy.xml"/>
+  <book path="src/resources/repose-translation-deploy.xml"/> 	
+  <book path="src/resources/repose-versioning-deploy.xml"/>
+</books>
+

--- a/documentation/docbook/pom.xml
+++ b/documentation/docbook/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>papi</artifactId>
-        <version>2.6.12-SNAPSHOT</version>
+        <version>2.8.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -17,12 +17,25 @@
     
     <build>
         <plugins>
+	  <plugin>
+            <groupId>com.rackspace.cloud.api</groupId>
+            <artifactId>olink-maven-plugin</artifactId>
+            <version>1.0</version>
+            <executions>
+              <execution>
+		<phase>initialize</phase>
+		<goals>
+		  <goal>olink</goal>
+		</goals>
+              </execution>
+            </executions>
+	  </plugin>
             <plugin>
                 <groupId>com.rackspace.cloud.api</groupId>
                 <artifactId>clouddocs-maven-plugin</artifactId>
                 <!-- this <version> relates only to the *plugin* used for document formatting -->
                 <!-- the version of the *API* that is the subject of the document is indicated within each document -->
-                <version>1.6.1</version>
+                <version>1.9.2</version>
                 <executions>
                     <execution>
                         <id>g1</id>


### PR DESCRIPTION
And also use the new olink feature. Pro Tip: Use
${cfdu}/../../target/olink.db as the path to the olink db when
inserting olinks.
