### PR TITLE
Fixed the expected error message in a test that doesn't run in the normal Jenkins build.

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/derp/DerpAndClientAuthNDelegable.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/derp/DerpAndClientAuthNDelegable.groovy
@@ -114,12 +114,11 @@ class DerpAndClientAuthNDelegable extends ReposeValveTest {
 
         /* expected internal delegated messages to derp from authn:
             "status_code=401.component=client-auth-n.message=Unable to validate token:\\s.*;q=0.3"
-            "status_code=500.component=client-auth-n.message=Failure in AuthN filter.;q=0.3"
+            "status_code=500.component=client-auth-n.message=Failure in Auth-N filter.;q=0.3"
         */
         where:
         authRespCode | responseCode   | msgBody
         404          | "401"          | "Unable to validate token"
-        401          | "500"          | "Failure in AuthN filter"
+        401          | "500"          | "Failure in Auth-N filter."
     }
 }
-


### PR DESCRIPTION
This error message was normalized in REP-1526 Akka Client NPE. Since this test doesn't execute as part of the normal build cycle, it did not get caught until the nightly after the merge.