### PR TITLE
StopTheLine - fixing the jenkins flaky header translation tests

### DIFF
--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/caseSensitivityHeaders/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/caseSensitivityHeaders/header-translation.cfg.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-header-A" new-name="X-HEADER-D" remove-original="false" />
-    <header original-name="X-Header-b" new-name="X-Header-e" remove-original="false" />
-    <header original-name="X-HEADER-C" new-name="x-HEADER-E" remove-original="false" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/common/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/common/header-translation.cfg.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<header-translation  xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
+
+    <header original-name="X-OneToOne-A" new-name="X-OneToOne-C" remove-original="false" />
+    <header original-name="X-OneToOneRemoval-A" new-name="X-OneToOneRemoval-C" remove-original="true" />
+    <header original-name="X-OneToMany-A" new-name="X-OneToMany-C X-OneToMany-D" remove-original="false" />
+    <header original-name="X-OneToManyRemoval-A" new-name="X-OneToManyRemoval-C X-OneToManyRemoval-D" remove-original="true" />
+
+    <header original-name="X-StripHeader-A" new-name="" remove-original="true" />
+
+    <header original-name="X-ManyToMany-A" new-name="X-ManyToMany-D" remove-original="false" />
+    <header original-name="X-ManyToMany-B" new-name="X-ManyToMany-E" remove-original="false" />
+    <header original-name="X-ManyToMany-C" new-name="X-ManyToMany-F" remove-original="false" />
+
+    <header original-name="X-ManyToOne-A" new-name="X-ManyToOne-D" remove-original="true" />
+    <header original-name="X-ManyToOne-B" new-name="X-ManyToOne-D" remove-original="true" />
+    <header original-name="X-ManyToOne-C" new-name="X-ManyToOne-D" remove-original="true" />
+
+    <header original-name="X-ToExisting-A" new-name="X-Header-Existing" remove-original="false" />
+
+    <header original-name="X-mixedcase-A" new-name="X-MIXEDCASE-D" remove-original="false" />
+    <header original-name="X-Mixedcase-b" new-name="X-Mixedcase-e" remove-original="false" />
+    <header original-name="X-MIXEDCASE-C" new-name="x-MIXEDCASE-E" remove-original="false" />
+
+    <!-- CSL headers -->
+    <header original-name="x-pp-user" new-name="x-rax-username" />
+    <header original-name="x-tenant-name" new-name="x-rax-tenants" />
+    <header original-name="x-roles" new-name="x-rax-roles" />
+</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/csl/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/csl/header-translation.cfg.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation  xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="x-pp-user" new-name="x-rax-username" />
-    <header original-name="x-tenant-name" new-name="x-rax-tenants" />
-    <header original-name="x-roles" new-name="x-rax-roles" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/manyToMany/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/manyToMany/header-translation.cfg.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-Header-A" new-name="X-Header-D" remove-original="false" />
-    <header original-name="X-Header-B" new-name="X-Header-E" remove-original="false" />
-    <header original-name="X-Header-C" new-name="X-Header-F" remove-original="false" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/manyToOne/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/manyToOne/header-translation.cfg.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation  xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-Header-A" new-name="X-Header-D" remove-original="true" />
-    <header original-name="X-Header-B" new-name="X-Header-D" remove-original="true" />
-    <header original-name="X-Header-C" new-name="X-Header-D" remove-original="true" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/oneToMany/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/oneToMany/header-translation.cfg.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation  xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-Header-A" new-name="X-Header-C X-Header-D" remove-original="false" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/oneToManyRemoval/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/oneToManyRemoval/header-translation.cfg.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-Header-A" new-name="X-Header-C X-Header-D" remove-original="true" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/oneToOne/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/oneToOne/header-translation.cfg.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-Header-A" new-name="X-Header-C" remove-original="false" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/oneToOneRemoval/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/oneToOneRemoval/header-translation.cfg.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-Header-A" new-name="X-Header-C" remove-original="true" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/stripHeader/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/stripHeader/header-translation.cfg.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-Header-A" new-name="" remove-original="true" />
-</header-translation>

