### PR TITLE
Resolve build issues on some versions of maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,21 @@
         </snapshotRepository>
     </distributionManagement>
     
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>2.0.2-rax</version>
+            </dependency>
+            <dependency>
+                <groupId>xerces</groupId>
+                <artifactId>xerces-xsd11</artifactId>
+                <version>2.12.0-rax</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
This dependency manages those artifacts that we have custom versions of so that they consistently et resolved correctly. Originally i was only doing the one I needed on valve, but doing both artifacts at the top level is a better call, because it insures that they are always correct everywhere in the project.
