### PR TITLE
DO NOT MERGE: REP-1553 - 6.2.2.0 release

### DIFF
--- a/documentation/docbook/pom.xml
+++ b/documentation/docbook/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>papi</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/documentation/docbook/pom.xml
+++ b/documentation/docbook/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>papi</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.rackspace.papi</groupId>
     <artifactId>papi</artifactId>
-    <version>6.2.2.0-SNAPSHOT</version>
+    <version>6.2.2.0</version>
 
     <name>Repose</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.rackspace.papi</groupId>
     <artifactId>papi</artifactId>
-    <version>6.2.2.0</version>
+    <version>7.0.0.0-SNAPSHOT</version>
 
     <name>Repose</name>
 

--- a/repose-aggregator/commons/classloader/pom.xml
+++ b/repose-aggregator/commons/classloader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/classloader/pom.xml
+++ b/repose-aggregator/commons/classloader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/configuration/pom.xml
+++ b/repose-aggregator/commons/configuration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/configuration/pom.xml
+++ b/repose-aggregator/commons/configuration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/jetty/pom.xml
+++ b/repose-aggregator/commons/jetty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/jetty/pom.xml
+++ b/repose-aggregator/commons/jetty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/pom.xml
+++ b/repose-aggregator/commons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/pom.xml
+++ b/repose-aggregator/commons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/utilities/pom.xml
+++ b/repose-aggregator/commons/utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/commons/utilities/pom.xml
+++ b/repose-aggregator/commons/utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.commons</groupId>
         <artifactId>commons-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.commons</groupId>

--- a/repose-aggregator/components/cli-utils/pom.xml
+++ b/repose-aggregator/components/cli-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/cli-utils/pom.xml
+++ b/repose-aggregator/components/cli-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/datastores/api/pom.xml
+++ b/repose-aggregator/components/datastores/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>datastores-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/datastores/api/pom.xml
+++ b/repose-aggregator/components/datastores/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>datastores-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/datastores/distributed/pom.xml
+++ b/repose-aggregator/components/datastores/distributed/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>datastores-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/datastores/distributed/pom.xml
+++ b/repose-aggregator/components/datastores/distributed/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>datastores-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/datastores/ehcache/pom.xml
+++ b/repose-aggregator/components/datastores/ehcache/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>datastores-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/datastores/ehcache/pom.xml
+++ b/repose-aggregator/components/datastores/ehcache/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>datastores-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/datastores/pom.xml
+++ b/repose-aggregator/components/datastores/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/datastores/pom.xml
+++ b/repose-aggregator/components/datastores/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>components-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/filters/add-header/pom.xml
+++ b/repose-aggregator/components/filters/add-header/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>filters-support</artifactId>
         <groupId>com.rackspace.papi.components</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/filters/add-header/pom.xml
+++ b/repose-aggregator/components/filters/add-header/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>filters-support</artifactId>
         <groupId>com.rackspace.papi.components</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/filters/client-auth/pom.xml