--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/translatingToExistingHeader/header-translation.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/translatingToExistingHeader/header-translation.cfg.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<header-translation xmlns="http://docs.api.rackspacecloud.com/repose/header-translation/v1.0">
-    <header original-name="X-Header-A" new-name="X-Header-Existing" remove-original="false" />
-</header-translation>

--- a/test/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationTest.groovy
@@ -9,261 +9,222 @@ import org.rackspace.gdeproxy.Request
 
 class HeaderTranslationTest extends ReposeValveTest {
 
-    def setup() {
+    def setupSpec() {
         deproxy = new Deproxy()
         deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
+
+        repose.applyConfigs( "features/filters/headertranslation/common")
+        repose.start()
     }
 
-    def cleanup() {
-        repose.stop()
+    def cleanupSpec() {
         deproxy.shutdown()
+        repose.stop()
     }
 
     def "when translating request headers one-to-one without removal"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                             "features/filters/headertranslation/oneToOne" )
-        repose.start()
 
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        sentRequest.request.getHeaders().contains("X-Header-A")
-        sentRequest.request.getHeaders().contains("X-Header-B")
-        sentRequest.request.getHeaders().contains("X-Header-C")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-A").equalsIgnoreCase("a")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-B").equalsIgnoreCase("b")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-C").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().contains("X-OneToOne-A")
+        sentRequest.request.getHeaders().contains("X-OneToOne-B")
+        sentRequest.request.getHeaders().contains("X-OneToOne-C")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToOne-A").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToOne-B").equalsIgnoreCase("b")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToOne-C").equalsIgnoreCase("a")
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a", "X-Header-B" : "b"]
-        "GET"  | ["X-Header-A" : "a", "X-Header-B" : "b"]
+        "POST" | ["X-OneToOne-A" : "a", "X-OneToOne-B" : "b"]
+        "GET"  | ["X-OneToOne-A" : "a", "X-OneToOne-B" : "b"]
     }
 
     def "when translating request headers one-to-one with removal"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                             "features/filters/headertranslation/oneToOneRemoval" )
-        repose.start()
-
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        !sentRequest.request.getHeaders().contains("X-Header-A")
-        sentRequest.request.getHeaders().contains("X-Header-B")
-        sentRequest.request.getHeaders().contains("X-Header-C")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-B").equalsIgnoreCase("b")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-C").equalsIgnoreCase("a")
+        !sentRequest.request.getHeaders().contains("X-OneToOneRemoval-A")
+        sentRequest.request.getHeaders().contains("X-OneToOneRemoval-B")
+        sentRequest.request.getHeaders().contains("X-OneToOneRemoval-C")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToOneRemoval-B").equalsIgnoreCase("b")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToOneRemoval-C").equalsIgnoreCase("a")
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a", "X-Header-B" : "b"]
-        "GET"  | ["X-Header-A" : "a", "X-Header-B" : "b"]
+        "POST" | ["X-OneToOneRemoval-A" : "a", "X-OneToOneRemoval-B" : "b"]
+        "GET"  | ["X-OneToOneRemoval-A" : "a", "X-OneToOneRemoval-B" : "b"]
     }
 
     def "when translating request headers one-to-many without removal"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                             "features/filters/headertranslation/oneToMany" )
-        repose.start()
-
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        sentRequest.request.getHeaders().contains("X-Header-A")
-        sentRequest.request.getHeaders().contains("X-Header-B")
-        sentRequest.request.getHeaders().contains("X-Header-C")
-        sentRequest.request.getHeaders().contains("X-Header-D")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-A").equalsIgnoreCase("a")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-B").equalsIgnoreCase("b")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-C").equalsIgnoreCase("a")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-D").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().contains("X-OneToMany-A")
+        sentRequest.request.getHeaders().contains("X-OneToMany-B")
+        sentRequest.request.getHeaders().contains("X-OneToMany-C")
+        sentRequest.request.getHeaders().contains("X-OneToMany-D")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToMany-A").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToMany-B").equalsIgnoreCase("b")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToMany-C").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToMany-D").equalsIgnoreCase("a")
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a", "X-Header-B" : "b"]
-        "GET"  | ["X-Header-A" : "a", "X-Header-B" : "b"]
+        "POST" | ["X-OneToMany-A" : "a", "X-OneToMany-B" : "b"]
+        "GET"  | ["X-OneToMany-A" : "a", "X-OneToMany-B" : "b"]
     }
 
     def "when translating request headers one-to-many with removal"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                             "features/filters/headertranslation/oneToManyRemoval" )
