### PR TITLE
Removed unused version property

### DIFF
--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -14,10 +14,6 @@
    <name>Repose Core - Power API Core Library</name>
    <description>TODO</description>
 
-   <properties>
-      <reposeVersion>${project.version}</reposeVersion>
-   </properties>
-
    <packaging>jar</packaging>
 
    <dependencies>


### PR DESCRIPTION
Probably leftover from before we made the poms more consistent by inheriting the project version from the root pom.
