### PR TITLE
Moved LoggerContext configuration.

### DIFF
--- a/repose-aggregator/core/core-lib/src/test/groovy/org/openrepose/core/jmx/ConfigurationInformationTest.groovy
+++ b/repose-aggregator/core/core-lib/src/test/groovy/org/openrepose/core/jmx/ConfigurationInformationTest.groovy
@@ -1,7 +1,6 @@
 package org.openrepose.core.jmx
 
 import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.core.LogEvent
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.test.appender.ListAppender
 import org.mockito.ArgumentCaptor
@@ -44,15 +43,12 @@ class ConfigurationInformationTest extends Specification {
         when(healthCheckService.register()).thenReturn(healthCheckServiceProxy)
 
         configurationInformation = new ConfigurationInformation(configurationService, ports, healthCheckService)
-
     }
 
     def "if localhost can find self in system model on update, should resolve outstanding issues with health check service"() {
         given:
         def listenerObject
         def listenerCaptor = ArgumentCaptor.forClass(UpdateListener.class)
-        LoggerContext ctx = (LoggerContext) LogManager.getContext(false)
-        ListAppender app = ((ListAppender)(ctx.getConfiguration().getAppender("List0"))).clear()
 
         doNothing().when(configurationService).subscribeTo(eq("system-model.cfg.xml"), listenerCaptor.capture(), eq(SystemModel.class))
 

--- a/repose-aggregator/core/core-lib/src/test/groovy/org/openrepose/core/services/context/impl/RequestProxyServiceContextTest.groovy
+++ b/repose-aggregator/core/core-lib/src/test/groovy/org/openrepose/core/services/context/impl/RequestProxyServiceContextTest.groovy
@@ -2,7 +2,6 @@ package org.openrepose.core.services.context.impl
 
 import com.google.common.base.Optional
 import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.core.LogEvent
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.test.appender.ListAppender
 import org.mockito.ArgumentCaptor

--- a/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/services/logging/LoggingServiceImplTest.scala
+++ b/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/services/logging/LoggingServiceImplTest.scala
@@ -6,6 +6,8 @@ import java.nio.file.Files
 
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.config.ConfigurationFactory
+import org.apache.logging.log4j.status.StatusLogger
 import org.apache.logging.log4j.test.appender.ListAppender
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -37,70 +39,86 @@ class LoggingServiceImplTest extends FunSpec with Matchers {
     }
   }
 
