### PR TITLE
Removed the Thread Context Stack/Nested Diagnostic Context conversion pa...

### DIFF
--- a/repose-aggregator/commons/utilities/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/commons/utilities/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration packages="org.openrepose.commons.utils.xslt">
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
         <LogErrorListener name="ErrorListener"/>

--- a/repose-aggregator/components/filters/client-auth/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/components/filters/client-auth/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>

--- a/repose-aggregator/components/filters/rackspace-auth-user/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/components/filters/rackspace-auth-user/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>

--- a/repose-aggregator/components/filters/rate-limiting/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/components/filters/rate-limiting/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>

--- a/repose-aggregator/components/filters/slf4j-http-logging/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/components/filters/slf4j-http-logging/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
         <List name="List1"/>

--- a/repose-aggregator/core/core-lib/src/test/resources/log4j2-RequestHeaderServiceContextTest.xml
+++ b/repose-aggregator/core/core-lib/src/test/resources/log4j2-RequestHeaderServiceContextTest.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>

--- a/repose-aggregator/core/core-lib/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/core/core-lib/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>

--- a/repose-aggregator/core/valve/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/core/valve/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>

--- a/repose-aggregator/external/service-clients/auth/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/external/service-clients/auth/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+            <PatternLayout pattern="%-4r [%t] %-5p %c  - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>


### PR DESCRIPTION
...ttern from all of the Log4J 2.x to prevent the empty brackets from showing up in every log message.
