### PR TITLE
Modulate the timebomb

### DIFF
--- a/repose-aggregator/commons/utilities/src/test/groovy/com/rackspace/papi/commons/util/logging/apache/format/converters/DateTimeFormatConverterTest.groovy
+++ b/repose-aggregator/commons/utilities/src/test/groovy/com/rackspace/papi/commons/util/logging/apache/format/converters/DateTimeFormatConverterTest.groovy
@@ -1,5 +1,6 @@
 package com.rackspace.papi.commons.util.logging.apache.format.converters
 
+import org.junit.Assume
 import org.junit.Ignore
 import org.junit.Test
 /**
@@ -38,25 +39,33 @@ class DateTimeFormatConverterTest {
         assert result.equals(testValue)
     }
 
-    @Test
-    void "Timebomb for date conversion format"() {
-        //The format we are using is incorrect and doesn't do what it says it does, the following two tests prove it
-        //unfortunately the simple date format in java 1.6 is broken for our purposes, when we upgrade to 1.7
-        //these test can be unignored and the appropriate format un commented in DateConversionFormat
-        assert new Date() < new Date(2014 - 1900, Calendar.JULY, 9, 9, 0)
-    }
+    /*
+     * The format we're using is incorrect and doesn't do what it says it does,
+     * the following two tests prove it.
+     *
+     * Unfortunately the SimpleDateFormat class in Java 1.6 is broken
+     * The splodeDate is set to July of 2014, which is about when we expect to be switching to JDK 1.7
+     * At this point the tests will execute, and probably fail unless we've switched to JDK 1.7, at which point they
+     * should succeed!
+     *
+     * As long as the assumption proves false, it will ignore the tests. So we're assuming that we're past the timebomb
+     * date, otherwise the test method is ignored
+     */
+    def splodeDate = new Date(2014 - 1900, Calendar.JULY, 1, 9, 0);
 
-    @Ignore
     @Test
     void "valid input gets converted correctly"() {
+        Assume.assumeTrue(new Date() > splodeDate)
+
         def testValue = "1994-11-05T13:15:30Z"
         String result = converter.convert(testValue, 'ISO_8601', 'RFC_1123')
         assert result.equals('Sat, 05 Nov 1994 13:15:30 GMT')
     }
 
-    @Ignore
     @Test
     void "valid input value with a bad output format defaults to rfc-1123"() {
+        Assume.assumeTrue(new Date() > splodeDate)
+
         def testValue = "1994-11-05T13:15:30Z"
         String result = converter.convert(testValue, 'ISO_8601', 'squirrel noises')
         assert (result.equals('Sat, 05 Nov 1994 13:15:30 GMT'))


### PR DESCRIPTION
Using an assumption on the methods that we're ignoring rather than the
timebomb method itself.

This feels a bit cleaner to me, and ignores the tests properly, rather
than using @Ignore.
