### PR TITLE
Wire-tap std-out and std-err

### DIFF
--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -210,6 +210,12 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
 
+        <!-- this guy gets me some dependencies that let me log STDERR and STDOUT 
+        while still letting them go to the console -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-iostreams</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/core/services/logging/LoggingServiceImpl.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/core/services/logging/LoggingServiceImpl.java
@@ -1,12 +1,16 @@
 package org.openrepose.core.services.logging;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.apache.logging.log4j.io.IoBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -16,6 +20,19 @@ public class LoggingServiceImpl implements LoggingService {
     private String currentConfigFileName = null;
 
     public LoggingServiceImpl() {
+        //Do some log wrapping only one time, not every time we configure
+        //Wiretap Standard Error to the STDERR logger
+        PrintStream stdErr = IoBuilder.forLogger("STDERR")
+                .setLevel(Level.WARN)
+                .filter(System.err) //Also output to standard err, but I want it in my logs!
+                .buildPrintStream();
+        System.setErr(stdErr);
+
+        PrintStream stdOut = IoBuilder.forLogger("STDOUT")
+                .setLevel(Level.INFO)
+                .filter(System.out)
+                .buildPrintStream();
+        System.setOut(stdOut);
     }
 
     @Override

--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -298,6 +298,12 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-iostreams</artifactId>
+                <version>2.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
                 <type>test-jar</type>
                 <version>2.1</version>


### PR DESCRIPTION
Using this dependency, we can easily build a wiretapper that will grab
anything that goes to stderr or stdout and also log it to a named
logger. This is very useful.

Because I cherry-picked it from the spring branch, it got mad. It seems most of the conflicts were whitespace conflicts, but the patch here is good.

Conflicts:
	repose-aggregator/core/core-lib/pom.xml
	repose-aggregator/core/core-lib/src/main/java/org/openrepose/core/services/logging/LoggingServiceImpl.java
	repose-aggregator/pom.xml