### PR TITLE
REP-1885 Updated the RPM packages to use Versioned Virtual Packages

### DIFF
--- a/repose-aggregator/extensions/api-validator/pom.xml
+++ b/repose-aggregator/extensions/api-validator/pom.xml
@@ -64,6 +64,7 @@
             <groupId>com.rackspace.papi.components.api-checker</groupId>
             <artifactId>checker-core</artifactId>
             <version>1.0.21</version>
+            <!--version>1.0.22-SNAPSHOT</version-->
         </dependency>
     </dependencies>
 

--- a/repose-aggregator/extensions/api-validator/pom.xml
+++ b/repose-aggregator/extensions/api-validator/pom.xml
@@ -64,7 +64,6 @@
             <groupId>com.rackspace.papi.components.api-checker</groupId>
             <artifactId>checker-core</artifactId>
             <version>1.0.21</version>
-            <!--version>1.0.22-SNAPSHOT</version-->
         </dependency>
     </dependencies>
 

--- a/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
@@ -174,7 +174,7 @@
 
                             <requires>
                                 <require>java &gt;= 1.7.0</require>
-                                <require>repose-${project.version}</require>
+                                <require>repose = ${project.version}</require>
                             </requires>
 
                             <group>Applications/Internet</group>

--- a/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
@@ -145,7 +145,7 @@
 
                             <requires>
                                 <require>java &gt;= 1.7.0</require>
-                                <require>repose-${project.version}</require>
+                                <require>repose = ${project.version}</require>
                             </requires>
 
                             <obsoletes>

--- a/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
@@ -142,7 +142,7 @@
 
                             <requires>
                                 <require>java &gt;= 1.7.0</require>
-                                <require>repose-${project.version}</require>
+                                <require>repose = ${project.version}</require>
                             </requires>
 
                             <obsoletes>

--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -284,7 +284,7 @@
                             </requires>
 
                             <provides>
-                                <provide>repose-${project.version}</provide>
+                                <provide>repose = ${project.version}</provide>
                             </provides>
 
                             <conflicts>

--- a/repose-aggregator/installation/rpm/repose-war/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-war/pom.xml
@@ -236,7 +236,7 @@
                             </requires>
 
                             <provides>
-                                <provide>repose-${project.version}</provide>
+                                <provide>repose = ${project.version}</provide>
                             </provides>
 
                             <conflicts>


### PR DESCRIPTION
See: #1264 

This does work contrary to the documentation referenced by the plugin (http://www.rpm.org/max-rpm-snapshot/s1-rpm-depend-manual-dependencies.html). I have submitted a patch to the RPM Maven Plugin team to update the documentation to reflect this.