### PR TITLE
added missing container.cfg.xml to api-validator commons directory. test...

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/apivalidator/common/container.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/apivalidator/common/container.cfg.xml
@@ -1,0 +1,7 @@
+<repose-container xmlns='http://docs.rackspacecloud.com/repose/container/v2.0'>
+    <deployment-config  http-port="${reposePort}">
+        <deployment-directory auto-clean="true">${repose.home}</deployment-directory>
+        <artifact-directory check-interval="1000">${repose.home}/artifacts</artifact-directory>
+        <logging-configuration href="log4j.properties" />
+    </deployment-config>
+</repose-container>


### PR DESCRIPTION
...s were broken with my last commit which cleared config directories at the beginning of tests. The multivalidator test relied on tests running before it placing the container.cfg.xml file
