### PR TITLE
Fix failing client auth tests

### DIFF
--- a/repose-aggregator/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/atomfeed/AuthFeedListenerTest.java
+++ b/repose-aggregator/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/atomfeed/AuthFeedListenerTest.java
@@ -14,31 +14,22 @@ import com.rackspace.papi.components.clientauth.common.AuthUserCache;
 import com.rackspace.papi.components.clientauth.openstack.v1_0.OsAuthCachePrefix;
 import com.rackspace.papi.service.datastore.Datastore;
 import com.rackspace.papi.service.datastore.impl.ehcache.EHCacheDatastore;
-import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.config.Configuration;
+import org.junit.Before;
+import org.junit.Test;
+import org.openstack.docs.identity.api.v2.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.openstack.docs.identity.api.v2.AuthenticateResponse;
-import org.openstack.docs.identity.api.v2.Role;
-import org.openstack.docs.identity.api.v2.RoleList;
-import org.openstack.docs.identity.api.v2.ServiceCatalog;
-import org.openstack.docs.identity.api.v2.ServiceForCatalog;
-import org.openstack.docs.identity.api.v2.TenantForAuthenticateResponse;
-import org.openstack.docs.identity.api.v2.Token;
-import org.openstack.docs.identity.api.v2.UserForAuthenticateResponse;
 
 /**
  *
@@ -104,7 +95,8 @@ public class AuthFeedListenerTest {
 
       Token token = new Token();
       token.setId("tokenid");
-      GregorianCalendar cal = new GregorianCalendar(2013, 11, 12);
+      GregorianCalendar cal = new GregorianCalendar();
+      cal.add(Calendar.MONTH, 1);
       token.setExpires(new XMLGregorianCalendarImpl(cal));
       TenantForAuthenticateResponse tenantForAuthenticateResponse = new TenantForAuthenticateResponse();
       tenantForAuthenticateResponse.setId("tenantId");

--- a/repose-aggregator/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/atomfeed/FeedListenerManagerTest.java
+++ b/repose-aggregator/components/client-auth/src/test/java/com/rackspace/papi/components/clientauth/atomfeed/FeedListenerManagerTest.java
@@ -15,33 +15,21 @@ import com.rackspace.papi.components.clientauth.openstack.v1_0.OsAuthCachePrefix
 import com.rackspace.papi.service.datastore.Datastore;
 import com.rackspace.papi.service.datastore.impl.ehcache.EHCacheDatastore;
 import com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.config.Configuration;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.openstack.docs.identity.api.v2.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.openstack.docs.identity.api.v2.AuthenticateResponse;
-import org.openstack.docs.identity.api.v2.Role;
-import org.openstack.docs.identity.api.v2.RoleList;
-import org.openstack.docs.identity.api.v2.ServiceCatalog;
-import org.openstack.docs.identity.api.v2.ServiceForCatalog;
-import org.openstack.docs.identity.api.v2.TenantForAuthenticateResponse;
-import org.openstack.docs.identity.api.v2.Token;
-import org.openstack.docs.identity.api.v2.UserForAuthenticateResponse;
 
 /**
  *
@@ -107,7 +95,8 @@ public class FeedListenerManagerTest {
 
       Token token = new Token();
       token.setId("tokenid");
-      GregorianCalendar cal = new GregorianCalendar(2013, 11, 12);
+      GregorianCalendar cal = new GregorianCalendar();
+      cal.add(Calendar.MONTH, 1);
       token.setExpires(new XMLGregorianCalendarImpl(cal));
       TenantForAuthenticateResponse tenantForAuthenticateResponse = new TenantForAuthenticateResponse();
       tenantForAuthenticateResponse.setId("tenantId");


### PR DESCRIPTION
Made tests pass again. Instead of counting on a static date for expiration it is now always one month in the future.
