### PR TITLE
Hopefully resolve flaky failure problems for the DistDataStoreMisConfigTest

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/datastore/DistDataStoreMisConfigTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/datastore/DistDataStoreMisConfigTest.groovy
@@ -10,33 +10,14 @@ import org.rackspace.deproxy.PortFinder
 import spock.lang.Ignore
 import spock.lang.Unroll
 
+import static framework.TestUtils.timedSearch
+
 /**
  * Created by jennyvo on 4/9/14.
  */
 @Category(Slow)
 class DistDataStoreMisConfigTest extends ReposeValveTest{
     static def datastoreEndpoint
-
-    /**
-     * Takes a boolean closure that will indicate whatever it's looking for
-     * If the timeout hits, it's going to fail via throwing an exception
-     * This could probably be reused in many places.
-     * @param timeoutSeconds
-     * @param block
-     */
-    def timedSearch(int timeoutSeconds, Closure block) {
-        def startTime = System.currentTimeMillis()
-        boolean foundIt = false
-        while(System.currentTimeMillis() < startTime + timeoutSeconds * 1000 && !foundIt) {
-            foundIt = block.call()
-            Thread.sleep(500)
-        }
-
-        if(!foundIt) {
-            throw new Exception("Unable to satisfy condition within ${timeoutSeconds} seconds")
-        }
-        foundIt
-    }
 
 
     @Unroll("When start data store config #configuration")

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/TestUtils.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/TestUtils.groovy
@@ -4,6 +4,8 @@ import org.linkedin.util.clock.SystemClock
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 
+import java.util.concurrent.TimeUnit
+
 import static org.linkedin.groovy.util.concurrent.GroovyConcurrentUtils.waitForCondition
 
 class TestUtils {
@@ -14,4 +16,33 @@ class TestUtils {
 
         return runningJvms.in.text
     }
+
+    /**
+     * Takes a boolean closure that will indicate whatever it's looking for
+     * If the timeout hits, it's going to fail via throwing an exception
+     * This could probably be reused in many places.
+     *
+     * Additionally, you can pass in an optional TimeUnit, it operates in seconds right now.
+     * it will wait 500ms between iterations right now.
+     * @param timeout
+     * @param timeUnit
+     * @param block
+     * @return
+     */
+    static def timedSearch(int timeout, TimeUnit timeUnit = TimeUnit.SECONDS, Closure block) {
+        def startTime = System.currentTimeMillis()
+        boolean foundIt = false
+
+        while(System.currentTimeMillis() < startTime + timeUnit.toMillis(timeout) && !foundIt) {
+            foundIt = block.call()
+            Thread.sleep(500)
+        }
+
+        if(!foundIt) {
+            throw new Exception("Unable to satisfy condition within ${timeout} seconds")
+        }
+        foundIt
+    }
+
+
 }


### PR DESCRIPTION
It will look for the log output every half second, limited to no longer
than 10 seconds. This should alleviate the flakyness where it was
expecting logs before they got there. I hope.
