### PR TITLE
copied mocks servlet to spock-functional tests repose_home

### DIFF
--- a/test/spock-functional-test/pom.xml
+++ b/test/spock-functional-test/pom.xml
@@ -61,7 +61,7 @@
         <repose.root.war.location>${repose.home}/${repose.root.war}</repose.root.war.location>
         <mocks.war.dir>${project.set.dir}/functional-tests/mocks-servlet/target</mocks.war.dir>
         <mocks.war>mocks-servlet-${project.version}.war</mocks.war>
-        <mocks.war.location>${mocks.war.dir}/${mocks.war}</mocks.war.location>
+        <mocks.war.location>${repose.home}/${mocks.war}</mocks.war.location>
     </properties>
 
 
@@ -398,6 +398,13 @@
                 <directory>${repose.root.war.directory}</directory>
                 <includes>
                     <include>${repose.root.war}</include>
+                </includes>
+                <targetPath>${project.build.directory}/repose_home</targetPath>
+            </testResource>
+            <testResource>
+                <directory>${mocks.war.dir}</directory>
+                <includes>
+                    <include>${mocks.war}</include>
                 </includes>
                 <targetPath>${project.build.directory}/repose_home</targetPath>
             </testResource>


### PR DESCRIPTION
Copies mocks servlet war to functional-tests target/repose_home directory. This is so the jenkins functional tests can run without having to build the functional-tests module
