### PR TITLE
STOP THE LINE - i broke some new tests

### DIFF
--- a/test/spock-functional-test/src/test/configs/features/filters/headertranslation/perftest/header-transform.xsl
+++ b/test/spock-functional-test/src/test/configs/features/filters/headertranslation/perftest/header-transform.xsl
@@ -38,14 +38,14 @@
     <xsl:template match="httpx:header">
         <xsl:choose>
 
-            <xsl:when test="@name = 'x-header-a'" >
+            <xsl:when test="@name = 'x-onetomany-a'" >
                 <xsl:element name="httpx:header">
-                    <xsl:attribute name="name"><xsl:value-of select="'x-header-c'"/></xsl:attribute>
+                    <xsl:attribute name="name"><xsl:value-of select="'x-onetomany-c'"/></xsl:attribute>
                     <xsl:attribute name="value"><xsl:value-of select="@value"/></xsl:attribute>
                     <xsl:attribute name="quality"><xsl:value-of select="@quality"/></xsl:attribute>
                 </xsl:element>
                 <xsl:element name="httpx:header">
-                    <xsl:attribute name="name"><xsl:value-of select="'x-header-d'"/></xsl:attribute>
+                    <xsl:attribute name="name"><xsl:value-of select="'x-onetomany-d'"/></xsl:attribute>
                     <xsl:attribute name="value"><xsl:value-of select="@value"/></xsl:attribute>
                     <xsl:attribute name="quality"><xsl:value-of select="@quality"/></xsl:attribute>
                 </xsl:element>

