### PR TITLE
Fix and cleanup Debian init script

### DIFF
--- a/repose-aggregator/installation/configs/etc/init.d/deb/repose-valve
+++ b/repose-aggregator/installation/configs/etc/init.d/deb/repose-valve
@@ -41,7 +41,7 @@ start_repose()
 ###########################
 stop_repose()
 {
-  start-stop-daemon -p $PID_FILE --stop --retry 5 --exec $JAVA -- -jar $REPOSE_JAR
+  start-stop-daemon -p $PID_FILE --stop --retry 5 --exec $JAVA
   log_progress_msg "stopped"
 }
 


### PR DESCRIPTION
"start-stop-daemon --stop --exec /usr/bin/java" will never stop Repose or any process if /usr/bin/java is a symlink.

Remove "-- ..." because "--stop" doesn't accept arguments for the process it's trying to stop (only "--start" does that).

See start-stop-daemon man page for more information.
