### PR TITLE
This test was failing on the new jenkins, it cleary at some point had a ...

### DIFF
--- a/project-set/commons/configuration/src/test/java/com/rackspace/papi/commons/config/manager/LockedConfigurationUpdaterTest.java
+++ b/project-set/commons/configuration/src/test/java/com/rackspace/papi/commons/config/manager/LockedConfigurationUpdaterTest.java
@@ -83,7 +83,7 @@ public class LockedConfigurationUpdaterTest {
             t1.start();
             t2.start();
 
-            //Thread.sleep(20);
+            Thread.sleep(20);
             
             t1.join();
             t2.join();


### PR DESCRIPTION
...delay to enoucrage it working. I've added the delay back to see if it makes it more stable on jenkins.