+  def cleanupLoggerContext(context: LoggerContext)() = {
+    System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY)
+    context.reconfigure
+    StatusLogger.getLogger.reset
+  }
+
   val validExtensions = List("xml", "json", "yaml")
   validExtensions.foreach { ext =>
     describe(s"On Startup with extension $ext, the system") {
       it("Loads a fully qualified URL.") {
-        yamlWrapper(ext) {
-          val loggingService = new LoggingServiceImpl()
-          val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        try {
+          yamlWrapper(ext) {
+            val loggingService = new LoggingServiceImpl()
 
-          val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
-          val file1 = File.createTempFile("log4j2-", s".$ext")
-          Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
+            val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
+            val file1 = File.createTempFile("log4j2-", s".$ext")
+            file1.deleteOnExit()
+            Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
 
-          loggingService.updateLoggingConfiguration(file1.toURI.toURL.toString)
+            loggingService.updateLoggingConfiguration(file1.toURI.toURL.toString)
 
-          val config1 = context.getConfiguration
-          val app1 = config1.getAppender("List1").asInstanceOf[ListAppender]
-          app1 should not be null
-          app1.clear
+            val config1 = context.getConfiguration
+            val app1 = config1.getAppender("List1").asInstanceOf[ListAppender]
+            app1 should not be null
+            app1.clear
 
-          LOG.error("ERROR LEVEL LOG STATEMENT 1")
-          LOG.warn("WARN  LEVEL LOG STATEMENT 1")
-          LOG.info("INFO  LEVEL LOG STATEMENT 1")
-          LOG.debug("DEBUG LEVEL LOG STATEMENT 1")
-          LOG.trace("TRACE LEVEL LOG STATEMENT 1")
+            LOG.error("ERROR LEVEL LOG STATEMENT 1")
+            LOG.warn("WARN  LEVEL LOG STATEMENT 1")
+            LOG.info("INFO  LEVEL LOG STATEMENT 1")
+            LOG.debug("DEBUG LEVEL LOG STATEMENT 1")
+            LOG.trace("TRACE LEVEL LOG STATEMENT 1")
 
-          val events1 = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
+            val events1 = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
 
-          events1 should contain("ERROR LEVEL LOG STATEMENT 1")
-          events1 should contain("WARN  LEVEL LOG STATEMENT 1")
-          events1 should not contain "INFO  LEVEL LOG STATEMENT 1"
-          events1 should not contain "DEBUG LEVEL LOG STATEMENT 1"
-          events1 should not contain "TRACE LEVEL LOG STATEMENT 1"
+            events1 should contain("ERROR LEVEL LOG STATEMENT 1")
+            events1 should contain("WARN  LEVEL LOG STATEMENT 1")
+            events1 should not contain "INFO  LEVEL LOG STATEMENT 1"
+            events1 should not contain "DEBUG LEVEL LOG STATEMENT 1"
+            events1 should not contain "TRACE LEVEL LOG STATEMENT 1"
+          }
+        } finally {
+          cleanupLoggerContext(context)
         }
       }
 
       it("Loads a relative pathed file.") {
-        yamlWrapper(ext) {
-          val loggingService = new LoggingServiceImpl()
-          val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        try {
+          yamlWrapper(ext) {
+            val loggingService = new LoggingServiceImpl()
 
-          val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
-          val file1 = File.createTempFile("log4j2-", s".$ext")
-          Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
+            val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
+            val file1 = File.createTempFile("log4j2-", s".$ext")
+            file1.deleteOnExit()
+            Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
 
-          loggingService.updateLoggingConfiguration(file1.getCanonicalPath)
+            loggingService.updateLoggingConfiguration(file1.getCanonicalPath)
 
-          val config1 = context.getConfiguration
-          val app1 = config1.getAppender("List1").asInstanceOf[ListAppender]
-          app1 should not be null
-          app1.clear
+            val config1 = context.getConfiguration
+            val app1 = config1.getAppender("List1").asInstanceOf[ListAppender]
+            app1 should not be null
+            app1.clear
 
-          LOG.error("ERROR LEVEL LOG STATEMENT 1")
-          LOG.warn("WARN  LEVEL LOG STATEMENT 1")
-          LOG.info("INFO  LEVEL LOG STATEMENT 1")
-          LOG.debug("DEBUG LEVEL LOG STATEMENT 1")
-          LOG.trace("TRACE LEVEL LOG STATEMENT 1")
+            LOG.error("ERROR LEVEL LOG STATEMENT 1")
+            LOG.warn("WARN  LEVEL LOG STATEMENT 1")
+            LOG.info("INFO  LEVEL LOG STATEMENT 1")
+            LOG.debug("DEBUG LEVEL LOG STATEMENT 1")
+            LOG.trace("TRACE LEVEL LOG STATEMENT 1")
 
-          val events = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
+            val events = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
 
-          events should contain("ERROR LEVEL LOG STATEMENT 1")
-          events should contain("WARN  LEVEL LOG STATEMENT 1")
-          events should not contain "INFO  LEVEL LOG STATEMENT 1"
-          events should not contain "DEBUG LEVEL LOG STATEMENT 1"
-          events should not contain "TRACE LEVEL LOG STATEMENT 1"
+            events should contain("ERROR LEVEL LOG STATEMENT 1")
+            events should contain("WARN  LEVEL LOG STATEMENT 1")
+            events should not contain "INFO  LEVEL LOG STATEMENT 1"
+            events should not contain "DEBUG LEVEL LOG STATEMENT 1"
+            events should not contain "TRACE LEVEL LOG STATEMENT 1"
+          }
+        } finally {
+          cleanupLoggerContext(context)
         }
       }
 
@@ -116,117 +134,135 @@ class LoggingServiceImplTest extends FunSpec with Matchers {
 
         val events = appDefault.getEvents.toList.map(_.getMessage.getFormattedMessage)
         events.find(_.contains("ERROR FALLING BACK TO THE DEFAULT LOGGING CONFIGURATION!!!")) should not be None
+
+        cleanupLoggerContext(context)
       }
     }
 
     describe(s"From know good state with extension $ext, the system ") {
       it("Switches to another known configuration.") {
-        yamlWrapper(ext) {
-          val loggingService = new LoggingServiceImpl()
-          val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        try {
+          yamlWrapper(ext) {
+            val loggingService = new LoggingServiceImpl()
 
-          val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
-          val file1 = File.createTempFile("log4j2-", s".$ext")
-          Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
+            val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
+            val file1 = File.createTempFile("log4j2-", s".$ext")
+            file1.deleteOnExit()
+            Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
 
-          loggingService.updateLoggingConfiguration(file1.toURI.toURL.toString)
+            loggingService.updateLoggingConfiguration(file1.toURI.toURL.toString)
 
-          val config1 = context.getConfiguration
-          val app1 = config1.getAppender("List1").asInstanceOf[ListAppender]
-          app1 should not be null
-          app1.clear
+            val config1 = context.getConfiguration
+            val app1 = config1.getAppender("List1").asInstanceOf[ListAppender]
+            app1 should not be null
+            app1.clear
 
-          LOG.error("ERROR LEVEL LOG STATEMENT 1")
-          LOG.warn("WARN  LEVEL LOG STATEMENT 1")
-          LOG.info("INFO  LEVEL LOG STATEMENT 1")
-          LOG.debug("DEBUG LEVEL LOG STATEMENT 1")
-          LOG.trace("TRACE LEVEL LOG STATEMENT 1")
+            LOG.error("ERROR LEVEL LOG STATEMENT 1")
+            LOG.warn("WARN  LEVEL LOG STATEMENT 1")
+            LOG.info("INFO  LEVEL LOG STATEMENT 1")
+            LOG.debug("DEBUG LEVEL LOG STATEMENT 1")
+            LOG.trace("TRACE LEVEL LOG STATEMENT 1")
 
-          val content2 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List2.$ext")).mkString
-          val file2 = File.createTempFile("log4j2-", s".$ext")
-          Files.write(file2.toPath, content2.getBytes(StandardCharsets.UTF_8))
+            val content2 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List2.$ext")).mkString
+            val file2 = File.createTempFile("log4j2-", s".$ext")
+            file2.deleteOnExit()
+            Files.write(file2.toPath, content2.getBytes(StandardCharsets.UTF_8))
 
-          loggingService.updateLoggingConfiguration(file2.toURI.toURL.toString)
+            loggingService.updateLoggingConfiguration(file2.toURI.toURL.toString)
 
-          LOG.error("ERROR LEVEL LOG STATEMENT 2")
-          LOG.warn("WARN  LEVEL LOG STATEMENT 2")
-          LOG.info("INFO  LEVEL LOG STATEMENT 2")
-          LOG.debug("DEBUG LEVEL LOG STATEMENT 2")
-          LOG.trace("TRACE LEVEL LOG STATEMENT 2")
+            LOG.error("ERROR LEVEL LOG STATEMENT 2")
+            LOG.warn("WARN  LEVEL LOG STATEMENT 2")
+            LOG.info("INFO  LEVEL LOG STATEMENT 2")
+            LOG.debug("DEBUG LEVEL LOG STATEMENT 2")
+            LOG.trace("TRACE LEVEL LOG STATEMENT 2")
 
-          val events1 = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
-          events1 should contain("ERROR LEVEL LOG STATEMENT 1")
-          events1 should contain("WARN  LEVEL LOG STATEMENT 1")
-          events1 should not contain "INFO  LEVEL LOG STATEMENT 1"
-          events1 should not contain "DEBUG LEVEL LOG STATEMENT 1"
-          events1 should not contain "TRACE LEVEL LOG STATEMENT 1"
-          events1 should not contain "ERROR LEVEL LOG STATEMENT 2"
-          events1 should not contain "WARN  LEVEL LOG STATEMENT 2"
-          events1 should not contain "INFO  LEVEL LOG STATEMENT 2"
-          events1 should not contain "DEBUG LEVEL LOG STATEMENT 2"
-          events1 should not contain "TRACE LEVEL LOG STATEMENT 2"
+            val events1 = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
+            events1 should contain("ERROR LEVEL LOG STATEMENT 1")
+            events1 should contain("WARN  LEVEL LOG STATEMENT 1")
+            events1 should not contain "INFO  LEVEL LOG STATEMENT 1"
+            events1 should not contain "DEBUG LEVEL LOG STATEMENT 1"
+            events1 should not contain "TRACE LEVEL LOG STATEMENT 1"
+            events1 should not contain "ERROR LEVEL LOG STATEMENT 2"
+            events1 should not contain "WARN  LEVEL LOG STATEMENT 2"
+            events1 should not contain "INFO  LEVEL LOG STATEMENT 2"
+            events1 should not contain "DEBUG LEVEL LOG STATEMENT 2"
+            events1 should not contain "TRACE LEVEL LOG STATEMENT 2"
 
-          val config2 = context.getConfiguration
-          val app2 = config2.getAppender("List2").asInstanceOf[ListAppender]
-          app2 should not be null
-          val events2 = app2.getEvents.toList.map(_.getMessage.getFormattedMessage)
-          events2 should not contain "ERROR LEVEL LOG STATEMENT 1"
-          events2 should not contain "WARN  LEVEL LOG STATEMENT 1"
-          events2 should not contain "INFO  LEVEL LOG STATEMENT 1"
-          events2 should not contain "DEBUG LEVEL LOG STATEMENT 1"
-          events2 should not contain "TRACE LEVEL LOG STATEMENT 1"
-          events2 should contain("ERROR LEVEL LOG STATEMENT 2")
-          events2 should contain("WARN  LEVEL LOG STATEMENT 2")
-          events2 should contain("INFO  LEVEL LOG STATEMENT 2")
-          events2 should contain("DEBUG LEVEL LOG STATEMENT 2")
-          events2 should not contain "TRACE LEVEL LOG STATEMENT 2"
+            val config2 = context.getConfiguration
+            val app2 = config2.getAppender("List2").asInstanceOf[ListAppender]
+            app2 should not be null
+            val events2 = app2.getEvents.toList.map(_.getMessage.getFormattedMessage)
+            events2 should not contain "ERROR LEVEL LOG STATEMENT 1"
+            events2 should not contain "WARN  LEVEL LOG STATEMENT 1"
+            events2 should not contain "INFO  LEVEL LOG STATEMENT 1"
+            events2 should not contain "DEBUG LEVEL LOG STATEMENT 1"
+            events2 should not contain "TRACE LEVEL LOG STATEMENT 1"
+            events2 should contain("ERROR LEVEL LOG STATEMENT 2")
+            events2 should contain("WARN  LEVEL LOG STATEMENT 2")
+            events2 should contain("INFO  LEVEL LOG STATEMENT 2")
+            events2 should contain("DEBUG LEVEL LOG STATEMENT 2")
+            events2 should not contain "TRACE LEVEL LOG STATEMENT 2"
+          }
+        } finally {
+          cleanupLoggerContext(context)
         }
       }
 
       it("Fails to switch when provided NULL.") {
-        yamlWrapper(ext) {
-          val loggingService = new LoggingServiceImpl()
-          val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        try {
+          yamlWrapper(ext) {
+            val loggingService = new LoggingServiceImpl()
 
-          val content2 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List2.$ext")).mkString
-          val file2 = File.createTempFile("log4j2-", s".$ext")
-          Files.write(file2.toPath, content2.getBytes(StandardCharsets.UTF_8))
+            val content2 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List2.$ext")).mkString
+            val file2 = File.createTempFile("log4j2-", s".$ext")
+            file2.deleteOnExit()
+            Files.write(file2.toPath, content2.getBytes(StandardCharsets.UTF_8))
 
-          loggingService.updateLoggingConfiguration(file2.getAbsolutePath)
+            loggingService.updateLoggingConfiguration(file2.getAbsolutePath)
 
-          val config2 = context.getConfiguration
-          val app2 = config2.getAppender("List2").asInstanceOf[ListAppender]
-          app2 should not be null
-          app2.clear
+            val config2 = context.getConfiguration
+            val app2 = config2.getAppender("List2").asInstanceOf[ListAppender]
+            app2 should not be null
+            app2.clear
 
-          loggingService.updateLoggingConfiguration(null)
+            loggingService.updateLoggingConfiguration(null)
 
-          val events2 = app2.getEvents.toList.map(_.getMessage.getFormattedMessage)
-          events2 should contain("Requested to reload a NULL configuration.")
+            val events2 = app2.getEvents.toList.map(_.getMessage.getFormattedMessage)
+            events2 should contain("Requested to reload a NULL configuration.")
+          }
+        } finally {
+          cleanupLoggerContext(context)
         }
       }
 
       it("Fails to switch when provided the same file.") {
-        yamlWrapper(ext) {
-          val loggingService = new LoggingServiceImpl()
-          val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        try {
+          yamlWrapper(ext) {
+            val loggingService = new LoggingServiceImpl()
 
-          val content2 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List2.$ext")).mkString
-          val file2 = File.createTempFile("log4j2-", s".$ext")
-          Files.write(file2.toPath, content2.getBytes(StandardCharsets.UTF_8))
+            val content2 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List2.$ext")).mkString
+            val file2 = File.createTempFile("log4j2-", s".$ext")
+            file2.deleteOnExit()
+            Files.write(file2.toPath, content2.getBytes(StandardCharsets.UTF_8))
 
-          loggingService.updateLoggingConfiguration(file2.getAbsolutePath)
+            loggingService.updateLoggingConfiguration(file2.getAbsolutePath)
 
-          val config2 = context.getConfiguration
-          val app2 = config2.getAppender("List2").asInstanceOf[ListAppender]
-          app2 should not be null
-          app2.clear
+            val config2 = context.getConfiguration
+            val app2 = config2.getAppender("List2").asInstanceOf[ListAppender]
+            app2 should not be null
+            app2.clear
 
-          loggingService.updateLoggingConfiguration(file2.getAbsolutePath)
+            loggingService.updateLoggingConfiguration(file2.getAbsolutePath)
 
-          val events2 = app2.getEvents.toList.map(_.getMessage.getFormattedMessage)
+            val events2 = app2.getEvents.toList.map(_.getMessage.getFormattedMessage)
 
-          events2 should contain("Requested to reload the same configuration: " + file2.getAbsolutePath)
+            events2 should contain("Requested to reload the same configuration: " + file2.getAbsolutePath)
+          }
+        } finally {
+          cleanupLoggerContext(context)
         }
       }
 
@@ -238,26 +274,31 @@ class LoggingServiceImplTest extends FunSpec with Matchers {
       )
       invalidUrls.foreach { url =>
         it( s"""Fails to switch when provided the invalid URL: "$url".""") {
-          yamlWrapper(ext) {
-            val loggingService = new LoggingServiceImpl()
-            val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+          val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+          try {
+            yamlWrapper(ext) {
+              val loggingService = new LoggingServiceImpl()
 
-            val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
-            val file1 = File.createTempFile("log4j2-", s".$ext")
-            Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
+              val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
+              val file1 = File.createTempFile("log4j2-", s".$ext")
+              file1.deleteOnExit()
+              Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
 
-            loggingService.updateLoggingConfiguration(file1.toURI.toURL.toString)
+              loggingService.updateLoggingConfiguration(file1.toURI.toURL.toString)
 
-            val config = context.getConfiguration
-            val app1 = config.getAppender("List1").asInstanceOf[ListAppender]
-            app1 should not be null
-            app1.clear
+              val config = context.getConfiguration
+              val app1 = config.getAppender("List1").asInstanceOf[ListAppender]
+              app1 should not be null
+              app1.clear
 
-            loggingService.updateLoggingConfiguration(url)
+              loggingService.updateLoggingConfiguration(url)
 
-            val events1 = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
+              val events1 = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
 
-            events1 should contain(s"An attempt was made to switch to an invalid Logging Configuration file: $url")
+              events1 should contain(s"An attempt was made to switch to an invalid Logging Configuration file: $url")
+            }
+          } finally {
+            cleanupLoggerContext(context)
           }
         }
       }
@@ -265,81 +306,86 @@ class LoggingServiceImplTest extends FunSpec with Matchers {
 
     describe(s"On configuration modification with extension $ext, the system") {
       it("reloads the configuration.") {
-        yamlWrapper(ext) {
-          val loggingService = new LoggingServiceImpl()
-          val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        try {
+          yamlWrapper(ext) {
+            val loggingService = new LoggingServiceImpl()
 
-          val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
-          val file1 = File.createTempFile("log4j2-", s".$ext")
-          Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
+            val content1 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List1.$ext")).mkString
+            val file1 = File.createTempFile("log4j2-", s".$ext")
+            file1.deleteOnExit()
+            Files.write(file1.toPath, content1.getBytes(StandardCharsets.UTF_8))
 
-          loggingService.updateLoggingConfiguration(file1.toURI.toURL.toString)
+            loggingService.updateLoggingConfiguration(file1.toURI.toURL.toString)
 
-          val config1 = context.getConfiguration
-          val app1 = config1.getAppender("List1").asInstanceOf[ListAppender]
-          app1 should not be null
-          app1.clear
+            val config1 = context.getConfiguration
+            val app1 = config1.getAppender("List1").asInstanceOf[ListAppender]
+            app1 should not be null
+            app1.clear
 
-          LOG.error("ERROR LEVEL LOG STATEMENT 1")
-          LOG.warn("WARN  LEVEL LOG STATEMENT 1")
-          LOG.info("INFO  LEVEL LOG STATEMENT 1")
-          LOG.debug("DEBUG LEVEL LOG STATEMENT 1")
-          LOG.trace("TRACE LEVEL LOG STATEMENT 1")
+            LOG.error("ERROR LEVEL LOG STATEMENT 1")
+            LOG.warn("WARN  LEVEL LOG STATEMENT 1")
+            LOG.info("INFO  LEVEL LOG STATEMENT 1")
+            LOG.debug("DEBUG LEVEL LOG STATEMENT 1")
+            LOG.trace("TRACE LEVEL LOG STATEMENT 1")
 
-          var i = 5 + 1
-          LOG.debug(s"Waiting for one second longer than the monitor interval ($i)..")
-          System.out.print("Waiting for one second longer than the monitor interval..")
-          while (i > 0) {
-            System.out.print(". ")
-            Thread.sleep(1000)
-            i -= 1
+            var i = 5 + 1
+            LOG.debug(s"Waiting for one second longer than the monitor interval ($i)..")
+            System.out.print("Waiting for one second longer than the monitor interval..")
+            while (i > 0) {
+              System.out.print(". ")
+              Thread.sleep(1000)
+              i -= 1
+            }
+            System.out.println(".")
+
+            val content2 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List2.$ext")).mkString
+            Files.write(file1.toPath, content2.getBytes(StandardCharsets.UTF_8))
+
+            // This loop and sleep was adopted directly from the Log4J 2.x tests
+            // provides the tickling of the logging infrastructure to wake up and reload.
+            var j = 15
+            while (j > 0) {
+              LOG.trace(s"Reconfiguring LogManager... $j")
+              j -= 1
+            }
+            Thread.sleep(100)
+
+            LOG.error("ERROR LEVEL LOG STATEMENT 2")
+            LOG.warn("WARN  LEVEL LOG STATEMENT 2")
+            LOG.info("INFO  LEVEL LOG STATEMENT 2")
+            LOG.debug("DEBUG LEVEL LOG STATEMENT 2")
+            LOG.trace("TRACE LEVEL LOG STATEMENT 2")
+
+            val events1 = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
+            events1 should contain("ERROR LEVEL LOG STATEMENT 1")
+            events1 should contain("WARN  LEVEL LOG STATEMENT 1")
+            events1 should not contain "INFO  LEVEL LOG STATEMENT 1"
+            events1 should not contain "DEBUG LEVEL LOG STATEMENT 1"
+            events1 should not contain "TRACE LEVEL LOG STATEMENT 1"
+            events1 should not contain "ERROR LEVEL LOG STATEMENT 2"
+            events1 should not contain "WARN  LEVEL LOG STATEMENT 2"
+            events1 should not contain "INFO  LEVEL LOG STATEMENT 2"
+            events1 should not contain "DEBUG LEVEL LOG STATEMENT 2"
+            events1 should not contain "TRACE LEVEL LOG STATEMENT 2"
+
+            val config2 = context.getConfiguration
+            val app2 = config2.getAppender("List2").asInstanceOf[ListAppender]
+            app2 should not be null
+            val events2 = app2.getEvents.toList.map(_.getMessage.getFormattedMessage)
+            events2 should not contain "ERROR LEVEL LOG STATEMENT 1"
+            events2 should not contain "WARN  LEVEL LOG STATEMENT 1"
+            events2 should not contain "INFO  LEVEL LOG STATEMENT 1"
+            events2 should not contain "DEBUG LEVEL LOG STATEMENT 1"
+            events2 should not contain "TRACE LEVEL LOG STATEMENT 1"
+            events2 should contain("ERROR LEVEL LOG STATEMENT 2")
+            events2 should contain("WARN  LEVEL LOG STATEMENT 2")
+            events2 should contain("INFO  LEVEL LOG STATEMENT 2")
+            events2 should contain("DEBUG LEVEL LOG STATEMENT 2")
+            events2 should not contain "TRACE LEVEL LOG STATEMENT 2"
           }
-          System.out.println(".")
-
-          val content2 = Source.fromInputStream(this.getClass.getResourceAsStream(s"/LoggingServiceImplTest/log4j2-List2.$ext")).mkString
-          Files.write(file1.toPath, content2.getBytes(StandardCharsets.UTF_8))
-
-          // This loop and sleep was adopted directly from the Log4J 2.x tests
-          // provides the tickling of the logging infrastructure to wake up and reload.
-          var j = 15
-          while (j > 0) {
-            LOG.trace(s"Reconfiguring LogManager... $j")
-            j -= 1
-          }
-          Thread.sleep(100)
-
-          LOG.error("ERROR LEVEL LOG STATEMENT 2")
-          LOG.warn("WARN  LEVEL LOG STATEMENT 2")
-          LOG.info("INFO  LEVEL LOG STATEMENT 2")
-          LOG.debug("DEBUG LEVEL LOG STATEMENT 2")
-          LOG.trace("TRACE LEVEL LOG STATEMENT 2")
-
-          val events1 = app1.getEvents.toList.map(_.getMessage.getFormattedMessage)
-          events1 should contain("ERROR LEVEL LOG STATEMENT 1")
-          events1 should contain("WARN  LEVEL LOG STATEMENT 1")
-          events1 should not contain "INFO  LEVEL LOG STATEMENT 1"
-          events1 should not contain "DEBUG LEVEL LOG STATEMENT 1"
-          events1 should not contain "TRACE LEVEL LOG STATEMENT 1"
-          events1 should not contain "ERROR LEVEL LOG STATEMENT 2"
-          events1 should not contain "WARN  LEVEL LOG STATEMENT 2"
-          events1 should not contain "INFO  LEVEL LOG STATEMENT 2"
-          events1 should not contain "DEBUG LEVEL LOG STATEMENT 2"
-          events1 should not contain "TRACE LEVEL LOG STATEMENT 2"
-
-          val config2 = context.getConfiguration
-          val app2 = config2.getAppender("List2").asInstanceOf[ListAppender]
-          app2 should not be null
-          val events2 = app2.getEvents.toList.map(_.getMessage.getFormattedMessage)
-          events2 should not contain "ERROR LEVEL LOG STATEMENT 1"
-          events2 should not contain "WARN  LEVEL LOG STATEMENT 1"
-          events2 should not contain "INFO  LEVEL LOG STATEMENT 1"
-          events2 should not contain "DEBUG LEVEL LOG STATEMENT 1"
-          events2 should not contain "TRACE LEVEL LOG STATEMENT 1"
-          events2 should contain("ERROR LEVEL LOG STATEMENT 2")
-          events2 should contain("WARN  LEVEL LOG STATEMENT 2")
-          events2 should contain("INFO  LEVEL LOG STATEMENT 2")
-          events2 should contain("DEBUG LEVEL LOG STATEMENT 2")
-          events2 should not contain "TRACE LEVEL LOG STATEMENT 2"
+        } finally {
+          cleanupLoggerContext(context)
         }
       }
     }


### PR DESCRIPTION
Moved the retrieval of the `LoggerContext` from class variables configured in the test `setUp()` to local variables in the actual tests.
This had been seen on a few other tests previously, and if it continues to be a problem then we should move all of the `LoggerContext` variables to use this pattern.
It may become more prevalent when we Springify everything, as this seems to have something to do with actual context initialization.
