### PR TITLE
Pushing guava lib down to 14.0.1

### DIFF
--- a/project-set/core/core-lib/pom.xml
+++ b/project-set/core/core-lib/pom.xml
@@ -122,7 +122,7 @@
       <dependency>
          <groupId>com.google.guava</groupId>
          <artifactId>guava</artifactId>
-         <version>15.0</version>
+         <version>14.0.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
In my update of google guava to the latest version (15.0), I missed the fact that api-checker is including a version that was more recent than our previous one (12.0) but less current than the latest one.

This issue only exposed itself when running in glassfish.  Don't I wish we had some automated functional tests running in glassfish!
