### PR TITLE
Updated api validator jmx to not use absolute numbers in assertions

### DIFF
--- a/test/spock-functional-test/src/test/groovy/features/filters/apivalidator/ApiValidatorJMXTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/apivalidator/ApiValidatorJMXTest.groovy
@@ -22,25 +22,17 @@ class ApiValidatorJMXTest extends ReposeValveTest {
     String API_VALIDATOR_ALL = PREFIX + "api-validator" + NAME_ROLE_ALL
 
     def setupSpec() {
-        deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
-    }
-
-    def setup() {
-        // TODO move repose startup to startupSpec(), clear MBeans in setup()
         repose.applyConfigs(
                 "features/filters/apivalidator/common",
                 "features/filters/apivalidator/jmx")
         repose.start()
-        sleep(15000)
-    }
-
-    def cleanup() {
-        repose.stop()
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.getProperty("target.port").toInteger())
     }
 
     def cleanupSpec() {
         deproxy.shutdown()
+        repose.stop()
     }
 
     def "when loading validators on startup, should register validator MXBeans"() {
@@ -72,103 +64,175 @@ class ApiValidatorJMXTest extends ReposeValveTest {
         afterUpdateBeans.size() == 2
         afterUpdateBeans.each { updatedBean ->
             beforeUpdateBeans.each {
-                updatedBean.name != it.name
+                assert(updatedBean.name != it.name)
             }
         }
     }
 
     def "when request is for role-1, should increment invalid request for ApiValidator mbeans for role 1"() {
+        given:
+        def validator1Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count")
+        validator1Target = (validator1Target == null) ? 0 : validator1Target
+        def validator2Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count")
+        validator2Target = (validator2Target == null) ? 0 : validator2Target
+        def validator3Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count")
+        validator3Target = (validator3Target == null) ? 0 : validator3Target
+        def validatorAllTarget = repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count")
+        validatorAllTarget = (validatorAllTarget == null) ? 0 : validatorAllTarget
 
         when:
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "post",headers:['X-Roles':'role-1']])
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "get",headers:['X-Roles':'role-1']])
 
         then:
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == 1
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == (validator1Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == ((validator2Target == 0) ? null : validator2Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == ((validator3Target == 0) ? null : validator3Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == (validatorAllTarget + 1)
     }
 
     def "when request is for role-2, should increment invalid request for ApiValidator mbeans for role 2"() {
+        given:
+        def validator1Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count")
+        validator1Target = (validator1Target == null) ? 0 : validator1Target
+        def validator2Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count")
+        validator2Target = (validator2Target == null) ? 0 : validator2Target
+        def validator3Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count")
+        validator3Target = (validator3Target == null) ? 0 : validator3Target
+        def validatorAllTarget = repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count")
+        validatorAllTarget = (validatorAllTarget == null) ? 0 : validatorAllTarget
 
         when:
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "post",headers:['X-Roles':'role-2']])
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "get",headers:['X-Roles':'role-2']])
 
         then:
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == 1
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == (validator2Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == ((validator1Target == 0) ? null : validator1Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == ((validator3Target == 0) ? null : validator3Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == (validatorAllTarget + 1)
     }
 
     def "when request is for role-3, should increment invalid request for ApiValidator mbeans for role 3"() {
+        given:
+        def validator1Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count")
+        validator1Target = (validator1Target == null) ? 0 : validator1Target
+        def validator2Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count")
+        validator2Target = (validator2Target == null) ? 0 : validator2Target
+        def validator3Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count")
+        validator3Target = (validator3Target == null) ? 0 : validator3Target
+        def validatorAllTarget = repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count")
+        validatorAllTarget = (validatorAllTarget == null) ? 0 : validatorAllTarget
 
         when:
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "get",headers:['X-Roles':'role-3']])
         deproxy.makeRequest([url: reposeEndpoint + "/non-resource", method: "get",headers:['X-Roles':'role-3']])
 
         then:
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == 1
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == (validator3Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == ((validator2Target == 0) ? null : validator2Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == ((validator1Target == 0) ? null : validator1Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == (validatorAllTarget + 1)
     }
 
     def "when request is for role-3 and role-2, should increment invalid request for ApiValidator mbeans for role 3 and role 2"() {
+        given:
+        def validator1Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count")
+        validator1Target = (validator1Target == null) ? 0 : validator1Target
+        def validator2Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count")
+        validator2Target = (validator2Target == null) ? 0 : validator2Target
+        def validator3Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count")
+        validator3Target = (validator3Target == null) ? 0 : validator3Target
+        def validatorAllTarget = repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count")
+        validatorAllTarget = (validatorAllTarget == null) ? 0 : validatorAllTarget
 
         when:
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "get",headers:['X-Roles':'role-3, role-2']])
         deproxy.makeRequest([url: reposeEndpoint + "/non-resource", method: "get",headers:['X-Roles':'role-3, role-2']])
 
         then:
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == 2
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == (validator3Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == (validator2Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == ((validator1Target == 0) ? null : validator1Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == (validatorAllTarget + 2)
     }
 
     def "when request is for role-3 and role-1, should increment invalid request for ApiValidator mbeans for role 3 and role 1"() {
+        given:
+        def validator1Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count")
+        validator1Target = (validator1Target == null) ? 0 : validator1Target
+        def validator2Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count")
+        validator2Target = (validator2Target == null) ? 0 : validator2Target
+        def validator3Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count")
+        validator3Target = (validator3Target == null) ? 0 : validator3Target
+        def validatorAllTarget = repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count")
+        validatorAllTarget = (validatorAllTarget == null) ? 0 : validatorAllTarget
 
         when:
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "get",headers:['X-Roles':'role-3, role-1']])
         deproxy.makeRequest([url: reposeEndpoint + "/non-resource", method: "get",headers:['X-Roles':'role-3, role-1']])
 
         then:
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == 2
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == (validator3Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == ((validator2Target == 0) ? null : validator2Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == (validator1Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == (validatorAllTarget + 2)
     }
 
     def "when request is for role-1 and role-2, should increment invalid request for ApiValidator mbeans for role 1 and role 2"() {
+        given:
+        def validator1Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count")
+        validator1Target = (validator1Target == null) ? 0 : validator1Target
+        def validator2Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count")
+        validator2Target = (validator2Target == null) ? 0 : validator2Target
+        def validator3Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count")
+        validator3Target = (validator3Target == null) ? 0 : validator3Target
+        def validatorAllTarget = repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count")
+        validatorAllTarget = (validatorAllTarget == null) ? 0 : validatorAllTarget
 
         when:
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "get",headers:['X-Roles':'role-1, role-2']])
         deproxy.makeRequest([url: reposeEndpoint + "/non-resource", method: "get",headers:['X-Roles':'role-1, role-2']])
 
         then:
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == null
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == 2
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == ((validator3Target == 0) ? null : validator3Target)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == (validator2Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == (validator1Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == (validatorAllTarget + 2)
     }
 
     def "when request is for role-3, role-1 and role-2, should increment invalid request for ApiValidator mbeans for role 3, role 1, and role 2"() {
+        given:
+        def validator1Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count")
+        validator1Target = (validator1Target == null) ? 0 : validator1Target
+        def validator2Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count")
+        validator2Target = (validator2Target == null) ? 0 : validator2Target
+        def validator3Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count")
+        validator3Target = (validator3Target == null) ? 0 : validator3Target
+        def validatorAllTarget = repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count")
+        validatorAllTarget = (validatorAllTarget == null) ? 0 : validatorAllTarget
 
         when:
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "get",headers:['X-Roles':'role-3, role-2, role-1']])
         deproxy.makeRequest([url: reposeEndpoint + "/non-resource", method: "get",headers:['X-Roles':'role-3, role-2, role-1']])
 
         then:
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == 3
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == (validator3Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == (validator2Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == (validator1Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == (validatorAllTarget + 3)
     }
 
     def "when request is for api validator, should increment ApiValidator mbeans for all"() {
+        given:
+        def validator1Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count")
+        validator1Target = (validator1Target == null) ? 0 : validator1Target
+        def validator2Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count")
+        validator2Target = (validator2Target == null) ? 0 : validator2Target
+        def validator3Target = repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count")
+        validator3Target = (validator3Target == null) ? 0 : validator3Target
+        def validatorAllTarget = repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count")
+        validatorAllTarget = (validatorAllTarget == null) ? 0 : validatorAllTarget
 
         when:
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "post",headers:['X-Roles':'role-3']])
@@ -176,10 +240,9 @@ class ApiValidatorJMXTest extends ReposeValveTest {
         deproxy.makeRequest([url: reposeEndpoint + "/resource", method: "post",headers:['X-Roles':'role-1']])
 
         then:
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == 1
-        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == 3
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_3, "Count") == (validator3Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_2, "Count") == (validator2Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_1, "Count") == (validator1Target + 1)
+        repose.jmx.getMBeanAttribute(API_VALIDATOR_ALL, "Count") == (validatorAllTarget + 3)
     }
-
 }


### PR DESCRIPTION
Added given steps that initialize target values in order to compare them to asserted items.
