### PR TITLE
Adding copytruncate to logrotate to stop empty files

### DIFF
--- a/repose-aggregator/installation/configs/etc/logrotate.d/repose
+++ b/repose-aggregator/installation/configs/etc/logrotate.d/repose
@@ -4,4 +4,5 @@
     missingok
     notifempty
     compress
+    copytruncate
 }


### PR DESCRIPTION
When logrotate rotates the repose logs, the result is empty log files because the file handle being written is still the old file.  The solution is to configure logrotate with copytruncate so that it copies the file and repose will continue to write to the old file handle.