### PR TITLE
Removed the duplicate dependency declaration for the commons-pool

### DIFF
--- a/repose-aggregator/components/filters/translation/pom.xml
+++ b/repose-aggregator/components/filters/translation/pom.xml
@@ -87,11 +87,6 @@
             <artifactId>xalan</artifactId>
             <version>2.7.1</version>
         </dependency>
-        <dependency>
-            <groupId>commons-pool</groupId>
-            <artifactId>commons-pool</artifactId>
-            <version>1.6</version>
-        </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
This is the `WARNING` that was showing up.

    [WARNING]
    [WARNING] Some problems were encountered while building the effective model for com.rackspace.papi.components:translation:jar:7.0.0.0-SNAPSHOT
    [WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: commons-pool:commons-pool:jar -> version 1.6 vs (?) @ line 109, column 21
    [WARNING]
    [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
    [WARNING]
    [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
    [WARNING]
