### PR TITLE
STL: D-14393 fixing broken functional test due to unnecessary test confi...

### DIFF
--- a/test/spock-functional-test/src/test/configs/features/filters/ratelimiting/datastore/rate-limiting.cfg.xml
+++ b/test/spock-functional-test/src/test/configs/features/filters/ratelimiting/datastore/rate-limiting.cfg.xml
@@ -3,8 +3,8 @@
 <rate-limiting datastore="distributed/hash-ring"  datastore-warn-limit="1" use-capture-groups="true" xmlns="http://docs.rackspacecloud.com/repose/rate-limiting/v1.0">
    <request-endpoint uri-regex="/limits" include-absolute-limits="false" />
  
-   <limit-group id="limited" groups="BETA_Group IP_Standard" default="true">
-       <limit uri="/*" uri-regex="/test" http-methods="GET" unit="HOUR" value="3" />
+   <limit-group id="limited" groups="BETA_Group IP_Standard" default="false">
+       <limit uri="/*" uri-regex="/(.*)" http-methods="GET" unit="HOUR" value="3" />
    </limit-group>
  
    <limit-group id="limited3" groups="BETA_Group1 IP_Standard1" default="false">


### PR DESCRIPTION
STL

DatastoreWarnLimitTest is breaking in jenkins.  After debugging it appears that the config used by this test was changed in such a way that it no longer works for this test.  Since this is the only test that uses this config, and is now broken, I just reverted the config back to its original settings, verified it runs locally.
