### PR TITLE
Start and stop the deproxy at the same time as Repose.

### DIFF
--- a/test/spock-functional-test/src/test/groovy/features/filters/translation/TranslationMultiMatchTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/translation/TranslationMultiMatchTest.groovy
@@ -24,6 +24,9 @@ class TranslationMultiMatchTest extends ReposeValveTest {
     //Start repose once for this particular translation test
     def setupSpec() {
 
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
+
         repose.applyConfigs(
                 "features/filters/translation/common",
                 "features/filters/translation/multimatch"
@@ -31,18 +34,9 @@ class TranslationMultiMatchTest extends ReposeValveTest {
         repose.start()
     }
 
-    def setup() {
-
-        deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
-    }
-
-    def cleanup() {
-        deproxy.shutdown()
-    }
-
     def cleanupSpec() {
         repose.stop()
+        deproxy.shutdown()
     }
 
     def "when translating responses"() {

--- a/test/spock-functional-test/src/test/groovy/features/filters/translation/TranslationRequestTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/translation/TranslationRequestTest.groovy
@@ -31,6 +31,9 @@ class TranslationRequestTest extends ReposeValveTest {
     //Start repose once for this particular translation test
     def setupSpec() {
 
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
+
         repose.applyConfigs(
                 "features/filters/translation/common",
                 "features/filters/translation/request"
@@ -38,18 +41,9 @@ class TranslationRequestTest extends ReposeValveTest {
         repose.start()
     }
 
-    def setup() {
-
-        deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
-    }
-
-    def cleanup() {
-        deproxy.shutdown()
-    }
-
     def cleanupSpec() {
         repose.stop()
+        deproxy.shutdown()
     }
 
     def "when translating requests"() {

--- a/test/spock-functional-test/src/test/groovy/features/filters/translation/saxonEE/TranslationSaxonEEFunctionalityTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/translation/saxonEE/TranslationSaxonEEFunctionalityTest.groovy
@@ -29,6 +29,9 @@ class TranslationSaxonEEFunctionalityTest extends ReposeValveTest {
     //Start repose once for this particular translation test
     def setupSpec() {
 
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
+
         def saxonHome = System.getenv("SAXON_HOME")
 
         assert saxonHome != null
@@ -42,19 +45,9 @@ class TranslationSaxonEEFunctionalityTest extends ReposeValveTest {
         repose.start()
     }
 
-    def setup() {
-
-        deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
-    }
-
-    def cleanup() {
-        deproxy.shutdown()
-    }
-
     def cleanupSpec() {
-        deproxy.shutdown()
         repose.stop()
+        deproxy.shutdown()
     }
 
     def "when translating json within xml in the request body"() {


### PR DESCRIPTION
This should fix the spock test failures after https://github.com/rackerlabs/repose/pull/673 
