### PR TITLE
Rep 1673 client state

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/httpconnectionpool/smallpool/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/httpconnectionpool/smallpool/http-connection-pool.cfg.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<http-connection-pools xmlns="http://docs.rackspacecloud.com/repose/http-connection-pool/v1.0">
+
+    <!-- Configuration for the default pool.  Any users of the service will by default, retrieve HTTP connections
+        using this default pool configuration.
+    -->
+    <pool id="default"
+          default="true"
+          http.conn-manager.max-total="5"
+          http.conn-manager.max-per-route="2"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/httpconnectionpool/HttpClientStateTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/httpconnectionpool/HttpClientStateTest.groovy
@@ -81,7 +81,7 @@ class HttpClientStateTest extends ReposeValveTest {
         (1..1000).each { count ->
             defer {
                 HttpClient client = new DefaultHttpClient()
-                def response = client.execute(new HttpGet("http://localhost:${jettyPort}/"))
+                def response = client.execute(new HttpGet("http://localhost:${properties.reposePort}/"))
                 String content = response.getEntity().getContent().getText()
                 sessionIds.add(content) //Just store it for later verification
                 //Lets not use deproxy this time

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/httpconnectionpool/HttpClientStateTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/httpconnectionpool/HttpClientStateTest.groovy
@@ -75,7 +75,7 @@ class HttpClientStateTest extends ReposeValveTest {
         when:
 
         //Do it as a thread pool, in order to perhaps exercise the clients...
-        def pool = Executors.newFixedThreadPool(10)
+        def pool = Executors.newFixedThreadPool(20)
         def defer = { c -> pool.submit(c as Callable) }
         //TODO: make a pile of requests, and for all of them each one should have a different session, not one should be reused
         (1..1000).each { count ->
@@ -84,6 +84,14 @@ class HttpClientStateTest extends ReposeValveTest {
                 def response = client.execute(new HttpGet("http://localhost:${properties.reposePort}/"))
                 String content = response.getEntity().getContent().getText()
                 sessionIds.add(content) //Just store it for later verification
+
+                //Make one more request using this client, to see if we get the same session id
+                def response2 = client.execute(new HttpGet("http://localhost:${properties.reposePort}/"))
+                String content2 = response2.getEntity().getContent().getText()
+
+                //TODO: need to check this somehow in the spock assertions
+                assert content.equals(content2)
+
                 //Lets not use deproxy this time
 //                MessageChain mc = deproxy.makeRequest([url: reposeEndpoint + "/", headers: [
 //                        'x-trace-request': 'true',

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/httpconnectionpool/HttpClientStateTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/httpconnectionpool/HttpClientStateTest.groovy
@@ -1,0 +1,128 @@
+package features.services.httpconnectionpool
+
+import framework.ReposeValveTest
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.DefaultHttpClient
+import org.eclipse.jetty.server.Handler
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server.handler.DefaultHandler
+import org.eclipse.jetty.server.handler.HandlerList
+import org.eclipse.jetty.server.session.SessionHandler
+import org.eclipse.jetty.servlet.ServletHandler
+import org.rackspace.deproxy.Deproxy
+
+import javax.servlet.ServletException
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import javax.servlet.http.HttpSession
+import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class HttpClientStateTest extends ReposeValveTest {
+
+    Server server = null;
+
+    def cleanup() {
+        if (deproxy)
+            deproxy.shutdown()
+
+        server?.stop()
+    }
+
+    def "the connection pool should not persist cookies between clients"() {
+        given:
+
+        //Stand up a stupid jetty that can do stuff with a proxy
+        server = new Server(0)
+        //We should always get a new session here, maybe check the debug logging, otherwise we might have to reach in somehow
+        HandlerList handlers = new HandlerList()
+
+        SessionHandler handler = new SessionHandler()
+        ServletHandler servlet = new ServletHandler()
+        servlet.addServletWithMapping(SimpleServlet.class, "/*")
+
+        DefaultHandler defaultHandler = new DefaultHandler()
+        handlers.setHandlers([handler, servlet].toArray() as Handler[])
+        server.setHandler(handlers)
+
+        server.start()
+
+        int jettyPort = ((ServerConnector) server.getConnectors()[0]).getLocalPort()
+
+        deproxy = new Deproxy()
+        //Don't have deproxy do anything on our jetty port, we've got that covered
+        //deproxy.addEndpoint(jettyPort)
+
+        properties.targetPort = jettyPort //OVERRIDE with mine!
+        def params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/services/httpconnectionpool/common", params)
+        repose.configurationProvider.applyConfigs("features/services/httpconnectionpool/smallpool", params)
+        repose.start()
+
+        waitUntilReadyToServiceRequests()
+
+        //Make a pool, use that pool to do owrk, make sure the sessions are always different!
+
+
+        def sessionIds = new CopyOnWriteArrayList<String>()
+        when:
+
+        //Do it as a thread pool, in order to perhaps exercise the clients...
+        def pool = Executors.newFixedThreadPool(10)
+        def defer = { c -> pool.submit(c as Callable) }
+        //TODO: make a pile of requests, and for all of them each one should have a different session, not one should be reused
+        (1..1000).each { count ->
+            defer {
+                HttpClient client = new DefaultHttpClient()
+                def response = client.execute(new HttpGet("http://localhost:${jettyPort}/"))
+                String content = response.getEntity().getContent().getText()
+                sessionIds.add(content) //Just store it for later verification
+                //Lets not use deproxy this time
+//                MessageChain mc = deproxy.makeRequest([url: reposeEndpoint + "/", headers: [
+//                        'x-trace-request': 'true',
+//                        'x-count-thingy': count,
+//                ]])
+            }
+        }
+
+        pool.shutdown()
+        pool.awaitTermination(100, TimeUnit.SECONDS)
+
+        then: "something?"
+        //TODO need to assert that it's always getting a new session
+        Set<String> sessionIdSet = new HashSet<>()
+        sessionIds.each { id ->
+            assert sessionIdSet.add(id)
+        }
+
+    }
+
+
+    public static class SimpleServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            //Get the session in here, and do something to make sure it's always different
+            HttpSession session = req.getSession()
+
+            def cookies = req.getCookies()
+
+            def value = session.getAttribute("KEY")
+            println("Session ID: ${session.getId()} HEADER COUNT: ${req.getHeader("x-count-thingy")} KEY:${value} cookies: ${cookies}")
+            session.setAttribute("KEY", "VALUE")
+            def cookie = new Cookie("TESTCOOKIE", "TEH VALUE")
+            resp.addCookie(cookie)
+
+            resp.setContentType("text/plain")
+            resp.setStatus(HttpServletResponse.SC_OK)
+            resp.getWriter().println(session.getId())
+        }
+    }
+
+}

--- a/repose-aggregator/services/httpclient/impl/src/main/java/org/openrepose/services/httpclient/impl/HttpConnectionPoolProvider.java
+++ b/repose-aggregator/services/httpclient/impl/src/main/java/org/openrepose/services/httpclient/impl/HttpConnectionPoolProvider.java
@@ -1,5 +1,8 @@
 package org.openrepose.services.httpclient.impl;
 
+import org.apache.http.client.params.CookiePolicy;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpParams;
 import org.openrepose.core.service.httpclient.config.PoolType;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.params.ClientPNames;
@@ -30,7 +33,21 @@ public final class HttpConnectionPoolProvider {
 
         cm.setDefaultMaxPerRoute(poolConf.getHttpConnManagerMaxPerRoute());
         cm.setMaxTotal(poolConf.getHttpConnManagerMaxTotal());
-        DefaultHttpClient client = new DefaultHttpClient(cm);
+
+        //Set all the params up front, instead of mutating them? Maybe this matters
+        HttpParams params = new BasicHttpParams();
+        params.setParameter(ClientPNames.COOKIE_POLICY, CookiePolicy.IGNORE_COOKIES);
+        params.setBooleanParameter(ClientPNames.HANDLE_REDIRECTS, false);
+        params.setIntParameter(CoreConnectionPNames.SO_TIMEOUT, poolConf.getHttpSocketTimeout());
+        params.setIntParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, poolConf.getHttpConnectionTimeout());
+        params.setParameter(CoreConnectionPNames.TCP_NODELAY, poolConf.isHttpTcpNodelay());
+        params.setParameter(CoreConnectionPNames.MAX_HEADER_COUNT, poolConf.getHttpConnectionMaxHeaderCount());
+        params.setParameter(CoreConnectionPNames.MAX_LINE_LENGTH, poolConf.getHttpConnectionMaxLineLength());
+        params.setParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE, poolConf.getHttpSocketBufferSize());
+
+        //Pass in the params and the connection manager
+        DefaultHttpClient client = new DefaultHttpClient(cm, params);
+
         final String uuid =  UUID.randomUUID().toString();
         client.getParams().setParameter(CLIENT_INSTANCE_ID, uuid);
         SSLContext sslContext = ProxyUtilities.getTrustingSslContext();
@@ -38,13 +55,6 @@ public final class HttpConnectionPoolProvider {
         SchemeRegistry registry = cm.getSchemeRegistry();
         Scheme scheme = new Scheme("https", DEFAULT_HTTPS_PORT, ssf);
         registry.register(scheme);
-        client.getParams().setBooleanParameter(ClientPNames.HANDLE_REDIRECTS, false);
-        client.getParams().setIntParameter(CoreConnectionPNames.SO_TIMEOUT, poolConf.getHttpSocketTimeout());
-        client.getParams().setIntParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, poolConf.getHttpConnectionTimeout());
-        client.getParams().setParameter(CoreConnectionPNames.TCP_NODELAY, poolConf.isHttpTcpNodelay());
-        client.getParams().setParameter(CoreConnectionPNames.MAX_HEADER_COUNT, poolConf.getHttpConnectionMaxHeaderCount());
-        client.getParams().setParameter(CoreConnectionPNames.MAX_LINE_LENGTH, poolConf.getHttpConnectionMaxLineLength());
-        client.getParams().setParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE, poolConf.getHttpSocketBufferSize());
 
         client.setKeepAliveStrategy(new ConnectionKeepAliveWithTimeoutStrategy(poolConf.getKeepaliveTimeout()));
 

--- a/repose-aggregator/services/httpclient/impl/src/main/java/org/openrepose/services/httpclient/impl/HttpConnectionPoolProvider.java
+++ b/repose-aggregator/services/httpclient/impl/src/main/java/org/openrepose/services/httpclient/impl/HttpConnectionPoolProvider.java
@@ -44,12 +44,14 @@ public final class HttpConnectionPoolProvider {
         params.setParameter(CoreConnectionPNames.MAX_HEADER_COUNT, poolConf.getHttpConnectionMaxHeaderCount());
         params.setParameter(CoreConnectionPNames.MAX_LINE_LENGTH, poolConf.getHttpConnectionMaxLineLength());
         params.setParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE, poolConf.getHttpSocketBufferSize());
+        params.setBooleanParameter(CHUNKED_ENCODING_PARAM, poolConf.isChunkedEncoding());
+
+        final String uuid =  UUID.randomUUID().toString();
+        params.setParameter(CLIENT_INSTANCE_ID, uuid);
 
         //Pass in the params and the connection manager
         DefaultHttpClient client = new DefaultHttpClient(cm, params);
 
-        final String uuid =  UUID.randomUUID().toString();
-        client.getParams().setParameter(CLIENT_INSTANCE_ID, uuid);
         SSLContext sslContext = ProxyUtilities.getTrustingSslContext();
         SSLSocketFactory ssf = new SSLSocketFactory(sslContext, SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
         SchemeRegistry registry = cm.getSchemeRegistry();
@@ -57,8 +59,6 @@ public final class HttpConnectionPoolProvider {
         registry.register(scheme);
 
         client.setKeepAliveStrategy(new ConnectionKeepAliveWithTimeoutStrategy(poolConf.getKeepaliveTimeout()));
-
-        client.getParams().setBooleanParameter(CHUNKED_ENCODING_PARAM, poolConf.isChunkedEncoding());
 
         LOG.info("HTTP connection pool {} with instance id {} has been created", poolConf.getId(), uuid);
 


### PR DESCRIPTION
This is a test, and then a solution for the session bugs we've been having. Maybe there's more to it, but I think I've got it covered. In a thousand different requests, with a very small pool size (5) I didn't ever encounter a duplicated session. I make two requests with each http client to ensure that the same client gets the same session, and that was reliable as well.