### PR TITLE
STL: marking tests as flaky

### DIFF
--- a/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/AnotherCacheOffsetTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/AnotherCacheOffsetTest.groovy
@@ -1,8 +1,7 @@
 package features.filters.clientauthn.cache
-
 import features.filters.clientauthn.IdentityServiceResponseSimulator
 import framework.ReposeValveTest
-import framework.category.Slow
+import framework.category.Flaky
 import org.apache.commons.lang.RandomStringUtils
 import org.joda.time.DateTime
 import org.junit.experimental.categories.Category
@@ -10,7 +9,7 @@ import org.rackspace.gdeproxy.Deproxy
 import org.rackspace.gdeproxy.MessageChain
 import spock.lang.Shared
 
-@Category(Slow.class)
+@Category(Flaky)
 class AnotherCacheOffsetTest extends ReposeValveTest {
 
     @Shared def identityEndpoint

--- a/test/spock-functional-test/src/test/groovy/features/filters/headertranslation/PerformanceTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/headertranslation/PerformanceTest.groovy
@@ -1,13 +1,12 @@
 package features.filters.headertranslation
-
 import framework.ReposeValveTest
-import framework.category.Benchmark
+import framework.category.Flaky
 import org.joda.time.DateTime
 import org.junit.experimental.categories.Category
 import org.rackspace.gdeproxy.Deproxy
 import org.rackspace.gdeproxy.MessageChain
 
-@Category(Benchmark.class)
+@Category(Flaky)
 class PerformanceTest extends ReposeValveTest {
 
     def setupSpec() {


### PR DESCRIPTION
These tests run for me locally but fail sporadically when running in jenkins.  It appears that the additional time it takes to run in jenkins is influencing tests that expect consistent timings of code execution.
