### PR TITLE
update fix flaky RateLimitingTest

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/RateLimitingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/RateLimitingTest.groovy
@@ -511,7 +511,9 @@ class RateLimitingTest extends ReposeValveTest {
     }
     // Helper methods
     private int parseRemainingFromXML(String s, int limit) {
-        DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance()
+        factory.setNamespaceAware(true)
+        DocumentBuilder documentBuilder = factory.newDocumentBuilder()
         Document document = documentBuilder.parse(new InputSource(new StringReader(s)))
 
         document.getDocumentElement().normalize()
@@ -520,7 +522,9 @@ class RateLimitingTest extends ReposeValveTest {
     }
 
     private int parseAbsoluteFromXML(String s, int limit) {
-        DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance()
+        factory.setNamespaceAware(true)
+        DocumentBuilder documentBuilder = factory.newDocumentBuilder()
         Document document = documentBuilder.parse(new InputSource(new StringReader(s)))
 
         document.getDocumentElement().normalize()


### PR DESCRIPTION
- update document builder to .setNamespaceAware(true)
- run >5 times all pass hopefully this flakiness is gone
