### PR TITLE
set false flag for multivalidator test to throw exception on process kil...

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/apivalidator/MultipleValidatorsTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/apivalidator/MultipleValidatorsTest.groovy
@@ -29,7 +29,8 @@ class MultipleValidatorsTest extends ReposeValveTest {
 
     def cleanupSpec() {
         if (repose)
-            repose.stop()
+            // TODO: Figure out a more elegant way for this test to shutdown.
+            repose.stop(throwExceptionOnKill: false)
         if (deproxy)
             deproxy.shutdown()
     }


### PR DESCRIPTION
...l. this test is taking too long to kill the validators so was causing job failures
