### PR TITLE
Flume Appender Fix

### DIFF
--- a/repose-aggregator/core/core-lib/src/main/resources/log4j2.xml
+++ b/repose-aggregator/core/core-lib/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
+<Configuration packages="org.apache.logging.log4j.flume.appender">
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d %-r4 [%t] %-5p %c - %m%n"/>

--- a/repose-aggregator/core/core-lib/src/main/resources/org/openrepose/core/services/logging/log4j2-DEFAULT.xml
+++ b/repose-aggregator/core/core-lib/src/main/resources/org/openrepose/core/services/logging/log4j2-DEFAULT.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
+<Configuration packages="org.apache.logging.log4j.flume.appender">
     <Appenders>
         <Console name="STDOUT">
             <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>

--- a/repose-aggregator/core/valve/pom.xml
+++ b/repose-aggregator/core/valve/pom.xml
@@ -204,6 +204,11 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.logging.log4j:log4j-flume-ng</artifact>
+                                    <excludes>
                                         <exclude>META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat</exclude>
                                     </excludes>
                                 </filter>

--- a/repose-aggregator/core/valve/pom.xml
+++ b/repose-aggregator/core/valve/pom.xml
@@ -206,6 +206,14 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <!-- We are removing the Log4j2Plugins.dat file from the log4j-flume-ng dependency
+                                     so that we don't overwrite the existing Log4j2Plugins.dat file. Overwriting causes
+                                     logs to vanish (presumably being consumed by the Flume appender). This is a
+                                     design flaw which exists between the Log4j2 plugin system and fat/shaded jars.
+                                     See: https://issues.apache.org/jira/browse/LOG4J2-673
+
+                                     Note that the packages attribute in the Log4j2 configuration file should cause
+                                     Log4j2 to recognize the Flume appender as a plugin.-->
                                 <filter>
                                     <artifact>org.apache.logging.log4j:log4j-flume-ng</artifact>
                                     <excludes>

--- a/repose-aggregator/core/valve/pom.xml
+++ b/repose-aggregator/core/valve/pom.xml
@@ -204,6 +204,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/common/log4j2-test.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/common/log4j2-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
+<Configuration packages="org.apache.logging.log4j.flume.appender">
     <Appenders>
         <RollingFile name="RollingFile" fileName="${repose.log.name}"
                      filePattern="${repose.log.pattern}" immediateFlush="true">

--- a/repose-aggregator/installation/configs/core/log4j2.xml
+++ b/repose-aggregator/installation/configs/core/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration monitorInterval="15">
+<Configuration monitorInterval="15" packages="org.apache.logging.log4j.flume.appender">
     <Appenders>
         <Console name="STDOUT">
             <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>


### PR DESCRIPTION
So the problem seems to have arisen from the Log4j2Plugins.dat file which was generated and made its way into our fat jar. I am not 100% certain why that broke things (maybe the plugin was generated for the flume appender jar and moving it into our fat jar messed everything up?) but changing the mechanism log4j2 uses to load the plugin at least got our logs back.

I have also not yet tested this. I'm going to let the PR builder test our current system test suite, and I imagine our new Repose to Flume tests will make sure the appender is working.

A couple of other things to consider:
1. We may be able to prevent the Log4j2Plugins.dat file from being generated rather than excluding it in the shader plugin.
2. There are a couple of other ways we could add the plugin without changing the log4j2 configuration file. See: http://logging.apache.org/log4j/2.x/manual/plugins.html