--- a/test/spock-functional-test/src/test/groovy/features/filters/headertranslation/PerformanceTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/headertranslation/PerformanceTest.groovy
@@ -10,47 +10,44 @@ import org.rackspace.gdeproxy.MessageChain
 
 class PerformanceTest extends ReposeValveTest {
 
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
+    }
+
+    def cleanupSpec() {
+        deproxy.shutdown()
+    }
+
 
     def "performance test configs produce expected responses"() {
         when: "I make a request through header translation filter"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/oneToMany" )
+        repose.applyConfigs( "features/filters/headertranslation/common")
         repose.start()
-        deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
-        MessageChain mcHdrXlate = deproxy.makeRequest(reposeEndpoint, "GET", ["X-Header-A":"12345", "X-Header-B":"abcde"])
-
+        MessageChain mcHdrXlate = deproxy.makeRequest(reposeEndpoint, "GET", ["X-OneToMany-A":"12345", "X-OneToMany-B":"abcde"])
         repose.stop()
-        deproxy.shutdown()
 
         and: "I make a request through header translation filter"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/oneToMany" )
+        repose.applyConfigs( "features/filters/headertranslation/perftest")
         repose.start()
-        deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
-        MessageChain mcTranslation = deproxy.makeRequest(reposeEndpoint, "GET", ["X-Header-A":"12345", "X-Header-B":"abcde"])
-
+        MessageChain mcTranslation = deproxy.makeRequest(reposeEndpoint, "GET", ["X-OneToMany-A":"12345", "X-OneToMany-B":"abcde"])
         repose.stop()
-        deproxy.shutdown()
 
-        then:
-
+        then: "Headers are translated correctly by HDR XLATE"
         def mcHdrHandling = mcHdrXlate.handlings.get(0)
+        mcHdrHandling.request.headers.contains("X-OneToMany-A")
+        mcHdrHandling.request.headers.contains("X-OneToMany-C")
+        mcHdrHandling.request.headers.contains("X-OneToMany-D")
+        mcHdrHandling.request.headers.getFirstValue("X-OneToMany-C") == mcHdrXlate.sentRequest.headers.getFirstValue("X-OneToMany-A")
+        mcHdrHandling.request.headers.getFirstValue("X-OneToMany-D") == mcHdrXlate.sentRequest.headers.getFirstValue("X-OneToMany-A")
 
-        mcHdrHandling.request.headers.contains("X-Header-A")
-        mcHdrHandling.request.headers.contains("X-Header-C")
-        mcHdrHandling.request.headers.contains("X-Header-D")
-        mcHdrHandling.request.headers.getFirstValue("X-Header-C") == mcHdrXlate.sentRequest.headers.getFirstValue("X-Header-A")
-        mcHdrHandling.request.headers.getFirstValue("X-Header-D") == mcHdrXlate.sentRequest.headers.getFirstValue("X-Header-A")
-
-        then:
+        then: "Headers are translated correctly by Translation Filter"
         def mcTransHandling = mcTranslation.handlings.get(0)
-        mcTransHandling.request.headers.contains("X-Header-A")
-        mcTransHandling.request.headers.contains("X-Header-C")
-        mcTransHandling.request.headers.contains("X-Header-D")
-        mcTransHandling.request.headers.getFirstValue("X-Header-C") == mcTranslation.sentRequest.headers.getFirstValue("X-Header-A")
-        mcTransHandling.request.headers.getFirstValue("X-Header-D") == mcTranslation.sentRequest.headers.getFirstValue("X-Header-A")
+        mcTransHandling.request.headers.contains("X-OneToMany-A")
+        mcTransHandling.request.headers.contains("X-OneToMany-C")
+        mcTransHandling.request.headers.contains("X-OneToMany-D")
+        mcTransHandling.request.headers.getFirstValue("X-OneToMany-C") == mcTranslation.sentRequest.headers.getFirstValue("X-OneToMany-A")
+        mcTransHandling.request.headers.getFirstValue("X-OneToMany-D") == mcTranslation.sentRequest.headers.getFirstValue("X-OneToMany-A")
     }
 
     def "performance test to ensure header translation is on par or better than translation filter"() {
@@ -58,23 +55,16 @@ class PerformanceTest extends ReposeValveTest {
         int totalRequests = 1000
 
         when: "I make 100 requests through header translation filter"
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/oneToMany" )
+        repose.applyConfigs( "features/filters/headertranslation/common")
         repose.start()
-        deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
         def averageWithHdrXlate = makeRequests(totalRequests)
         repose.stop()
-        deproxy.shutdown()
 
         and: "I make 100 requests through translation filter"
         repose.applyConfigs( "features/filters/headertranslation/perftest")
         repose.start()
-        deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
         def averageWithTranslationFilter = makeRequests(totalRequests)
         repose.stop()
-        deproxy.shutdown()
 
         then: "Average response time for header translation is <= avg response time for translation filter"
         println("HDR XLATE: " + averageWithHdrXlate + " Translation: " + averageWithTranslationFilter)

--- a/test/spock-functional-test/src/test/groovy/features/filters/headertranslation/ReliabilityTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/headertranslation/ReliabilityTest.groovy
@@ -14,8 +14,7 @@ class ReliabilityTest extends ReposeValveTest {
 
     //Start repose once for this particular translation test
     def setupSpec() {
-        repose.applyConfigs( "features/filters/headertranslation/common",
-                "features/filters/headertranslation/oneToMany" )
+        repose.applyConfigs( "features/filters/headertranslation/common")
         repose.start()
         deproxy = new Deproxy()
         deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
@@ -23,7 +22,7 @@ class ReliabilityTest extends ReposeValveTest {
         def missingHeaderErrorHandler = { Request request ->
             def headers = request.getHeaders()
 
-            if (!headers.contains("X-Header-C") || !headers.contains("X-Header-D")) {
+            if (!headers.contains("X-OneToMany-C") || !headers.contains("X-OneToMany-D")) {
                 return new Response(500, "INTERNAL SERVER ERROR", null, "MISSING HEADERS")
             }
 
@@ -57,7 +56,7 @@ class ReliabilityTest extends ReposeValveTest {
                     def HttpClient client = new DefaultHttpClient()
 
                     HttpGet httpGet = new HttpGet(reposeEndpoint)
-                    httpGet.addHeader('X-Header-A','lisa.rocks')
+                    httpGet.addHeader('X-OneToMany-A','lisa.rocks')
                     httpGet.addHeader('thread-name', 'spock-thread-'+threadNum+'-request-'+i)
 
                     HttpResponse response = client.execute(httpGet)

--- a/test/spock-functional-test/src/test/groovy/features/filters/translation/TranslateResponseTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/translation/TranslateResponseTest.groovy
@@ -35,19 +35,13 @@ class TranslateResponseTest extends ReposeValveTest {
                 "features/filters/translation/response"
         )
         repose.start()
-    }
-
-    def setup() {
 
         deproxy = new Deproxy()
         deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
     }
 
-    def cleanup() {
-        deproxy.shutdown()
-    }
-
     def cleanupSpec() {
+        deproxy.shutdown()
         repose.stop()
     }
 
@@ -106,7 +100,7 @@ class TranslateResponseTest extends ReposeValveTest {
 
     def "when attempting to translate an invalid xml/json response"() {
 
-        given: "Origin serivce returns invalid json/xml"
+        given: "Origin service returns invalid json/xml"
         def xmlResp = { request -> return new Response(200, "OK", respHeaders, respBody) }
 
 

--- a/test/spock-functional-test/src/test/groovy/features/filters/uristripper/UriStripperLocationRewriteTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/uristripper/UriStripperLocationRewriteTest.groovy
@@ -1,4 +1,4 @@
-package features.filters.uristripper.locationrewrite
+package features.filters.uristripper
 
 import framework.ReposeValveTest
 import org.rackspace.gdeproxy.Deproxy
@@ -44,7 +44,7 @@ class UriStripperLocationRewriteTest extends ReposeValveTest {
 
     }
 
-    @Unroll("Location header should be changed when repose can find a place to place removed token: request path: #requestPath location header: #locationheader contains tenant: #containsTenant")
+    @Unroll("Location header is modified when path: #requestPath location: #locationheader contains tenant: #containsTenant")
     def "when putting back tenant id to Location Header within the Response"() {
 
         given:

--- a/test/spock-functional-test/src/test/groovy/features/filters/uristripper/UriStripperNoLocationRewriteTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/uristripper/UriStripperNoLocationRewriteTest.groovy
@@ -1,4 +1,4 @@
-package features.filters.uristripper.nolocationrewrite
+package features.filters.uristripper
 
 import framework.ReposeValveTest
 import org.rackspace.gdeproxy.Deproxy


### PR DESCRIPTION
1. I broke tests by removing the oneToMany config directory.  Updated those tests.
2. Modified the package structure for uristripper - caused weird Junit test name output
3. Made the TranslateResponseTest less flaky by moving deproxy setup/shutdown to setupSpec/cleanupSpec
