### PR TITLE
The errors for missing config files are really noisy

### DIFF
--- a/repose-aggregator/commons/configuration/src/main/java/org/openrepose/commons/config/parser/jaxb/JaxbConfigurationParser.java
+++ b/repose-aggregator/commons/configuration/src/main/java/org/openrepose/commons/config/parser/jaxb/JaxbConfigurationParser.java
@@ -45,6 +45,7 @@ public class JaxbConfigurationParser<T> extends AbstractConfigurationObjectParse
                 objectPool.invalidateObject(pooledObject);
                 pooledObject = null;
                 LOG.warn("This *MIGHT* be important! Unable to read configuration file: {}", ioe.getMessage());
+                LOG.trace("Unable to read configuration file.", ioe);
             } catch (Exception e) {
                 objectPool.invalidateObject(pooledObject);
                 pooledObject = null;


### PR DESCRIPTION
The missing config file errors with giant stack traces really made the logs hard to follow. It showed up when we replaced the pools. This specifically catches the IO exception, logs it at a WARN level and indicates that it might be important. No stacktrace is logged, because it's super long.

This makes them quieter, and reduces them to a WARN level, because
they're not really errors. (But they might be)
