### PR TITLE
Remove calls to println in Identity service simulators.

### DIFF
--- a/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/IdentityServiceRemoveTenantedValidationResponseSimulator.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/IdentityServiceRemoveTenantedValidationResponseSimulator.groovy
@@ -180,7 +180,6 @@ class IdentityServiceRemoveTenantedValidationResponseSimulator {
 
         def body = templateEngine.createTemplate(template).make(params)
 
-        println body
         return new Response(code, null, headers, body)
     }
 

--- a/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/IdentityServiceResponseSimulator.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/IdentityServiceResponseSimulator.groovy
@@ -192,7 +192,6 @@ class IdentityServiceResponseSimulator {
 
         def body = templateEngine.createTemplate(template).make(params)
 
-        println body
         return new Response(code, null, headers, body)
     }
 

--- a/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/RackspaceIdentityServiceResponseSimulator.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/clientauthn/RackspaceIdentityServiceResponseSimulator.groovy
@@ -121,7 +121,6 @@ class RackspaceIdentityServiceResponseSimulator {
 
         def body = templateEngine.createTemplate(template).make(params)
 
-        println body
         return new Response(code, null, headers, body)
     }
 
@@ -169,7 +168,6 @@ Response handleGroupsCall(Request request) {
 
     def body = templateEngine.createTemplate(template).make(params)
 
-    println body
     return new Response(code, null, headers, body)
 
 }


### PR DESCRIPTION
There are a few calls to println in the identity service simulators They clog up the debug output on tests and make it harder to diagnose errors. This pull request removes those calls to println.
