### PR TITLE
Added permissions back to installation files

### DIFF
--- a/repose-aggregator/installation/rpm/cli-utils/pom.xml
+++ b/repose-aggregator/installation/rpm/cli-utils/pom.xml
@@ -66,6 +66,7 @@
 
                                 <mapping>
                                     <directory>/usr/bin</directory>
+                                    <filemode>770</filemode>
 
                                     <sources>
                                         <source>

--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -57,6 +57,7 @@
                                 <mapping>
                                     <directory>/etc/init.d</directory>
                                     <directoryIncluded>false</directoryIncluded>
+                                    <filemode>755</filemode>
 
                                     <sources>
                                         <source>
@@ -85,6 +86,7 @@
                                 <mapping>
                                     <directory>/etc/sysconfig</directory>
                                     <directoryIncluded>false</directoryIncluded>
+                                    <filemode>644</filemode>
                                     <sources>
                                         <source>
                                             <location>src/rpm/etc/sysconfig/repose</location>
@@ -94,6 +96,7 @@
                                 <mapping>
                                     <directory>/etc/logrotate.d</directory>
                                     <directoryIncluded>false</directoryIncluded>
+                                    <filemode>644</filemode>
                                     <sources>
                                         <source>
                                             <location>src/rpm/etc/logrotate.d/repose</location>
@@ -102,6 +105,7 @@
                                 </mapping>
                                 <mapping>
                                     <directory>/usr/local/bin</directory>
+                                    <filemode>755</filemode>
                                     <sources>
                                         <source>
                                             <location>${basedir}/../../bash/clean-repose-deploy

--- a/repose-aggregator/installation/rpm/ug-repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/ug-repose-valve/pom.xml
@@ -85,6 +85,7 @@
 
                                 <mapping>
                                     <directory>/usr/local/bin</directory>
+                                    <filemode>755</filemode>
 
                                     <sources>
                                         <source>
@@ -97,6 +98,7 @@
                                 <mapping>
                                     <directory>/etc/init.d</directory>
                                     <directoryIncluded>false</directoryIncluded>
+                                    <filemode>755</filemode>
 
                                     <sources>
                                         <source>
@@ -136,6 +138,7 @@
                                 <mapping>
                                     <directory>/etc/logrotate.d</directory>
                                     <directoryIncluded>false</directoryIncluded>
+                                    <filemode>644</filemode>
 
                                     <sources>
                                         <source>


### PR DESCRIPTION
The scripts we provide should be executable by default. I went added and added the file permissions back wherever they were removed (c71da5621f505283ec85d37f7d2540a39b04d1ec). As far as I can tell, these permissions do not change the permissions of containing directories.

As far as the permissions we should actually be using go, I wouldn't mind some discussion. I think I mostly agree with what's here.
