### PR TITLE
added cleaning of config directory per setupSpec for reposeValve tests

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/ReposeValveTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/ReposeValveTest.groovy
@@ -30,6 +30,7 @@ abstract class ReposeValveTest extends Specification {
         switch (properties.getReposeContainer().toLowerCase()) {
             case "valve":
                 configureReposeValve()
+                repose.configurationProvider.cleanConfigDirectory()
                 break
             case "tomcat":
                 throw new UnsupportedOperationException("Please implement me")


### PR DESCRIPTION
This commit clears out the config directory before a test runs so if multiple tests are ran then previous test configs don't interfere with the current test being executed.