+++ b/repose-aggregator/components/filters/client-auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/client-auth/pom.xml
+++ b/repose-aggregator/components/filters/client-auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/client-authorization/pom.xml
+++ b/repose-aggregator/components/filters/client-authorization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/client-authorization/pom.xml
+++ b/repose-aggregator/components/filters/client-authorization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/client-ip-identity/pom.xml
+++ b/repose-aggregator/components/filters/client-ip-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/client-ip-identity/pom.xml
+++ b/repose-aggregator/components/filters/client-ip-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/compression/pom.xml
+++ b/repose-aggregator/components/filters/compression/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/compression/pom.xml
+++ b/repose-aggregator/components/filters/compression/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/content-identity-auth-2.0/pom.xml
+++ b/repose-aggregator/components/filters/content-identity-auth-2.0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/content-identity-auth-2.0/pom.xml
+++ b/repose-aggregator/components/filters/content-identity-auth-2.0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/content-normalization/pom.xml
+++ b/repose-aggregator/components/filters/content-normalization/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/content-normalization/pom.xml
+++ b/repose-aggregator/components/filters/content-normalization/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/content-type-stripper/pom.xml
+++ b/repose-aggregator/components/filters/content-type-stripper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/content-type-stripper/pom.xml
+++ b/repose-aggregator/components/filters/content-type-stripper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/default-router/pom.xml
+++ b/repose-aggregator/components/filters/default-router/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/default-router/pom.xml
+++ b/repose-aggregator/components/filters/default-router/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/destination-router/pom.xml
+++ b/repose-aggregator/components/filters/destination-router/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/destination-router/pom.xml
+++ b/repose-aggregator/components/filters/destination-router/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/echo/pom.xml
+++ b/repose-aggregator/components/filters/echo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/echo/pom.xml
+++ b/repose-aggregator/components/filters/echo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/filter-bundle/pom.xml
+++ b/repose-aggregator/components/filters/filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/filter-bundle/pom.xml
+++ b/repose-aggregator/components/filters/filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/flush-output/pom.xml
+++ b/repose-aggregator/components/filters/flush-output/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/flush-output/pom.xml
+++ b/repose-aggregator/components/filters/flush-output/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/forwarded-proto/pom.xml
+++ b/repose-aggregator/components/filters/forwarded-proto/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <artifactId>forwarded-proto</artifactId>

--- a/repose-aggregator/components/filters/forwarded-proto/pom.xml
+++ b/repose-aggregator/components/filters/forwarded-proto/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forwarded-proto</artifactId>

--- a/repose-aggregator/components/filters/header-id-mapping/pom.xml
+++ b/repose-aggregator/components/filters/header-id-mapping/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/header-id-mapping/pom.xml
+++ b/repose-aggregator/components/filters/header-id-mapping/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/header-identity/pom.xml
+++ b/repose-aggregator/components/filters/header-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/header-identity/pom.xml
+++ b/repose-aggregator/components/filters/header-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/header-normalization/pom.xml
+++ b/repose-aggregator/components/filters/header-normalization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/header-normalization/pom.xml
+++ b/repose-aggregator/components/filters/header-normalization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/header-translation/pom.xml
+++ b/repose-aggregator/components/filters/header-translation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/header-translation/pom.xml
+++ b/repose-aggregator/components/filters/header-translation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/iri-validator/pom.xml
+++ b/repose-aggregator/components/filters/iri-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <artifactId>iri-validator</artifactId>

--- a/repose-aggregator/components/filters/iri-validator/pom.xml
+++ b/repose-aggregator/components/filters/iri-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>iri-validator</artifactId>

--- a/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
+++ b/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <artifactId>openstack-identity-v3</artifactId>

--- a/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
+++ b/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openstack-identity-v3</artifactId>

--- a/repose-aggregator/components/filters/pom.xml
+++ b/repose-aggregator/components/filters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-support</artifactId>
         <groupId>com.rackspace.papi.components</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/filters/pom.xml
+++ b/repose-aggregator/components/filters/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>components-support</artifactId>
         <groupId>com.rackspace.papi.components</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/components/filters/rackspace-auth-user/pom.xml
+++ b/repose-aggregator/components/filters/rackspace-auth-user/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/rackspace-auth-user/pom.xml
+++ b/repose-aggregator/components/filters/rackspace-auth-user/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/pom.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <artifactId>rackspace-identity-basic-auth</artifactId>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/pom.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>rackspace-identity-basic-auth</artifactId>

--- a/repose-aggregator/components/filters/rate-limiting/pom.xml
+++ b/repose-aggregator/components/filters/rate-limiting/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/rate-limiting/pom.xml
+++ b/repose-aggregator/components/filters/rate-limiting/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/service-authentication/pom.xml
+++ b/repose-aggregator/components/filters/service-authentication/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/service-authentication/pom.xml
+++ b/repose-aggregator/components/filters/service-authentication/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/slf4j-http-logging/pom.xml
+++ b/repose-aggregator/components/filters/slf4j-http-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>slf4j-http-logging</artifactId>

