### PR TITLE
REP-1869 Update POM's to sign RPM and DEB artifacts.

### DIFF
--- a/repose-aggregator/installation/deb/pom.xml
+++ b/repose-aggregator/installation/deb/pom.xml
@@ -46,6 +46,16 @@
                             <goals>
                                 <goal>jdeb</goal>
                             </goals>
+                            <configuration>
+                                <signPackage>true</signPackage>
+                                <!-- Old Debian based distros. -->
+                                <!--<signMethod>debsig-verify</signMethod>-->
+                                <!-- New Debian based distros. -->
+                                <signMethod>dpkg-sig</signMethod>
+                                <verbose>true</verbose>
+                                <key>${gpg.keyname}</key>
+                                <passphrase>${gpg.passphrase}</passphrase>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>default-jdeb</id>

--- a/repose-aggregator/installation/deb/pom.xml
+++ b/repose-aggregator/installation/deb/pom.xml
@@ -23,6 +23,43 @@
         <module>repose-valve</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <!-- this profile works with gnupg 2.0.x NOT with 2.1.x -->
+            <id>release-sign-artifacts</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.vafer</groupId>
+                        <artifactId>jdeb</artifactId>
+                        <version>1.3</version>
+
+                        <configuration>
+                            <signPackage>true</signPackage>
+                            <!-- Old Debian based distros. -->
+                            <!--<signMethod>debsig-verify</signMethod>-->
+                            <!-- New Debian based distros. -->
+                            <signMethod>dpkg-sig</signMethod>
+                            <verbose>true</verbose>
+                            <key>${gpg.keyname}</key>
+                            <passphrase>${gpg.passphrase}</passphrase>
+
+                            <description>
+                                Power API is a stack of reusable, software components that can be leveraged by
+                                service developers to perform common API processing tasks.
+                            </description>
+
+                            <copyright>Apache License, Version 2.0</copyright>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <extensions>
             <!-- Add support for the "deb" packaging -->
@@ -46,16 +83,6 @@
                             <goals>
                                 <goal>jdeb</goal>
                             </goals>
-                            <configuration>
-                                <signPackage>true</signPackage>
-                                <!-- Old Debian based distros. -->
-                                <!--<signMethod>debsig-verify</signMethod>-->
-                                <!-- New Debian based distros. -->
-                                <signMethod>dpkg-sig</signMethod>
-                                <verbose>true</verbose>
-                                <key>${gpg.keyname}</key>
-                                <passphrase>${gpg.passphrase}</passphrase>
-                            </configuration>
                         </execution>
                         <execution>
                             <id>default-jdeb</id>

--- a/repose-aggregator/installation/rpm/pom.xml
+++ b/repose-aggregator/installation/rpm/pom.xml
@@ -56,7 +56,7 @@
 
                         <keyname>${gpg.keyname}</keyname>
                         <keyPassphrase>
-                            <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+                            <passphrase>${gpg.passphrase}</passphrase>
                         </keyPassphrase>
 
                         <description>

--- a/repose-aggregator/installation/rpm/pom.xml
+++ b/repose-aggregator/installation/rpm/pom.xml
@@ -56,7 +56,7 @@
 
                         <keyname>${gpg.keyname}</keyname>
                         <keyPassphrase>
-                            <passphrase>${gpg.passphrase}</passphrase>
+                            <passphrase>${gpg.passphrase.esc}</passphrase>
                         </keyPassphrase>
 
                         <description>

--- a/repose-aggregator/installation/rpm/pom.xml
+++ b/repose-aggregator/installation/rpm/pom.xml
@@ -56,7 +56,7 @@
 
                         <keyname>${gpg.keyname}</keyname>
                         <keyPassphrase>
-                            <passphrase>${gpg.passphrase.esc}</passphrase>
+                            <passphrase>${gpg.passphrase}</passphrase>
                         </keyPassphrase>
 
                         <description>

--- a/repose-aggregator/installation/rpm/pom.xml
+++ b/repose-aggregator/installation/rpm/pom.xml
@@ -54,6 +54,11 @@
                         <group>Rackspace Repose</group>
                         <packager>Rackspace - Cloud Integration Team</packager>
 
+                        <keyname>${gpg.keyname}</keyname>
+                        <keyPassphrase>
+                            <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+                        </keyPassphrase>
+
                         <description>
                             Power API is a stack of reusable, software components that can be leveraged by
                             service developers to perform common API processing tasks.

--- a/repose-aggregator/installation/rpm/pom.xml
+++ b/repose-aggregator/installation/rpm/pom.xml
@@ -23,6 +23,47 @@
         <module>repose-valve</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <!-- this profile works with gnupg 2.0.x NOT with 2.1.x -->
+            <id>release-sign-artifacts</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                        <version>2.1.2</version>
+
+                        <configuration>
+                            <!-- _tmppath is not set correctly on all OSes so it is forced here -->
+                            <defineStatements>
+                                <defineStatement>_tmppath /tmp</defineStatement>
+                            </defineStatements>
+
+                            <group>Rackspace Repose</group>
+                            <packager>Rackspace - Cloud Integration Team</packager>
+
+                            <keyname>${gpg.keyname}</keyname>
+                            <keyPassphrase>
+                                <passphrase>${gpg.passphrase}</passphrase>
+                            </keyPassphrase>
+
+                            <description>
+                                Power API is a stack of reusable, software components that can be leveraged by
+                                service developers to perform common API processing tasks.
+                            </description>
+
+                            <copyright>Apache License, Version 2.0</copyright>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <!-- Having these here configures the plugin execution goals and configurations used by all children poms -->
         <pluginManagement>
@@ -30,7 +71,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>rpm-maven-plugin</artifactId>
-                    <version>2.1-alpha-1</version>
+                    <version>2.1.2</version>
 
                     <executions>
                         <execution>
@@ -53,11 +94,6 @@
 
                         <group>Rackspace Repose</group>
                         <packager>Rackspace - Cloud Integration Team</packager>
-
-                        <keyname>${gpg.keyname}</keyname>
-                        <keyPassphrase>
-                            <passphrase>${gpg.passphrase}</passphrase>
-                        </keyPassphrase>
 
                         <description>
                             Power API is a stack of reusable, software components that can be leveraged by

--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -471,7 +471,6 @@
             <properties>
                 <gpg.keyname>E7C89BBB</gpg.keyname>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-                <gpg.passphrase.esc>${env.GPG_PASSPHRASE_ESC}</gpg.passphrase.esc>
             </properties>
             <build>
                 <plugins>

--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -471,6 +471,7 @@
             <properties>
                 <gpg.keyname>E7C89BBB</gpg.keyname>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+                <gpg.passphrase.esc>${env.GPG_PASSPHRASE_ESC}</gpg.passphrase.esc>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
This requires the Repose Signing Keys and Passphrase ver. 3 dated Mar 26, 2015 to be on the Jenkins Master and Slaves before the final test can be executed.