### PR TITLE
Fix the waits.

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/configloadingandreloading/StartWithBadConfigsTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/configloadingandreloading/StartWithBadConfigsTest.groovy
@@ -68,7 +68,7 @@ class StartWithBadConfigsTest extends Specification {
         reposeLogSearch = new ReposeLogSearch(properties.getLogFile());
         repose.start(killOthersBeforeStarting: false,
                 waitOnJmxAfterStarting: false)
-        repose.waitForNon500FromUrl(url)
+        repose.waitForDesiredResponseCodeFromUrl(url, [503])
 
 
         expect: "starting Repose with good configs should yield 503's"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/configloadingandreloading/TransitionBadToGoodConfigsTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/configloadingandreloading/TransitionBadToGoodConfigsTest.groovy
@@ -75,7 +75,7 @@ class TransitionBadToGoodConfigsTest extends Specification {
         // start repose
         repose.start(killOthersBeforeStarting: false,
                 waitOnJmxAfterStarting: false)
-        repose.waitForNon500FromUrl(url, 120)
+        repose.waitForDesiredResponseCodeFromUrl(url, [503], 120)
 
 
         expect: "starting Repose with good configs should yield 503's"


### PR DESCRIPTION
Changes in pull request #899 to the wait methods broke some of the config loading/reloading system tests. This fixes them.