--- a/repose-aggregator/components/filters/slf4j-http-logging/pom.xml
+++ b/repose-aggregator/components/filters/slf4j-http-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <artifactId>slf4j-http-logging</artifactId>

--- a/repose-aggregator/components/filters/translation/pom.xml
+++ b/repose-aggregator/components/filters/translation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/translation/pom.xml
+++ b/repose-aggregator/components/filters/translation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/uri-identity/pom.xml
+++ b/repose-aggregator/components/filters/uri-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/uri-identity/pom.xml
+++ b/repose-aggregator/components/filters/uri-identity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/uri-normalization/pom.xml
+++ b/repose-aggregator/components/filters/uri-normalization/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/uri-normalization/pom.xml
+++ b/repose-aggregator/components/filters/uri-normalization/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/uri-stripper/pom.xml
+++ b/repose-aggregator/components/filters/uri-stripper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/uri-stripper/pom.xml
+++ b/repose-aggregator/components/filters/uri-stripper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/versioning/pom.xml
+++ b/repose-aggregator/components/filters/versioning/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/filters/versioning/pom.xml
+++ b/repose-aggregator/components/filters/versioning/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>filters-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/pom.xml
+++ b/repose-aggregator/components/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/components/pom.xml
+++ b/repose-aggregator/components/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components</groupId>

--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.core</groupId>
         <artifactId>core-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.core</groupId>
         <artifactId>core-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/repose-aggregator/core/pom.xml
+++ b/repose-aggregator/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/repose-aggregator/core/pom.xml
+++ b/repose-aggregator/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/repose-aggregator/core/valve/pom.xml
+++ b/repose-aggregator/core/valve/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.core</groupId>
         <artifactId>core-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/repose-aggregator/core/valve/pom.xml
+++ b/repose-aggregator/core/valve/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.core</groupId>
         <artifactId>core-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/repose-aggregator/core/web-application/pom.xml
+++ b/repose-aggregator/core/web-application/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.core</groupId>
         <artifactId>core-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/repose-aggregator/core/web-application/pom.xml
+++ b/repose-aggregator/core/web-application/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.rackspace.papi.core</groupId>
         <artifactId>core-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.core</groupId>

--- a/repose-aggregator/experimental/exception-filter/pom.xml
+++ b/repose-aggregator/experimental/exception-filter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.experimental</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/exception-filter/pom.xml
+++ b/repose-aggregator/experimental/exception-filter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.experimental</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/experimental-filter-bundle/pom.xml
+++ b/repose-aggregator/experimental/experimental-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.experimental</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/experimental-filter-bundle/pom.xml
+++ b/repose-aggregator/experimental/experimental-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.experimental</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/pom.xml
+++ b/repose-aggregator/experimental/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/pom.xml
+++ b/repose-aggregator/experimental/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/servlet-contract-filter/pom.xml
+++ b/repose-aggregator/experimental/servlet-contract-filter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.experimental</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/servlet-contract-filter/pom.xml
+++ b/repose-aggregator/experimental/servlet-contract-filter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.experimental</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/tightly-coupled-filter/pom.xml
+++ b/repose-aggregator/experimental/tightly-coupled-filter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.experimental</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/experimental/tightly-coupled-filter/pom.xml
+++ b/repose-aggregator/experimental/tightly-coupled-filter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.experimental</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.experimental</groupId>

--- a/repose-aggregator/extensions/api-validator/pom.xml
+++ b/repose-aggregator/extensions/api-validator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.extensions</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>

--- a/repose-aggregator/extensions/api-validator/pom.xml
+++ b/repose-aggregator/extensions/api-validator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.extensions</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>

--- a/repose-aggregator/extensions/extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/extensions/extensions-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.extensions</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>

--- a/repose-aggregator/extensions/extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/extensions/extensions-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.extensions</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>

--- a/repose-aggregator/extensions/pom.xml
+++ b/repose-aggregator/extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>

