### PR TITLE
D-16092 - more tests for rate limiting capture groups.

### DIFF
--- a/test/spock-functional-test/src/test/groovy/features/filters/ratelimiting/CaptureGroupsTest.groovy
+++ b/test/spock-functional-test/src/test/groovy/features/filters/ratelimiting/CaptureGroupsTest.groovy
@@ -480,7 +480,7 @@ class CaptureGroupsTest extends Specification {
 
         when: "we make one request to the second url"
         mc = deproxy.makeRequest(url: url2, headers: headers)
-        then: "it should make it to the origin service"
+        then: "it should be blocked"
         mc.receivedResponse.code == "413"
         mc.handlings.size() == 0
 
@@ -524,7 +524,7 @@ class CaptureGroupsTest extends Specification {
 
         when: "we make one request to the second url"
         mc = deproxy.makeRequest(url: url2, headers: headers)
-        then: "it should make it to the origin service"
+        then: "it should be blocked"
         mc.receivedResponse.code == "413"
         mc.handlings.size() == 0
 


### PR DESCRIPTION
I realized that we're not taking URI percent-encoding into account. URI's with percent-encoded, non-reserved characters should be considered equivalent to their un-encoded forms, meaning they count toward the same rate limits. Also, capitalization of hex digits within percent-encoded URI's shouldn't make a difference either, as they are also equivalent forms of the same URI.