-        repose.start()
 
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        !sentRequest.request.getHeaders().contains("X-Header-A")
-        sentRequest.request.getHeaders().contains("X-Header-B")
-        sentRequest.request.getHeaders().contains("X-Header-C")
-        sentRequest.request.getHeaders().contains("X-Header-D")
+        !sentRequest.request.getHeaders().contains("X-OneToManyRemoval-A")
+        sentRequest.request.getHeaders().contains("X-OneToManyRemoval-B")
+        sentRequest.request.getHeaders().contains("X-OneToManyRemoval-C")
+        sentRequest.request.getHeaders().contains("X-OneToManyRemoval-D")
 
         and: "origin receives headers which should not be affected by the translation"
-        sentRequest.request.getHeaders().getFirstValue("X-Header-B").equalsIgnoreCase("b")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-B").equalsIgnoreCase("b")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToManyRemoval-B").equalsIgnoreCase("b")
+        sentRequest.request.getHeaders().getFirstValue("X-OneToManyRemoval-B").equalsIgnoreCase("b")
 
         and: "origin receives translated all header values"
-        sentRequest.request.getHeaders().findAll("X-Header-C").contains("a")
-        sentRequest.request.getHeaders().findAll("X-Header-C").contains("b")
-        sentRequest.request.getHeaders().findAll("X-Header-C").contains("c")
-        sentRequest.request.getHeaders().findAll("X-Header-D").contains("a")
-        sentRequest.request.getHeaders().findAll("X-Header-D").contains("b")
-        sentRequest.request.getHeaders().findAll("X-Header-D").contains("c")
+        sentRequest.request.getHeaders().findAll("X-OneToManyRemoval-C").contains("a")
+        sentRequest.request.getHeaders().findAll("X-OneToManyRemoval-C").contains("b")
+        sentRequest.request.getHeaders().findAll("X-OneToManyRemoval-C").contains("c")
+        sentRequest.request.getHeaders().findAll("X-OneToManyRemoval-D").contains("a")
+        sentRequest.request.getHeaders().findAll("X-OneToManyRemoval-D").contains("b")
+        sentRequest.request.getHeaders().findAll("X-OneToManyRemoval-D").contains("c")
 
         and: "origin receives translated header values in order in which they were sent"
-        sentRequest.request.getHeaders().findAll("X-Header-C") == ["a","b","c"]
-        sentRequest.request.getHeaders().findAll("X-Header-D") == ["a","b","c"]
+        sentRequest.request.getHeaders().findAll("X-OneToManyRemoval-C") == ["a","b","c"]
+        sentRequest.request.getHeaders().findAll("X-OneToManyRemoval-D") == ["a","b","c"]
 
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a,b,c", "X-Header-B" : "b"]
-        "GET"  | ["X-Header-A" : "a,b,c", "X-Header-B" : "b"]
-        "POST" | ["X-Header-A" : "a ,b,c,,", "X-Header-B" : "b"]
+        "POST" | ["X-OneToManyRemoval-A" : "a,b,c", "X-OneToManyRemoval-B" : "b"]
+        "GET"  | ["X-OneToManyRemoval-A" : "a,b,c", "X-OneToManyRemoval-B" : "b"]
+        "POST" | ["X-OneToManyRemoval-A" : "a ,b,c,,", "X-OneToManyRemoval-B" : "b"]
 
     }
 
     def "when translating request headers one-to-none"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                             "features/filters/headertranslation/stripHeader" )