--- a/repose-aggregator/extensions/pom.xml
+++ b/repose-aggregator/extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.extensions</groupId>

--- a/repose-aggregator/external/jee6-schemas/pom.xml
+++ b/repose-aggregator/external/jee6-schemas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repose-aggregator/external/jee6-schemas/pom.xml
+++ b/repose-aggregator/external/jee6-schemas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repose-aggregator/external/os-auth-schemas/pom.xml
+++ b/repose-aggregator/external/os-auth-schemas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.external</groupId>

--- a/repose-aggregator/external/os-auth-schemas/pom.xml
+++ b/repose-aggregator/external/os-auth-schemas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external</groupId>

--- a/repose-aggregator/external/pjl-compressingFilter/pom.xml
+++ b/repose-aggregator/external/pjl-compressingFilter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/repose-aggregator/external/pjl-compressingFilter/pom.xml
+++ b/repose-aggregator/external/pjl-compressingFilter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/repose-aggregator/external/pom.xml
+++ b/repose-aggregator/external/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external</groupId>

--- a/repose-aggregator/external/pom.xml
+++ b/repose-aggregator/external/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.external</groupId>

--- a/repose-aggregator/external/service-clients/auth/pom.xml
+++ b/repose-aggregator/external/service-clients/auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>service-client-support</artifactId>
         <groupId>com.rackspace.papi.external.clients</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.cloud.services.clients</groupId>

--- a/repose-aggregator/external/service-clients/auth/pom.xml
+++ b/repose-aggregator/external/service-clients/auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>service-client-support</artifactId>
         <groupId>com.rackspace.papi.external.clients</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.cloud.services.clients</groupId>

--- a/repose-aggregator/external/service-clients/pom.xml
+++ b/repose-aggregator/external/service-clients/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.clients</groupId>

--- a/repose-aggregator/external/service-clients/pom.xml
+++ b/repose-aggregator/external/service-clients/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.external</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.clients</groupId>

--- a/repose-aggregator/functional-tests/container-support/pom.xml
+++ b/repose-aggregator/functional-tests/container-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.testing</groupId>

--- a/repose-aggregator/functional-tests/container-support/pom.xml
+++ b/repose-aggregator/functional-tests/container-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.testing</groupId>

--- a/repose-aggregator/functional-tests/glassfish-support/pom.xml
+++ b/repose-aggregator/functional-tests/glassfish-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.testing</groupId>

--- a/repose-aggregator/functional-tests/glassfish-support/pom.xml
+++ b/repose-aggregator/functional-tests/glassfish-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.testing</groupId>

--- a/repose-aggregator/functional-tests/mocks-servlet/pom.xml
+++ b/repose-aggregator/functional-tests/mocks-servlet/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.test.mocks</groupId>

--- a/repose-aggregator/functional-tests/mocks-servlet/pom.xml
+++ b/repose-aggregator/functional-tests/mocks-servlet/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.test.mocks</groupId>

--- a/repose-aggregator/functional-tests/mocks-util/pom.xml
+++ b/repose-aggregator/functional-tests/mocks-util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.test.mocks</groupId>

--- a/repose-aggregator/functional-tests/mocks-util/pom.xml
+++ b/repose-aggregator/functional-tests/mocks-util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.test.mocks</groupId>

--- a/repose-aggregator/functional-tests/pom.xml
+++ b/repose-aggregator/functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>profile-support</artifactId>
         <groupId>com.rackspace.papi</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/functional-tests/pom.xml
+++ b/repose-aggregator/functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>profile-support</artifactId>
         <groupId>com.rackspace.papi</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/functional-tests/spock-functional-test/pom.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.test</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repose-aggregator/functional-tests/spock-functional-test/pom.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi.test</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repose-aggregator/functional-tests/test-support/pom.xml
+++ b/repose-aggregator/functional-tests/test-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.test</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repose-aggregator/functional-tests/test-support/pom.xml
+++ b/repose-aggregator/functional-tests/test-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.test</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repose-aggregator/functional-tests/tomcat-support/pom.xml
+++ b/repose-aggregator/functional-tests/tomcat-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.testing</groupId>

