### PR TITLE
B-56715 - remove console out and debug logging from packaged log4j.prope...

### DIFF
--- a/project-set/installation/configs/core/log4j.properties
+++ b/project-set/installation/configs/core/log4j.properties
@@ -1,5 +1,5 @@
 # Set root logger level
-log4j.rootLogger=DEBUG, consoleOut, defaultFile
+log4j.rootLogger=INFO, defaultFile
 
 # Console
 log4j.appender.consoleOut=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
Small change to the log4j.properties default file that gets packaged up into our install bundles.  Removed console out as a default appender, and changed logging from DEBUG to INFO as default settings.