-        repose.start()
 
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        !sentRequest.request.getHeaders().contains("X-Header-A")
-        sentRequest.request.getHeaders().contains("X-Header-B")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-B").equalsIgnoreCase("b")
+        !sentRequest.request.getHeaders().contains("X-StripHeader-A")
+        sentRequest.request.getHeaders().contains("X-StripHeader-B")
+        sentRequest.request.getHeaders().getFirstValue("X-StripHeader-B").equalsIgnoreCase("b")
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a", "X-Header-B" : "b"]
-        "GET"  | ["X-Header-A" : "a", "X-Header-B" : "b"]
+        "POST" | ["X-StripHeader-A" : "a", "X-StripHeader-B" : "b"]
+        "GET"  | ["X-StripHeader-A" : "a", "X-StripHeader-B" : "b"]
     }
 
     def "when translating request headers many-to-many"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/manyToMany" )
-        repose.start()
 
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        sentRequest.request.getHeaders().contains("X-Header-A")
-        sentRequest.request.getHeaders().contains("X-Header-B")
-        sentRequest.request.getHeaders().contains("X-Header-C")
-        sentRequest.request.getHeaders().contains("X-Header-D")
-        sentRequest.request.getHeaders().contains("X-Header-E")
-        sentRequest.request.getHeaders().contains("X-Header-F")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-A").equalsIgnoreCase("a")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-B").equalsIgnoreCase("b")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-C").equalsIgnoreCase("c")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-D").equalsIgnoreCase("a")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-E").equalsIgnoreCase("b")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-F").equalsIgnoreCase("c")
+        sentRequest.request.getHeaders().contains("X-ManyToMany-A")
+        sentRequest.request.getHeaders().contains("X-ManyToMany-B")
+        sentRequest.request.getHeaders().contains("X-ManyToMany-C")
+        sentRequest.request.getHeaders().contains("X-ManyToMany-D")
+        sentRequest.request.getHeaders().contains("X-ManyToMany-E")
+        sentRequest.request.getHeaders().contains("X-ManyToMany-F")
+        sentRequest.request.getHeaders().getFirstValue("X-ManyToMany-A").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().getFirstValue("X-ManyToMany-B").equalsIgnoreCase("b")
+        sentRequest.request.getHeaders().getFirstValue("X-ManyToMany-C").equalsIgnoreCase("c")
+        sentRequest.request.getHeaders().getFirstValue("X-ManyToMany-D").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().getFirstValue("X-ManyToMany-E").equalsIgnoreCase("b")
+        sentRequest.request.getHeaders().getFirstValue("X-ManyToMany-F").equalsIgnoreCase("c")
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a", "X-Header-B" : "b", "X-Header-C" : "c"]
-        "GET"  | ["X-Header-A" : "a", "X-Header-B" : "b", "X-Header-C" : "c"]
+        "POST" | ["X-ManyToMany-A" : "a", "X-ManyToMany-B" : "b", "X-ManyToMany-C" : "c"]
+        "GET"  | ["X-ManyToMany-A" : "a", "X-ManyToMany-B" : "b", "X-ManyToMany-C" : "c"]
     }
 
     def "when translating request headers many-to-one"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/manyToOne" )
-        repose.start()
 
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        sentRequest.request.getHeaders().contains("X-Header-D")
-        sentRequest.request.getHeaders().findAll("X-Header-D").contains("a")
-        sentRequest.request.getHeaders().findAll("X-Header-D").contains("b")
-        sentRequest.request.getHeaders().findAll("X-Header-D").contains("c")
+        sentRequest.request.getHeaders().contains("X-ManyToOne-D")
+        sentRequest.request.getHeaders().findAll("X-ManyToOne-D").contains("a")
+        sentRequest.request.getHeaders().findAll("X-ManyToOne-D").contains("b")
+        sentRequest.request.getHeaders().findAll("X-ManyToOne-D").contains("c")
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a", "X-Header-B" : "b", "X-Header-C" : "c"]
-        "GET"  | ["X-Header-A" : "a", "X-Header-B" : "b", "X-Header-C" : "c"]
+        "POST" | ["X-ManyToOne-A" : "a", "X-ManyToOne-B" : "b", "X-ManyToOne-C" : "c"]
+        "GET"  | ["X-ManyToOne-A" : "a", "X-ManyToOne-B" : "b", "X-ManyToOne-C" : "c"]
     }
 
     def "when translating request headers translating to existing header"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/translatingToExistingHeader" )