--- a/repose-aggregator/functional-tests/tomcat-support/pom.xml
+++ b/repose-aggregator/functional-tests/tomcat-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>functional-test-support</artifactId>
         <groupId>com.rackspace.papi.test</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.external.testing</groupId>

--- a/repose-aggregator/installation/deb/pom.xml
+++ b/repose-aggregator/installation/deb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation</groupId>
         <artifactId>installation</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb</groupId>

--- a/repose-aggregator/installation/deb/pom.xml
+++ b/repose-aggregator/installation/deb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation</groupId>
         <artifactId>installation</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb</groupId>

--- a/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.cli-utils</groupId>

--- a/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.cli-utils</groupId>

--- a/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.filters.extensions</groupId>

--- a/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.filters.extensions</groupId>

--- a/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.filters</groupId>

--- a/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.filters</groupId>

--- a/repose-aggregator/installation/deb/repose-valve/pom.xml
+++ b/repose-aggregator/installation/deb/repose-valve/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.valve</groupId>

--- a/repose-aggregator/installation/deb/repose-valve/pom.xml
+++ b/repose-aggregator/installation/deb/repose-valve/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.valve</groupId>

--- a/repose-aggregator/installation/deb/repose-war/pom.xml
+++ b/repose-aggregator/installation/deb/repose-war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.war</groupId>

--- a/repose-aggregator/installation/deb/repose-war/pom.xml
+++ b/repose-aggregator/installation/deb/repose-war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.deb</groupId>
         <artifactId>deb</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.deb.war</groupId>

--- a/repose-aggregator/installation/pom.xml
+++ b/repose-aggregator/installation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation</groupId>

--- a/repose-aggregator/installation/pom.xml
+++ b/repose-aggregator/installation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>profile-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation</groupId>

--- a/repose-aggregator/installation/rpm/pom.xml
+++ b/repose-aggregator/installation/rpm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation</groupId>
         <artifactId>installation</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm</groupId>

--- a/repose-aggregator/installation/rpm/pom.xml
+++ b/repose-aggregator/installation/rpm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation</groupId>
         <artifactId>installation</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm</groupId>

--- a/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.cli-utils</groupId>

--- a/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.cli-utils</groupId>

--- a/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.filters.extensions</groupId>

--- a/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.filters.extensions</groupId>

--- a/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.filters</groupId>

--- a/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.filters</groupId>

--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.valve</groupId>

--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.valve</groupId>

--- a/repose-aggregator/installation/rpm/repose-war/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.war</groupId>

--- a/repose-aggregator/installation/rpm/repose-war/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.repose.installation.rpm</groupId>
         <artifactId>rpm</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.installation.rpm.war</groupId>

--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>papi</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi</groupId>

--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.rackspace.papi</groupId>
         <artifactId>papi</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi</groupId>

--- a/repose-aggregator/services/datastore/api/pom.xml
+++ b/repose-aggregator/services/datastore/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>datastore-service-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/datastore/api/pom.xml
+++ b/repose-aggregator/services/datastore/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>datastore-service-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/datastore/impl/pom.xml
+++ b/repose-aggregator/services/datastore/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>datastore-service-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/datastore/impl/pom.xml
+++ b/repose-aggregator/services/datastore/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>datastore-service-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/datastore/pom.xml
+++ b/repose-aggregator/services/datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/datastore/pom.xml
+++ b/repose-aggregator/services/datastore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/health-check/api/pom.xml
+++ b/repose-aggregator/services/health-check/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>health-check-service-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/health-check/api/pom.xml
+++ b/repose-aggregator/services/health-check/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>health-check-service-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/health-check/impl/pom.xml
+++ b/repose-aggregator/services/health-check/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>health-check-service-support</artifactId>
         <groupId>com.rackspace.papi.service</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.papi.service</groupId>

