### PR TITLE
Empty Request Body Test

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/EmptyRequestBodyTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/EmptyRequestBodyTest.groovy
@@ -31,7 +31,7 @@ class EmptyRequestBodyTest extends ReposeValveTest {
         method << ["PUT", "POST", "PATCH", "DELETE"]
     }
 
-    @Category(Bug.class)
+    @Category(Bug)
     @Unroll("#method should not have its body removed")
     def "Repose should not remove request bodies unless filters do so explicitly - bug"() {
         when:


### PR DESCRIPTION
> Yes. In other words, any HTTP request message is allowed to contain a message body, and thus must parse messages with that in mind. Server semantics for GET, however, are restricted such that a body, if any, has no semantic meaning to the request. The requirements on parsing are separate from the requirements on method semantics.
> 
> So, yes, you can send a body with GET, and no, it is never useful to do so.
> 
> This is part of the layered design of HTTP/1.1 that will become clear again once the spec is partitioned (work in progress).
> 
> ....Roy

There's some debate about whether or not removing the body of requests is permissible. We currently seem to remove the body of GET requests. This is a test to see what bodies we are removing. Please leave a comment with your opinion on the matter, since I'm not convinced one way or the other.
