### PR TITLE
Fixing client admin token failure

### DIFF
--- a/project-set/commons/utilities/src/main/java/com/rackspace/papi/commons/util/http/ServiceClient.java
+++ b/project-set/commons/utilities/src/main/java/com/rackspace/papi/commons/util/http/ServiceClient.java
@@ -1,9 +1,7 @@
 package com.rackspace.papi.commons.util.http;
 
 
-import com.rackspace.papi.commons.util.StringUriUtilities;
 import com.rackspace.papi.commons.util.io.RawInputStreamReader;
-import com.rackspace.papi.commons.util.proxy.ProxyRequestException;
 import com.rackspace.papi.service.httpclient.HttpClientNotFoundException;
 import com.rackspace.papi.service.httpclient.HttpClientService;
 
@@ -14,7 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.net.ssl.*;
 import javax.ws.rs.core.MediaType;
-import javax.xml.bind.JAXBElement;
 import java.util.Set;
 
 
@@ -140,7 +137,8 @@ public class ServiceClient {
         return new ServiceClientResponse(HttpStatusCode.INTERNAL_SERVER_ERROR.intValue(), null);
     }
 
-    public ServiceClientResponse post(String uri, JAXBElement body, MediaType contentType) {
+    public ServiceClientResponse post(String uri, String body, MediaType contentType) {
+
         HttpPost post = new HttpPost(uri);
 
         Map<String, String> headers= new HashMap<String, String>();
@@ -150,8 +148,8 @@ public class ServiceClient {
 
         setHeaders(post, headers);
 
-        if (body != null && !body.getValue().toString().isEmpty()) {
-            post.setEntity(new InputStreamEntity(new ByteArrayInputStream(body.getValue().toString().getBytes()),body.getValue().toString().length()));
+        if (body != null && !body.isEmpty()) {
+            post.setEntity(new InputStreamEntity(new ByteArrayInputStream(body.getBytes()),body.length()));
         }
         return execute(post);
     }

--- a/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/atomfeed/sax/AdminTokenProviderTest.java
+++ b/project-set/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/atomfeed/sax/AdminTokenProviderTest.java
@@ -30,6 +30,8 @@ import org.openstack.docs.identity.api.v2.ServiceForCatalog;
 import org.openstack.docs.identity.api.v2.TenantForAuthenticateResponse;
 import org.openstack.docs.identity.api.v2.Token;
 import org.openstack.docs.identity.api.v2.UserForAuthenticateResponse;
+
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Matchers.*;
@@ -41,10 +43,7 @@ public class AdminTokenProviderTest {
 
    @Before
    public void setUp() {
-
       client = mock(ServiceClient.class);
-
-
    }
 
    @Test
@@ -66,7 +65,7 @@ public class AdminTokenProviderTest {
       
       InputStream is = new ByteArrayInputStream(baos.toByteArray());
       ServiceClientResponse<AuthenticateResponse> resp = new ServiceClientResponse<AuthenticateResponse>(200, is);
-      when(client.post(anyString(), any(JAXBElement.class), eq(MediaType.APPLICATION_XML_TYPE))).thenReturn(resp);
+      when(client.post(anyString(), anyString(), eq(MediaType.APPLICATION_XML_TYPE))).thenReturn(resp);
       provider = new AdminTokenProvider(client, "authUrl", "user", "pass");
 
       String adminToken = provider.getAdminToken();

--- a/project-set/external/service-clients/auth/src/main/java/com/rackspace/auth/openstack/AuthenticationServiceFactory.java
+++ b/project-set/external/service-clients/auth/src/main/java/com/rackspace/auth/openstack/AuthenticationServiceFactory.java
@@ -3,6 +3,7 @@ package com.rackspace.auth.openstack;
 import com.rackspace.auth.AuthServiceException;
 import com.rackspace.auth.ResponseUnmarshaller;
 import com.rackspace.papi.commons.util.http.ServiceClient;
+import com.rackspace.papi.commons.util.transform.jaxb.JaxbEntityToXml;
 import com.rackspace.papi.service.httpclient.HttpClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ public class AuthenticationServiceFactory {
       return new AuthenticationServiceClient(targetHostUri, username, password, tenantId,
               new ResponseUnmarshaller(coreJaxbContext),
               new ResponseUnmarshaller(groupJaxbContext),
+              new JaxbEntityToXml(coreJaxbContext),
               new ServiceClient(connectionPoolId, httpClientService));
    }
 }

--- a/project-set/external/service-clients/auth/src/test/java/com/rackspace/auth/openstack/AuthenticationServiceClientTest.java
+++ b/project-set/external/service-clients/auth/src/test/java/com/rackspace/auth/openstack/AuthenticationServiceClientTest.java
@@ -5,6 +5,7 @@ import com.rackspace.auth.ResponseUnmarshaller;
 import com.rackspace.papi.commons.util.http.HttpStatusCode;
 import com.rackspace.papi.commons.util.http.ServiceClient;
 import com.rackspace.papi.commons.util.http.ServiceClientResponse;
+import com.rackspace.papi.commons.util.transform.jaxb.JaxbEntityToXml;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +14,6 @@ import org.junit.runner.RunWith;
 import org.openstack.docs.identity.api.v2.AuthenticateResponse;
 
 import javax.ws.rs.core.MediaType;
-import javax.xml.bind.JAXBElement;
 import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
@@ -52,7 +52,7 @@ public class AuthenticationServiceClientTest {
             serviceClient = mock(ServiceClient.class);
             authenticationServiceClient =
                     new AuthenticationServiceClient(targetHostUri, username, password, tenantId, responseUnmarshaller,
-                                                    responseUnmarshaller, serviceClient);
+                                                    responseUnmarshaller, mock(JaxbEntityToXml.class), serviceClient);
         }
 
         @After
@@ -64,7 +64,7 @@ public class AuthenticationServiceClientTest {
         public void shouldErrorWithCorrectMessageForInternalServerErrorCase() {
             when(serviceClient.get(anyString(), any(Map.class), anyString(), anyString(),anyString()))
                     .thenReturn(serviceClientResponseGet);
-            when(serviceClient.post(anyString(), any(JAXBElement.class), any(MediaType.class)))
+            when(serviceClient.post(anyString(), anyString(), any(MediaType.class)))
                     .thenReturn(serviceClientResponsePost);
             when(serviceClientResponseGet.getStatusCode()).thenReturn(HttpStatusCode.INTERNAL_SERVER_ERROR.intValue());
             when(serviceClientResponsePost.getStatusCode()).thenReturn(HttpStatusCode.INTERNAL_SERVER_ERROR.intValue());
@@ -79,7 +79,7 @@ public class AuthenticationServiceClientTest {
         public void shouldErrorWithCorrectMessageForDefaultErrorCase() {
             when(serviceClient.get(anyString(), any(Map.class), anyString(), anyString()))
                     .thenReturn(serviceClientResponseGet);
-            when(serviceClient.post(anyString(), any(JAXBElement.class), any(MediaType.class)))
+            when(serviceClient.post(anyString(), anyString(), any(MediaType.class)))
                     .thenReturn(serviceClientResponsePost);
             when(serviceClientResponseGet.getStatusCode()).thenReturn(999);
             when(serviceClientResponsePost.getStatusCode()).thenReturn(999);

--- a/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/IdentityServiceResponseSimulator.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/IdentityServiceResponseSimulator.groovy
@@ -6,7 +6,11 @@ import org.rackspace.gdeproxy.Request
 import org.rackspace.gdeproxy.Response
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormat;
-import org.joda.time.DateTimeZone;
+import org.joda.time.DateTimeZone
+
+import javax.xml.XMLConstants
+import javax.xml.transform.stream.StreamSource
+import javax.xml.validation.SchemaFactory;
 
 /**
  * Simulates responses from an Identity Service


### PR DESCRIPTION
Fix for the client auth-N issue where client auth-N was sending a bad body on POST to retrieve the admin token.
