### PR TITLE
B 62709 upgrade script

### DIFF
--- a/repose-aggregator/installation/deb/repose-valve/src/deb/control/preinst
+++ b/repose-aggregator/installation/deb/repose-valve/src/deb/control/preinst
@@ -8,7 +8,7 @@ then
     #Detects if the Dist-Datastore filter is present in the system-model.cfg.xml file. If the filter is an active component then this installation will fail.
     if cat $SYSTEM_MODEL | sed '/<!--.*-->/d'| sed '/<!--/,/-->/d' | grep 'filter.*dist-datastore'
     then
-        echo "Unable to upgrade. system-model.cfg.xml file contains the depricated dist-datastore filter. Please remove and re-run upgrade. For more information on the upgrade:  https://repose.atlassian.net/wiki/display/REPOSE/Release+Notes#ReleaseNotes-Release3.0.0(InProgress:UpdatetoJava1.7,RemoveDDFilter,ModularizeDD,BugFixes)"
+        echo "Unable to upgrade. system-model.cfg.xml file contains the deprecated dist-datastore filter. Please remove and re-run upgrade. For more information on the upgrade:  https://repose.atlassian.net/wiki/display/REPOSE/Release+Notes#ReleaseNotes-Release3.0.0(InProgress:UpdatetoJava1.7,RemoveDDFilter,ModularizeDD,BugFixes)"
         exit 1
     else
         exit 0

--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -153,7 +153,7 @@
                                         #Detects if the Dist-Datastore filter is present in the system-model.cfg.xml file. If the filter is an active component then this installation will fail.
                                         if cat $SYSTEM_MODEL | sed '/&lt;!--.*--&gt;/d'| sed '/&lt;!--/,/--&gt;/d' | grep 'filter.*dist-datastore'
                                         then
-                                            echo "Unable to upgrade. system-model.cfg.xml file contains the depricated dist-datastore filter. Please remove and re-run upgrade. For more information on the upgrade:<![CDATA[ https://repose.atlassian.net/wiki/display/REPOSE/Release+Notes#ReleaseNotes-Release3.0.0(InProgress:UpdatetoJava1.7,RemoveDDFilter,ModularizeDD,BugFixes)]]>"
+                                            echo "Unable to upgrade. system-model.cfg.xml file contains the deprecated dist-datastore filter. Please remove and re-run upgrade. For more information on the upgrade:<![CDATA[ https://repose.atlassian.net/wiki/display/REPOSE/Release+Notes#ReleaseNotes-Release3.0.0(InProgress:UpdatetoJava1.7,RemoveDDFilter,ModularizeDD,BugFixes)]]>"
 
                                             exit 1
                                         else


### PR DESCRIPTION
This update adds a check for the repose-valve deb and rpm packages to stop installation if the 'dist-datastore' filter is present in the existing system-model.cfg.xml file.
