### PR TITLE
Fix scala tests not running.

### DIFF
--- a/repose-aggregator/components/filters/add-header/src/test/scala/org/openrepose/filters/addheader/AddHeaderHandlerTest.scala
+++ b/repose-aggregator/components/filters/add-header/src/test/scala/org/openrepose/filters/addheader/AddHeaderHandlerTest.scala
@@ -4,12 +4,15 @@ import java.io.InputStream
 import javax.servlet.http.{HttpServletResponse, HttpServletResponseWrapper}
 
 import com.mockrunner.mock.web._
+import org.junit.runner.RunWith
 import org.openrepose.commons.utils.http.header.HeaderName
 import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse
 import org.openrepose.core.filter.logic.FilterDirector
 import org.openrepose.filters.addheader.config.{AddHeadersConfig, Header, HttpMessage}
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers, PrivateMethodTester}
 
+@RunWith(classOf[JUnitRunner])
 class AddHeaderHandlerTest extends FunSpec with Matchers with PrivateMethodTester with BeforeAndAfter {
   var handler: AddHeaderHandler = _
   var myDirector: FilterDirector = _

--- a/repose-aggregator/components/filters/derp/src/test/scala/org/openrepose/filters/derp/DerpFilterTest.scala
+++ b/repose-aggregator/components/filters/derp/src/test/scala/org/openrepose/filters/derp/DerpFilterTest.scala
@@ -3,16 +3,19 @@ package org.openrepose.filters.derp
 import java.io.PrintWriter
 import java.util
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import javax.servlet.{ServletRequest, FilterChain, ServletResponse}
+import javax.servlet.{FilterChain, ServletRequest, ServletResponse}
 
+import org.junit.runner.RunWith
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.FunSpec
+import org.scalatest.junit.JUnitRunner
 
 import scala.collection.JavaConverters.asJavaEnumerationConverter
 
+@RunWith(classOf[JUnitRunner])
 class DerpFilterTest extends FunSpec {
 
   describe("doFilter") {

--- a/repose-aggregator/components/filters/forwarded-proto/src/test/scala/org/openrepose/filters/forwardedproto/ForwardedProtoFilterTest.scala
+++ b/repose-aggregator/components/filters/forwarded-proto/src/test/scala/org/openrepose/filters/forwardedproto/ForwardedProtoFilterTest.scala
@@ -4,14 +4,17 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.{FilterChain, ServletResponse}
 
 import com.mockrunner.mock.web.MockHttpServletRequest
+import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 
 import scala.collection.JavaConverters._
 
+@RunWith(classOf[JUnitRunner])
 class ForwardedProtoFilterTest extends FunSpec with Matchers with MockitoSugar {
 
   val forwardedProtoFilter = new ForwardedProtoFilter()

--- a/repose-aggregator/components/filters/herp/src/test/scala/org.openrepose.filters.herp/HerpFilterTest.scala
+++ b/repose-aggregator/components/filters/herp/src/test/scala/org.openrepose.filters.herp/HerpFilterTest.scala
@@ -3,12 +3,15 @@ package org.openrepose.filters.herp
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.test.appender.ListAppender
-import org.openrepose.filters.herp.config.{Template, HerpConfig}
+import org.junit.runner.RunWith
+import org.openrepose.filters.herp.config.{HerpConfig, Template}
 import org.scalatest._
+import org.scalatest.junit.JUnitRunner
 import org.springframework.mock.web.{MockFilterChain, MockHttpServletRequest, MockHttpServletResponse}
 
 import scala.collection.JavaConverters._
 
+@RunWith(classOf[JUnitRunner])
 class HerpFilterTest extends FunSpec with BeforeAndAfterAll with BeforeAndAfter with Matchers {
 
   var herpFilter: HerpFilter = _
@@ -381,7 +384,7 @@ class HerpFilterTest extends FunSpec with BeforeAndAfterAll with BeforeAndAfter 
 
       def logEvents = listAppender.getEvents
       logEvents.size shouldBe 1
-      logEvents.get(0).getMessage.getFormattedMessage should not include("\nLine One\n Line Two")
+      logEvents.get(0).getMessage.getFormattedMessage should not include ("\nLine One\n Line Two")
     }
   }
 }

--- a/repose-aggregator/components/filters/iri-validator/src/test/scala/org/openrepose/filters/irivalidator/IriValidatorFilterTest.scala
+++ b/repose-aggregator/components/filters/iri-validator/src/test/scala/org/openrepose/filters/irivalidator/IriValidatorFilterTest.scala
@@ -3,11 +3,14 @@ package org.openrepose.filters.irivalidator
 import javax.servlet.FilterChain
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
+import org.junit.runner.RunWith
 import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.scalatest.FunSpec
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
 
+@RunWith(classOf[JUnitRunner])
 class IriValidatorFilterTest extends FunSpec with MockitoSugar {
 
   describe("doFilter") {

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/test/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3APITest.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/test/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3APITest.scala
@@ -3,10 +3,12 @@ package org.openrepose.filters.openstackidentityv3.utilities
 import java.io.ByteArrayInputStream
 import java.util.concurrent.TimeUnit
 import javax.ws.rs.core.MediaType
+
 import org.apache.http.message.BasicHeader
 import org.hamcrest.Matchers.{equalTo, is, lessThanOrEqualTo, theInstance}
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
+import org.junit.runner.RunWith
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.openrepose.commons.utils.http.{HttpStatusCode, ServiceClientResponse}
@@ -14,11 +16,13 @@ import org.openrepose.filters.openstackidentityv3.config.{OpenstackIdentityServi
 import org.openrepose.filters.openstackidentityv3.objects.{AuthenticateResponse, Group}
 import org.openrepose.services.datastore.Datastore
 import org.openrepose.services.serviceclient.akka.AkkaServiceClient
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers, PrivateMethodTester}
 
 import scala.util.{Failure, Success, Try}
 
+@RunWith(classOf[JUnitRunner])
 class OpenStackIdentityV3APITest extends FunSpec with BeforeAndAfter with Matchers with PrivateMethodTester with MockitoSugar {
 
   var identityV3API: OpenStackIdentityV3API = _

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/test/scala/org/openrepose/filters/rackspaceidentitybasicauth/BasicAuthUtilsTest.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/test/scala/org/openrepose/filters/rackspaceidentitybasicauth/BasicAuthUtilsTest.scala
@@ -1,8 +1,11 @@
 package org.openrepose.filters.rackspaceidentitybasicauth
 
 import org.apache.commons.codec.binary.Base64
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FunSpec, Matchers}
 
+@RunWith(classOf[JUnitRunner])
 class BasicAuthUtilsTest extends FunSpec with Matchers with BasicAuthUtils {
 
   describe("decoding username and API key credentials") {


### PR DESCRIPTION
Since the seven Scala test classes containing these 25 tests weren't annotated, the tests weren't running as part of the normal build process.
The tests could be manually executed and all were currently passing, but they would not have failed a build.