### PR TITLE
Glassfish resources are in maven central

### DIFF
--- a/repose-aggregator/functional-tests/glassfish-support/pom.xml
+++ b/repose-aggregator/functional-tests/glassfish-support/pom.xml
@@ -59,13 +59,4 @@
         </plugins>
 
     </build>
-
-    <repositories>
-        <repository>
-            <id>maven.java.net</id>
-            <name>Glassfish repository</name>
-            <url>http://maven.java.net/content/repositories/releases</url>
-            <!--url>http://download.java.net/maven/glassfish</url-->
-        </repository>
-    </repositories>
 </project>


### PR DESCRIPTION
This repo returns moved permanently, but whatever does the downloading
doesn't seem to honor that.

So this converts the repo to just use maven central, and now it all downloads correctly. Perhaps we should have a jenkins job that does nothing other than make sure we can always download all our artifacts?
