### PR TITLE
FLAKY UNIT TEST: GenericResourcePoolTest

### DIFF
--- a/project-set/commons/utilities/src/test/java/com/rackspace/papi/commons/util/pooling/GenericResourcePoolTest.java
+++ b/project-set/commons/utilities/src/test/java/com/rackspace/papi/commons/util/pooling/GenericResourcePoolTest.java
@@ -135,7 +135,7 @@ public class GenericResourcePoolTest {
                 t.start();
             }
             
-            while (internalThreadCount < 6) {
+            while (internalThreadCount < 7) {
                 Thread.sleep(10);
             }
             


### PR DESCRIPTION
This test failed 3 times on Jenkins in the past ~10 builds.  Increasing the minimum threads to wait for to 6 in order to alleviate the timing issue of the counter being incremented before the pool resource is used.
