### PR TITLE
Update client-auth-n-configuration.xsd

### DIFF
--- a/repose-aggregator/components/filters/client-auth/src/main/resources/META-INF/schema/config/client-auth-n-configuration.xsd
+++ b/repose-aggregator/components/filters/client-auth/src/main/resources/META-INF/schema/config/client-auth-n-configuration.xsd
@@ -97,7 +97,7 @@
             <xs:attribute name="auth-uri" type="xs:anyURI" use="optional">
                <xs:annotation>
                   <xs:documentation>
-                     <html:p>URL to auth against if different from client-auth url</html:p>
+                     <html:p>URI to auth against if different from client-auth uri</html:p>
                   </xs:documentation>
                </xs:annotation>
             </xs:attribute>
@@ -126,23 +126,23 @@
                </xs:annotation>
             </xs:attribute> 
             
-            <xs:assert vc:minVersion="1.1" test="if (@auth-url) then (xs:boolean(@isAuthed)) else true()"
+            <xs:assert vc:minVersion="1.1" test="if (@auth-uri) then (xs:boolean(@isAuthed)) else true()"
                        xerces:message="isAuthed must be configured true to configure an auth url for the rs atom feed"
                        saxon:message="isAuthed must be configured true to configure an auth url for the rs atom feed"/>
          
-            <xs:assert vc:minVersion="1.1" test="if (@auth-url) then (@user) else true()"
+            <xs:assert vc:minVersion="1.1" test="if (@auth-uri) then (@user) else true()"
                        xerces:message="If auth-url is configured then user and password must be supplied"
                        saxon:message="If auth-url is configured then user and password must be supplied"/>
          
-            <xs:assert vc:minVersion="1.1" test="if (@auth-url) then (@password) else true()"
+            <xs:assert vc:minVersion="1.1" test="if (@auth-uri) then (@password) else true()"
                        xerces:message="If auth-url is configured then user and password must be supplied"
                        saxon:message="If auth-url is configured then user and password must be supplied"/>
             
-            <xs:assert vc:minVersion="1.1" test="if (@user) then (@auth-url) else true()"
+            <xs:assert vc:minVersion="1.1" test="if (@user) then (@auth-uri) else true()"
                        xerces:message="If user is configured then auth-url must be configured"
                        saxon:message="If auth-url is configured then user and password must be supplied"/>
             
-            <xs:assert vc:minVersion="1.1" test="if (@password) then (@auth-url) else true()"
+            <xs:assert vc:minVersion="1.1" test="if (@password) then (@auth-uri) else true()"
                        xerces:message="If user is configured then auth-url must be configured"
                        saxon:message="If auth-url is configured then user and password must be supplied"/>
             


### PR DESCRIPTION
Fixed error where assertion is referring to the wrong attribute name in Rackspace-Identity-Feed.  @auth-url -> @auth-uri.
