### PR TITLE
Springified the FlushOutputFilter.

### DIFF
--- a/repose-aggregator/components/filters/flush-output/src/main/java/org/openrepose/components/flush/FlushOutputFilter.java
+++ b/repose-aggregator/components/filters/flush-output/src/main/java/org/openrepose/components/flush/FlushOutputFilter.java
@@ -1,9 +1,12 @@
 package org.openrepose.components.flush;
 
 import com.rackspace.papi.filter.logic.impl.FilterLogicHandlerDelegate;
-import java.io.IOException;
-import javax.servlet.*;
 
+import javax.inject.Named;
+import javax.servlet.*;
+import java.io.IOException;
+
+@Named
 public class FlushOutputFilter implements Filter {
 
     private FlushOutputHandlerFactory handlerFactory;


### PR DESCRIPTION
This one was annotated as a Named entity, but it did not have any Injection dependencies.