--- a/repose-aggregator/services/health-check/impl/pom.xml
+++ b/repose-aggregator/services/health-check/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>health-check-service-support</artifactId>
         <groupId>com.rackspace.papi.service</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.service</groupId>

--- a/repose-aggregator/services/health-check/pom.xml
+++ b/repose-aggregator/services/health-check/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/health-check/pom.xml
+++ b/repose-aggregator/services/health-check/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/httpclient/api/pom.xml
+++ b/repose-aggregator/services/httpclient/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>httpclient-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/httpclient/api/pom.xml
+++ b/repose-aggregator/services/httpclient/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>httpclient-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/httpclient/impl/pom.xml
+++ b/repose-aggregator/services/httpclient/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>httpclient-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/httpclient/impl/pom.xml
+++ b/repose-aggregator/services/httpclient/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>httpclient-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/httpclient/pom.xml
+++ b/repose-aggregator/services/httpclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/httpclient/pom.xml
+++ b/repose-aggregator/services/httpclient/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/pom.xml
+++ b/repose-aggregator/services/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>profile-support</artifactId>
         <groupId>com.rackspace.papi</groupId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
 
     <groupId>com.rackspace.repose.services</groupId>

--- a/repose-aggregator/services/pom.xml
+++ b/repose-aggregator/services/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>profile-support</artifactId>
         <groupId>com.rackspace.papi</groupId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.repose.services</groupId>

--- a/repose-aggregator/services/rate-limiting-service/pom.xml
+++ b/repose-aggregator/services/rate-limiting-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/rate-limiting-service/pom.xml
+++ b/repose-aggregator/services/rate-limiting-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/service-client/api/pom.xml
+++ b/repose-aggregator/services/service-client/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>service-client-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/service-client/api/pom.xml
+++ b/repose-aggregator/services/service-client/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>service-client-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/service-client/impl/pom.xml
+++ b/repose-aggregator/services/service-client/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>service-client-support</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/service-client/impl/pom.xml
+++ b/repose-aggregator/services/service-client/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.rackspace.papi.service</groupId>
         <artifactId>service-client-support</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/service-client/pom.xml
+++ b/repose-aggregator/services/service-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0-SNAPSHOT</version>
+        <version>6.2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/service-client/pom.xml
+++ b/repose-aggregator/services/service-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.repose.services</groupId>
         <artifactId>services-pom</artifactId>
-        <version>6.2.2.0</version>
+        <version>7.0.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
The following have been cherry-picked into 6.2.1.2:
* REP-729 (492d553fbe95575c24fcf861a627f94eee23070c^..1f92583760c77b7bc66932d70b66c5696a5ef9a4)
* REP-1528 (c79549e78c44a9c854b39a8b647589c1c5e26330^..309fc861a8bc9331c2521cb244c52644c1c3003d)
* REP-1540 (f4517c5ae8811b8ea08344587eb4978586cd97fb^..2d6078a7ff5a6f1f83d9e1f0c220963301928fcf)
* REP-1527 (21c7855fa33160f790e88f3f751dffc890b048cc^..5a8becb9d025f2675ee3912d9dd940ae1bb0a471)
* REP-1560 (58b0f16d4774777c2da3d3e4b873c448d50ecf7e^..a226dd8fe26de32486b6f86523ac1f57eb2a6bd1)
* REP-1595 (418a53731e33ba1e032745f8fb538a2740f9a000^..e688064624e6873311eef003811f26717047ac99)

I also brought in the time bomb update to the DistDatastoreServiceContainerTest
* 83bf07bd008d6c3453324900a1716fd28f154e0f
* 5b20c7ed0ae4c7b4a9b681fa4ce9c8a20b4ad257
* 970219f55810411816b2cb2336987399f6f554c2

Fixed some merge issues with the cherry-pick and assumptions made in master.
Commented out sections of AkkaServiceClientImplTest that expected the new SLF4J 2.x framework since this is not compatible with the earlier version provided in the backported release.