### PR TITLE
D-14567 Damage DD and Local DD Taking Over

### DIFF
--- a/project-set/components/datastore/src/main/java/com/rackspace/papi/components/datastore/hash/HashRingDatastore.java
+++ b/project-set/components/datastore/src/main/java/com/rackspace/papi/components/datastore/hash/HashRingDatastore.java
@@ -92,7 +92,7 @@ public class HashRingDatastore extends AbstractHashedDatastore {
     }
 
     private Object performAction(String name, byte[] id, DatastoreAction action, RemoteBehavior initialBehavior) {
-        boolean targetIsRemote;
+        boolean targetIsRemote = false;
 
         if (initialBehavior != RemoteBehavior.DISALLOW_FORWARDING) {
             RemoteBehavior remoteBehavior =
@@ -100,18 +100,20 @@ public class HashRingDatastore extends AbstractHashedDatastore {
 
             do {
                 final InetSocketAddress target = getTarget(id);
-                targetIsRemote = isRemoteTarget(target);
 
-                if (target != null && (targetIsRemote)) {
-                    LOG.debug("Routing datastore " + action.toString() + " request for, \"" + name + "\" to: " +
-                                      target.toString());
+                try {
+                    if (target != null && (targetIsRemote = isRemoteTarget(target))) {
+                        LOG.debug("Routing datastore " + action.toString() + " request for, \"" + name + "\" to: " +
+                                target.toString());
 
-                    try {
                         return action.performRemote(name, target, remoteBehavior);
-                    } catch (RemoteConnectionException rce) {
-                        clusterView.memberDamaged(target, rce.getMessage());
-                        remoteBehavior = RemoteBehavior.DISALLOW_FORWARDING;
                     }
+                } catch (RemoteConnectionException rce) {
+                    clusterView.memberDamaged(target, rce.getMessage());
+                    remoteBehavior = RemoteBehavior.DISALLOW_FORWARDING;
+                } catch (DatastoreOperationException doe) {
+                    clusterView.memberDamaged(target, doe.getMessage());
+                    remoteBehavior = RemoteBehavior.DISALLOW_FORWARDING;
                 }
             } while (targetIsRemote);
         } else {

--- a/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/datastore/impl/distributed/hash/HashRingDatastore.java
+++ b/project-set/core/core-lib/src/main/java/com/rackspace/papi/service/datastore/impl/distributed/hash/HashRingDatastore.java
@@ -1,12 +1,6 @@
 package com.rackspace.papi.service.datastore.impl.distributed.hash;
 
 import com.rackspace.papi.commons.util.io.ObjectSerializer;
-import com.rackspace.papi.service.datastore.impl.distributed.common.RemoteBehavior;
-import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.RemoteCommandExecutor;
-import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.RemoteConnectionException;
-import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.command.Delete;
-import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.command.Get;
-import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.command.Put;
 import com.rackspace.papi.service.datastore.Datastore;
 import com.rackspace.papi.service.datastore.DatastoreOperationException;
 import com.rackspace.papi.service.datastore.StoredElement;
@@ -14,6 +8,12 @@ import com.rackspace.papi.service.datastore.cluster.MutableClusterView;
 import com.rackspace.papi.service.datastore.encoding.EncodingProvider;
 import com.rackspace.papi.service.datastore.hash.MessageDigestFactory;
 import com.rackspace.papi.service.datastore.impl.AbstractHashedDatastore;
+import com.rackspace.papi.service.datastore.impl.distributed.common.RemoteBehavior;
+import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.RemoteCommandExecutor;
+import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.RemoteConnectionException;
+import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.command.Delete;
+import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.command.Get;
+import com.rackspace.papi.service.datastore.impl.distributed.hash.remote.command.Put;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
@malconis @rackerwilliams

I'm uncertain about catching the DatastoreOperationException here. From what I can tell, it isn't currently used for anything at higher levels of the call stack, but considering that we had left it for the rate limiting handler to catch prior to this, I wonder whether catching that exception is one of the datastore's responsibilities.

I've also considered having the isRemoteTarget(...) method of this class throw a RemoteConnectionException when catching a SocketException rather than a DatastoreOperationException. I'm not confident enough in my understanding to make that call right now, though.

The proposed changes seemed to be the most sure-fire way to fix the defect with minimal code change.
