### PR TITLE
Clearing TechDebt in the ResponseCaptureFilter class

### DIFF
--- a/repose-aggregator/experimental/servlet-contract-filter/src/main/java/org/openrepose/experimental/filters/servletcontract/ResponseCaptureFilter.java
+++ b/repose-aggregator/experimental/servlet-contract-filter/src/main/java/org/openrepose/experimental/filters/servletcontract/ResponseCaptureFilter.java
@@ -37,10 +37,10 @@ public class ResponseCaptureFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-
-        System.out.println("Start " + this.getClass().getName());
+        LOG.info("Start {}", this.getClass().getName());
     }
 
+    @SuppressWarnings("squid:S00112")
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
             throws IOException, ServletException {
@@ -53,17 +53,16 @@ public class ResponseCaptureFilter implements Filter {
         HttpServletRequest req = (HttpServletRequest) servletRequest;
 
         // Print out info from request & response wrapper
-        System.out.println("URI: " + req.getRequestURI());
-        System.out.println("Status: " + respWrap.getStatus());
-        System.out.println("resp Header 'Content-Type: " + respWrap.getHeader("Content-Type"));
+        LOG.info("URI: {}", req.getRequestURI());
+        LOG.info("Status: {}", respWrap.getStatus());
+        LOG.info("resp Header 'Content-Type: {}", respWrap.getHeader("Content-Type"));
 
         String content = respWrap.getContent();
 
-        System.out.println("Content Body: '" + content + "'");
+        LOG.info("Content Body: '{}'", content);
 
         // verify that the content is not empty.  This fails in repose but works in tomcat
         if (content.isEmpty()) {
-
             throw new RuntimeException("Content is empty");
         }
 
@@ -74,6 +73,7 @@ public class ResponseCaptureFilter implements Filter {
 
     @Override
     public void destroy() {
+        // There are no resources to release.
     }
 
     private class FilterServletOutputStream extends ServletOutputStream {
@@ -112,7 +112,6 @@ public class ResponseCaptureFilter implements Filter {
                 stream.close();
             } catch (IOException e) {
                 LOG.trace("Caught Exception while flushing and closing stream.", e);
-                e.printStackTrace();
             }
             return stream.toString();
         }


### PR DESCRIPTION
Added a SuppressWarnings annotation to ignore Sonar rule "Define and throw a dedicated exception instead of using a generic one." (squid:S00112) in this test class.
Replaced all of the System.out/err calls with equivalent Logger calls.
Added a comment to the empty destroy() method to prevent triggering squid:S1186.