### PR TITLE
Revert "Fix Debian init script's "stop" action"

### DIFF
--- a/repose-aggregator/installation/configs/etc/init.d/deb/repose-valve
+++ b/repose-aggregator/installation/configs/etc/init.d/deb/repose-valve
@@ -17,7 +17,7 @@ set -e
 
 CONFIG_DIRECTORY=/etc/repose
 
-JAVA=$(readlink -f /usr/bin/java)
+JAVA=/usr/bin/java
 
 NAME=repose-valve
 DAEMON_HOME=/usr/share/repose


### PR DESCRIPTION
This reverts commit 4b1bd2292f087af5dfaf36b88569adbbea514b1d.

My apologies to start-stop-daemon as it works just fine, but it was a
Repose packaging bug that kept the init script from stopping Repose
(immediately after upgrading Repose and installing Java 7 when
/proc/${PID}/exe of the still-running Repose doesn't point to the
/usr/bin/java of the new Java 7 package).
