### PR TITLE
Updated the two locations we use .execute()

### DIFF
--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/http/ServiceClient.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/http/ServiceClient.java
@@ -14,6 +14,7 @@ import org.apache.http.client.params.AuthPolicy;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.util.EntityUtils;
 import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.io.RawInputStreamReader;
@@ -110,7 +111,9 @@ public class ServiceClient {
                client.getParams().setParameter(queryParameters[index], queryParameters[index + 1]);
             }
 
-            HttpResponse httpResponse = client.execute(base);
+            //NOTE have to create a new HttpContext each time, to avoid reusing cookies accidentally
+            // If not doing this, the cookies and stuff can be shared, and that's super bad
+            HttpResponse httpResponse = client.execute(base, new BasicHttpContext());
             HttpEntity entity = httpResponse.getEntity();
 
             InputStream stream = null;

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/core/services/httpcomponent/RequestProxyServiceImpl.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/core/services/httpcomponent/RequestProxyServiceImpl.java
@@ -1,5 +1,6 @@
 package org.openrepose.core.services.httpcomponent;
 
+import org.apache.http.protocol.BasicHttpContext;
 import org.openrepose.commons.utils.StringUriUtilities;
 import org.openrepose.commons.utils.http.HttpStatusCode;
 import org.openrepose.commons.utils.http.ServiceClientResponse;
@@ -131,7 +132,10 @@ public class RequestProxyServiceImpl implements RequestProxyService {
     private ServiceClientResponse execute(HttpRequestBase base) {
         HttpClientResponse httpClientResponse = getClient();
         try {
-            HttpResponse httpResponse = httpClientResponse.getHttpClient().execute(base);
+            //We have to create a new HttpContext each time, so that we don't accidentally reuse cookies!
+            //REAL BAD
+            //Hopefully a plain BasicHttpContext() is suitable
+            HttpResponse httpResponse = httpClientResponse.getHttpClient().execute(base, new BasicHttpContext());
             HttpEntity entity = httpResponse.getEntity();
             HttpComponentResponseCodeProcessor responseCode = new HttpComponentResponseCodeProcessor(httpResponse.getStatusLine().getStatusCode());
 


### PR DESCRIPTION
This now creates a new BasicHttpContext() so that we don't reuse cookie
stores. It's probably been wrong since the HttpPooling stuff was added.