-        repose.start()
 
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        sentRequest.request.getHeaders().contains("X-Header-A")
+        sentRequest.request.getHeaders().contains("X-ToExisting-A")
         sentRequest.request.getHeaders().contains("X-Header-Existing")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-A").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().getFirstValue("X-ToExisting-A").equalsIgnoreCase("a")
         sentRequest.request.getHeaders().findAll("x-header-existing").contains("a")
         sentRequest.request.getHeaders().findAll("x-header-existing").contains("b")
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a", "X-Header-Existing" : "b"]
-        "GET"  | ["X-Header-A" : "a", "X-Header-Existing" : "b"]
+        "POST" | ["X-ToExisting-A" : "a", "X-Header-Existing" : "b"]
+        "GET"  | ["X-ToExisting-A" : "a", "X-Header-Existing" : "b"]
     }
 
     def "when translating request headers with mixed case"() {
-        setup: "load the correct configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/caseSensitivityHeaders" )
-        repose.start()
 
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)
         def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
 
         then: "origin receives translated headers"
-        sentRequest.request.getHeaders().contains("X-Header-A")
-        sentRequest.request.getHeaders().contains("X-Header-B")
-        sentRequest.request.getHeaders().contains("X-Header-C")
-        sentRequest.request.getHeaders().contains("X-Header-D")
-        sentRequest.request.getHeaders().contains("X-Header-E")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-A").equalsIgnoreCase("a")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-B").equalsIgnoreCase("b")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-C").equalsIgnoreCase("c")
-        sentRequest.request.getHeaders().getFirstValue("X-Header-D").equalsIgnoreCase("a")
-        sentRequest.request.getHeaders().findAll("x-header-e").contains("b")
-        sentRequest.request.getHeaders().findAll("x-header-e").contains("c")
+        sentRequest.request.getHeaders().contains("X-Mixedcase-A")
+        sentRequest.request.getHeaders().contains("X-Mixedcase-B")
+        sentRequest.request.getHeaders().contains("X-Mixedcase-C")
+        sentRequest.request.getHeaders().contains("X-Mixedcase-D")
+        sentRequest.request.getHeaders().contains("X-Mixedcase-E")
+        sentRequest.request.getHeaders().getFirstValue("X-Mixedcase-A").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().getFirstValue("X-Mixedcase-B").equalsIgnoreCase("b")
+        sentRequest.request.getHeaders().getFirstValue("X-Mixedcase-C").equalsIgnoreCase("c")
+        sentRequest.request.getHeaders().getFirstValue("X-Mixedcase-D").equalsIgnoreCase("a")
+        sentRequest.request.getHeaders().findAll("x-mixedcase-e").contains("b")
+        sentRequest.request.getHeaders().findAll("x-mixedcase-e").contains("c")
 
         where:
         method | reqHeaders
-        "POST" | ["X-Header-A" : "a", "X-Header-B" : "b", "X-Header-C" : "c"]
-        "GET"  | ["X-Header-A" : "a", "X-Header-B" : "b", "X-Header-C" : "c"]
+        "POST" | ["X-Mixedcase-A" : "a", "X-Mixedcase-B" : "b", "X-Mixedcase-C" : "c"]
+        "GET"  | ["X-Mixedcase-A" : "a", "X-Mixedcase-B" : "b", "X-Mixedcase-C" : "c"]
     }
 
 
     def "when translating CSL request headers"() {
-        setup: "load the csl configuration file"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/csl" )
-        repose.start()
 
         when: "client passes a request through repose with headers to be translated"
         def respFromOrigin = deproxy.makeRequest((String) reposeEndpoint, method, reqHeaders)


### PR DESCRIPTION
1. Flaky tests in jenkins due to rapid create/teardown of the deproxy endpoint, and the deproxy endpoint port is not being freed up quickly enough before the next test starts
2. Refactored the header translation tests so that different test cases can be executed using one header translation config file.  This also has the added benefit of reducing the test time for this test class from 5min 47sec to 14 sec.  Boom.
