### PR TITLE
REP-1953 Licensing Round Two

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,15 @@
+Contributions to this project are only accepted under the terms of the Apache License, v2.
+By contributing, you are agreeing that:
+
+ * All original copyrightable portions of your contribution are licensed under the Apache License, v2.
+ * Any portions of your contribution copyrighted by third parties are compatible
+   with the Apache license, v2 being used by the Repose project.
+ * You have the legal right to make the contribution.
+
+If any part of this contribution was made using your employer's time or resources,
+an authorized person from your employer will need to affirm your right to make contributions to Repose.
+Please contact the maintainers at reposecore@rackspace.com if you need help.
+
+In addition, the project maintainers may require additional administrative steps for some contributions,
+such as adding yourself to the CONTRIBUTORS.txt file, documenting any dependencies in DEPENDENCIES.txt, etc.
+Refusal to perform these additional administrative steps may result in your contribution being refused.

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -32,6 +32,7 @@ HttpComponents              4.2.5               org.apache.httpcomponents       
 Jackson                     2.4.0               com.fasterxml.jackson.core                  Apache License Version 2.0                                              http://wiki.fasterxml.com/JacksonDownload
                                                                                             GNU Lesser General Public License, version 2.1
 Java Binding (JSR 222)      0.6.3               org.jvnet.jaxb2_commons                     CDDL v1.1 and GPL v2                                                    https://jaxb.java.net/
+Java Inject (JSR 330)       1                   javax.inject                                Apache License Version 2.0                                              https://jcp.org/en/jsr/detail?id=330
 Java REST (JSR 311)         2.0.1               javax.ws.rs                                 Common Development and Distribution License (CDDL - Version 1.1)        https://jax-rs-spec.java.net/
 Jersey                      1.19                com.sun.jersey                              Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
                                                                                             GNU General Public License, version 2 with the “Classpath Exception"

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -15,52 +15,29 @@ Below is the full list of dependencies.
 By contributing to this project, you agree to abide to the terms and conditions
 outlined in CONTRIBUTORS.txt.
 
-Name                        Dependency version  POM groupId                                 Licenses                                                                Source
---------------------------  ------------------  -----------------------------------------   --------------------------------------------------------------------    ----------------------------------------------------------------------------------------------------------
 Apache Commons CLI          1.2                 commons-cli                                 Apache License Version 2.0                                              http://commons.apache.org/proper/commons-cli/dependencies.html
-Apache Commons Codec        1.10                commons-codec                               Apache License Version 2.0                                              http://www.apache.org/licenses/
-Apache Commons IO           2.4                 commons-io                                  Apache License Version 2.0                                              http://www.apache.org/licenses/
-Apache Commons Lang         3.3.2               commons-lang3                               Apache License Version 2.0                                              http://projects.apache.org/projects/commons_lang.html
-Apache Commons Pool         1.6                 commons-pool                                Apache License Version 2.0                                              http://projects.apache.org/projects/commons_pool.html
-Apache Jena                 1.1.1               org.apache.jena                             Apache License Version 2.0                                              http://jena.apache.org/
 Apache Tomcat               7.0.42              org.apache.tomcat                           Apache License Version 2.0                                              http://tomcat.apache.org/legal.html
 Apache Tomcat Embedded      7.0.42              org.apache.tomcat.embed                     Apache License Version 2.0                                              http://tomcat.apache.org/legal.html
-Apache Xerces               2.12.0-rax          xerces                                      Apache License Version 2.0                                              http://xerces.apache.org/xml-commons/licenses.html
-API Checker                 1.0.22              com.rackspace.papi.components.api-checker   Apache License Version 2.0                                              https://github.com/rackerlabs/api-checker/blob/master/LICENSE.txt
 CGLib                       2.2.2               cglib                                       Apache License Version 1.1                                              http://cglib.sourceforge.net/license.html
 DeProxy                     0.21                org.rackspace                               MIT License                                                             https://github.com/rackerlabs/deproxy/blob/master/LICENSE
-EHCache                     2.6.0               net.sf.ehcache                              Apache License Version 2.0                                              http://ehcache.org/about/license
 Glassfish                   3.1                 org.glassfish                               Common Development and Distribution License (CDDL - Version 1.1)        https://glassfish.java.net/license.html
                                                                                             GNU General Public License, version 2 with the "Classpath Exception"
 Glassfish Embedded          3.1.2.2             org.glassfish.main.extras                   Common Development and Distribution License (CDDL - Version 1.1)        https://glassfish.java.net/license.html
                                                                                             GNU General Public License, version 2 with the "Classpath Exception"
 Groovy                      2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
-Guava                       14.0.1              com.google.guava                            Apache License Version 2.0                                              https://code.google.com/p/guava-libraries/
 Hamcrest                    1.3                 org.hamcrest                                New BSD License                                                         https://code.google.com/p/hamcrest/
-Handlebars                  2.0.0               com.github.jknack                           Apache License Version 2.0                                              https://github.com/jknack/handlebars.java
-HttpComponents              4.2.5               org.apache.httpcomponents                   Apache License Version 2.0                                              http://hc.apache.org/httpcomponents-client-4.2.x/license.html
-Jackson                     2.4.0               com.fasterxml.jackson.core                  Apache License Version 2.0                                              http://wiki.fasterxml.com/JacksonDownload
-                                                                                            GNU Lesser General Public License, version 2.1
 Java EE                     6.0                 javax                                       Oracle Specific License                                                 http://www.oracle.com/technetwork/java/javase/downloads/366879
-Java Binding (JSR 222)      0.6.3               org.jvnet.jaxb2_commons                     CDDL v1.1 and GPL v2                                                    https://jaxb.java.net/
 Java Inject (JSR 330)       1                   javax.inject                                Apache License Version 2.0                                              https://jcp.org/en/jsr/detail?id=330
 Java Mail (JSR 919)         1.4.4               javax.mail                                  Common Development and Distribution License (CDDL - Version 1.1)        https://java.net/projects/javamail/pages/License
-Java REST (JSR 311)         2.0.1               javax.ws.rs                                 Common Development and Distribution License (CDDL - Version 1.1)        https://jax-rs-spec.java.net/
 Java Transaction (JSR 907)  1.1                 javax.transaction                           Oracle Specific License                                                 http://download.oracle.com/otndocs/jcp/jta-1.1-spec-oth-JSpec/jta-1.1-spec-oth-JSpec-license.html
                                                                                             GNU General Public License, version 2 with the "Classpath Exception"
 JBoss Java EE 6             1.0.0.Final         org.jboss.spec                              None listed for this specific version, future versions use              http://repo1.maven.org/maven2/org/jboss/spec/jboss-javaee-6.0/3.0.1.Final/jboss-javaee-6.0-3.0.1.Final.pom
 Specification APIs                                                                          GNU Lesser General Public License, Version 2.1
-Jersey                      1.19                com.sun.jersey                              Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
-                                                                                            GNU General Public License, version 2 with the “Classpath Exception"
 Jersey Common               2.14                org.glassfish.jersey.core                   Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
                                                                                             GNU General Public License, version 2 with the “Classpath Exception"
 Jersey Test Framework       1.0.3.1             com.sun.jersey.test.framework               Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
                                                                                             GNU General Public License, version 2 with the “Classpath Exception"
 Jetbrains Annotations       13.0                org.jetbrains                               Apache License Version 2.0                                              http://mvnrepository.com/artifact/org.jetbrains/annotations/13.0
-Jetty                       9.2.0.v20140526     org.eclipse.jetty                           Apache License Version 2.0                                              http://www.eclipse.org/jetty/licenses.php
-                                                                                            Eclipse Public License 1.0
-Joda Convert                1.7                 org.joda                                    Apache License Version 2.0                                              http://www.joda.org/joda-convert/
-Joda Time                   2.7                 joda-time                                   Apache License Version 2.0                                              http://joda-time.sourceforge.net/license.html
 JUnit                       4.12                junit                                       IBM's Common Public License Version 0.5                                 http://junit.sourceforge.net/doc/faq/faq.htm#overview_7
 linkedin-utils              1.8.0               org.linkedin                                Apache License Version 2.0                                              http://mvnrepository.com/artifact/org.linkedin/org.linkedin.util-groovy/1.7.2
 Log4J                       2.1                 log4j                                       Apache License Version 2.0                                              https://logging.apache.org/log4j/2.x/license.html
@@ -68,12 +45,41 @@ Mockito                     1.9.5               org.mockito                     
 Mockrunner                  1.0.0(0.4.1)        com.mockrunner                              Mockrunner specific license                                             http://mockrunner.sourceforge.net/LICENSE.txt
 PJL Compressing Filter      1.7                 net.sourceforge.pjl-comp-filter             Apache License Version 2.0                                              http://sourceforge.net/projects/pjl-comp-filter/
 PowerMock                   1.5.4               org.powermock                               Apache License Version 2.0                                              https://code.google.com/p/powermock/
+ScalaTest                   2.2.0               org.scalatest                               Apache License Version 2.0                                              http://www.scalatest.org/
+Spock                       0.7-groovy-2.0      org.spockframework                          Apache License Version 2.0                                              https://code.google.com/p/spock/
+XML Calabash                0.9.38              com.xmlcalabash                             None listed for this specific version, future versions use              https://search.maven.org/remotecontent?filepath=com/xmlcalabash/xmlcalabash/1.0.32-96/xmlcalabash-1.0.32-96.pom
+                                                                                            Common Development and Distribution License (CDDL - Version 1.1)
+                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
+XML Unit                    1.3                 xmlunit                                     BSD License                                                             http://sourceforge.net/projects/xmlunit/
+
+Name                        Dependency version  POM groupId                                 Licenses                                                                Source
+--------------------------  ------------------  -----------------------------------------   --------------------------------------------------------------------    ----------------------------------------------------------------------------------------------------------
+Apache Commons Codec        1.10                commons-codec                               Apache License Version 2.0                                              http://www.apache.org/licenses/
+Apache Commons IO           2.4                 commons-io                                  Apache License Version 2.0                                              http://www.apache.org/licenses/
+Apache Commons Lang         3.3.2               commons-lang3                               Apache License Version 2.0                                              http://projects.apache.org/projects/commons_lang.html
+Apache Commons Pool         1.6                 commons-pool                                Apache License Version 2.0                                              http://projects.apache.org/projects/commons_pool.html
+Apache Jena                 1.1.1               org.apache.jena                             Apache License Version 2.0                                              http://jena.apache.org/
+Apache Log4J                2.1                 org.apache.logging.log4j                    Apache License Version 2.0                                              https://logging.apache.org/log4j/2.x/license.html
+Apache Xerces               2.12.0-rax          xerces                                      Apache License Version 2.0                                              http://xerces.apache.org/xml-commons/licenses.html
+API Checker                 1.0.22              com.rackspace.papi.components.api-checker   Apache License Version 2.0                                              https://github.com/rackerlabs/api-checker/blob/master/LICENSE.txt
+EHCache                     2.6.0               net.sf.ehcache                              Apache License Version 2.0                                              http://ehcache.org/about/license
+Guava                       14.0.1              com.google.guava                            Apache License Version 2.0                                              https://code.google.com/p/guava-libraries/
+Handlebars                  2.0.0               com.github.jknack                           Apache License Version 2.0                                              https://github.com/jknack/handlebars.java
+HttpComponents              4.2.5               org.apache.httpcomponents                   Apache License Version 2.0                                              http://hc.apache.org/httpcomponents-client-4.2.x/license.html
+Jackson                     2.4.0               com.fasterxml.jackson.core                  Apache License Version 2.0                                              http://wiki.fasterxml.com/JacksonDownload
+                                                                                            GNU Lesser General Public License, version 2.1
+Java Binding (JSR 222)      0.6.3               org.jvnet.jaxb2_commons                     CDDL v1.1 and GPL v2                                                    https://jaxb.java.net/
+Java REST (JSR 311)         2.0.1               javax.ws.rs                                 Common Development and Distribution License (CDDL - Version 1.1)        https://jax-rs-spec.java.net/
+Jersey                      1.19                com.sun.jersey                              Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
+                                                                                            GNU General Public License, version 2 with the “Classpath Exception"
+Jetty                       9.2.0.v20140526     org.eclipse.jetty                           Apache License Version 2.0                                              http://www.eclipse.org/jetty/licenses.php
+                                                                                            Eclipse Public License 1.0
+Joda Convert                1.7                 org.joda                                    Apache License Version 2.0                                              http://www.joda.org/joda-convert/
+Joda Time                   2.7                 joda-time                                   Apache License Version 2.0                                              http://joda-time.sourceforge.net/license.html
 SLF4J                       1.7.7               org.slf4j                                   MIT License                                                             http://slf4j.org/license.html
 Saxon                       9.4.0.9             net.sf.saxon                                Mozilla Public License version 2.0                                      http://saxon.sourceforge.net/
 Scala Lang                  2.10.3              org.scala-lang                              Scala Specific License                                                  http://www.scala-lang.org/license.html
-ScalaTest                   2.2.0               org.scalatest                               Apache License Version 2.0                                              http://www.scalatest.org/
 Scopt                       3.2.0               com.github.scopt                            MIT License                                                             https://github.com/scopt/scopt
-Spock                       0.7-groovy-2.0      org.spockframework                          Apache License Version 2.0                                              https://code.google.com/p/spock/
 Spray JSON                  1.2.6               io.spray                                    Apache License Version 2.0                                              https://github.com/spray/spray-json
 Spring Framework            4.1.4.RELEASE       org.springframework                         Apache License Version 2.0                                              https://github.com/spring-projects/spring-framework
 Typesafe Akka               2.2.3               com.typesafe.akka                           Apache License Version 2.0                                              http://doc.akka.io/docs/akka/snapshot/project/licenses.html
@@ -81,8 +87,4 @@ Typesafe Config             1.2.1               com.typesafe                    
 Typesafe Play-JSON          2.3.4               com.typesafe.play                           Apache License Version 2.0                                              https://github.com/playframework/playframework
 Typesafe Scala Logging      2.1.2               com.typesafe.scala-logging                  Apache License Version 2.0                                              https://github.com/typesafehub/scala-logging
 Xalan-Java                  2.7.1               xalan                                       Apache License Version 2.0                                              http://xalan.apache.org/old/xalan-j/index.html
-XML Calabash                0.9.38              com.xmlcalabash                             None listed for this specific version, future versions use              https://search.maven.org/remotecontent?filepath=com/xmlcalabash/xmlcalabash/1.0.32-96/xmlcalabash-1.0.32-96.pom
-                                                                                            Common Development and Distribution License (CDDL - Version 1.1)
-                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
-XML Unit                    1.3                 xmlunit                                     BSD License                                                             http://sourceforge.net/projects/xmlunit/
 Yammer Metrics              2.2.0               com.yammer.metrics                          Apache License Version 2.0                                              http://metrics.codahale.com/about/release-notes/

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -28,7 +28,7 @@ API Checker             1.0.22              com.rackspace.papi.components.api-ch
 CGLib                   2.2.2               cglib                                       Apache License Version 1.1                                              http://cglib.sourceforge.net/license.html
 DeProxy                 0.21                org.rackspace                               MIT License                                                             https://github.com/rackerlabs/deproxy/blob/master/LICENSE
 EHCache                 2.6.0               net.sf.ehcache                              Apache License Version 2.0                                              http://ehcache.org/about/license
-Glassfish               3.1                 org.glassfish                               COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL - Version 1.1)        https://glassfish.java.net/license.html
+Glassfish               3.1                 org.glassfish                               Common Development and Distribution License (CDDL - Version 1.1)        https://glassfish.java.net/license.html
                                                                                         GNU General Public License, version 2 with the "Classpath Exception"
 Groovy                  2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
 Groovy                  2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
@@ -39,12 +39,12 @@ Jackson                 1.9.13              org.codehaus.jackson                
                                                                                         GNU Lesser General Public License, version 2.1
 Java EE                 6                   javax                                       Oracle Specific License                                                 http://www.oracle.com/technetwork/java/javase/downloads/366879
 Java Transaction API    1.1                 javax.transaction                           Oracle Specific License                                                 http://download.oracle.com/otndocs/jcp/jta-1.1-spec-oth-JSpec/jta-1.1-spec-oth-JSpec-license.html
-JavaMail                1.4.4               javax.mail                                  COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL - Version 1.1)        https://java.net/projects/javamail/pages/License
+JavaMail                1.4.4               javax.mail                                  Common Development and Distribution License (CDDL - Version 1.1)        https://java.net/projects/javamail/pages/License
                                                                                         GNU General Public License, version 2 with the "Classpath Exception"
 JaxB                    0.6.3               org.jvnet.jaxb2_commons                     CDDL v1.1 and GPL v2.                                                   https://jaxb.java.net/
 JBoss Java EE 6         1.0.0.Final         org.jboss.spec                              None listed for this specific version, future versions use              http://repo1.maven.org/maven2/org/jboss/spec/jboss-javaee-6.0/3.0.1.Final/jboss-javaee-6.0-3.0.1.Final.pom
 Specification APIs                                                                      GNU Lesser General Public License, Version 2.1
-Jersey                  1.16                com.sun.jersey                              COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL - Version 1.1)        https://jersey.java.net/license.html
+Jersey                  1.16                com.sun.jersey                              Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
                                                                                         GNU General Public License, version 2 with the “Classpath Exception"
 Jetty                   9.2.0.v20140526     org.eclipse.jetty                           Apache License 2.0                                                      http://www.eclipse.org/jetty/licenses.php
                                                                                         Eclipse Public License 1.0

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -1,0 +1,66 @@
+Original files contained with this distribution of Repose are licensed under
+the Apache License v2.0 (http://www.apache.org/licenses/LICENSE-2.0).
+
+You must agree to the terms of this license and abide by them before using,
+modifying, or distributing Repose or the Repose source code contained within
+this distribution.
+
+Some dependencies are under other licenses.
+
+By using, modifying, or distributing Repose you may also be subject to the
+terms of those licenses.
+
+Below is the full list of dependencies.
+
+By contributing to this project, you agree to abide to the terms and conditions
+outlined in CONTRIBUTORS.txt.
+
+Name                    Dependency version  POM groupId                                 Licenses                                                                Source
+----------------------  ------------------  -----------------------------------------   --------------------------------------------------------------------    ----------------------------------------------------------------------------------------------------------
+Akka                    2.2.3               com.typesafe.akka                           Apache License Version 2.0                                              http://doc.akka.io/docs/akka/snapshot/project/licenses.html
+Apache Commons CLI      1.2                 commons-cli                                 Apache License Version 2.0                                              http://commons.apache.org/proper/commons-cli/dependencies.html
+Apache Commons Codec    1.7                 commons-codec                               Apache License Version 2.0                                              http://www.apache.org/licenses/
+Apache Commons IO       2.4                 commons-io                                  Apache License Version 2.0                                              http://www.apache.org/licenses/
+Apache Commons Lang     2.6                 commons-lang                                Apache License Version 2.0                                              http://projects.apache.org/projects/commons_lang.html
+Apache Tomcat           7.0.42              org.apache.tomcat.embed                     Apache License Version 2.0                                              http://tomcat.apache.org/legal.html
+Apache Xerces           2.12.0-rax          xerces                                      Apache License Version 2.0                                              http://xerces.apache.org/xml-commons/licenses.html
+API Checker             1.0.22              com.rackspace.papi.components.api-checker   Apache License Version 2.0                                              https://github.com/rackerlabs/api-checker/blob/master/LICENSE.txt
+CGLib                   2.2.2               cglib                                       Apache License Version 1.1                                              http://cglib.sourceforge.net/license.html
+DeProxy                 0.21                org.rackspace                               MIT License                                                             https://github.com/rackerlabs/deproxy/blob/master/LICENSE
+EHCache                 2.6.0               net.sf.ehcache                              Apache License Version 2.0                                              http://ehcache.org/about/license
+Glassfish               3.1                 org.glassfish                               COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL - Version 1.1)        https://glassfish.java.net/license.html
+                                                                                        GNU General Public License, version 2 with the "Classpath Exception"
+Groovy                  2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
+Groovy                  2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
+Guava                   14.0.1              com.google.guava                            Apache License Version 2.0                                              https://code.google.com/p/guava-libraries/
+Hamcrest                1.3                 org.hamcrest                                New BSD License.                                                        https://code.google.com/p/hamcrest/
+HttpComponents          4.2.5               org.apache.httpcomponents                   Apache License Version 2.0                                              http://hc.apache.org/httpcomponents-client-4.2.x/license.html
+Jackson                 1.9.13              org.codehaus.jackson                        Apache License Version 2.0                                              http://wiki.fasterxml.com/JacksonDownload
+                                                                                        GNU Lesser General Public License, version 2.1
+Java EE                 6                   javax                                       Oracle Specific License                                                 http://www.oracle.com/technetwork/java/javase/downloads/366879
+Java Transaction API    1.1                 javax.transaction                           Oracle Specific License                                                 http://download.oracle.com/otndocs/jcp/jta-1.1-spec-oth-JSpec/jta-1.1-spec-oth-JSpec-license.html
+JavaMail                1.4.4               javax.mail                                  COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL - Version 1.1)        https://java.net/projects/javamail/pages/License
+                                                                                        GNU General Public License, version 2 with the "Classpath Exception"
+JaxB                    0.6.3               org.jvnet.jaxb2_commons                     CDDL v1.1 and GPL v2.                                                   https://jaxb.java.net/
+JBoss Java EE 6         1.0.0.Final         org.jboss.spec                              None listed for this specific version, future versions use              http://repo1.maven.org/maven2/org/jboss/spec/jboss-javaee-6.0/3.0.1.Final/jboss-javaee-6.0-3.0.1.Final.pom
+Specification APIs                                                                      GNU Lesser General Public License, Version 2.1
+Jersey                  1.16                com.sun.jersey                              COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL - Version 1.1)        https://jersey.java.net/license.html
+                                                                                        GNU General Public License, version 2 with the “Classpath Exception"
+Jetty                   9.2.0.v20140526     org.eclipse.jetty                           Apache License 2.0                                                      http://www.eclipse.org/jetty/licenses.php
+                                                                                        Eclipse Public License 1.0
+Joda-Time               2.2                 joda-time                                   Apache License Version 2.0                                              http://joda-time.sourceforge.net/license.html
+json-schema-validator   2.1.7               com.github.fge                              Licensed under LGPL 3.0.                                                https://github.com/fge/json-schema-validator
+JUnit                   4.11                junit                                       IBM's Common Public License Version 0.5                                 http://junit.sourceforge.net/doc/faq/faq.htm#overview_7
+linkedin-utils          1.8.0               org.linkedin                                Apache License Version 2.0                                              http://mvnrepository.com/artifact/org.linkedin/org.linkedin.util-groovy/1.7.2
+Log4J                   2.1                 log4j                                       Apache License Version 2.0                                              https://logging.apache.org/log4j/2.x/license.html
+Mockito                 1.9.5               org.mockito                                 MIT License.                                                            https://code.google.com/p/mockito/wiki/License
+Mockrunner              1.0.0               com.mockrunner                              Mockrunner specific license                                             http://mockrunner.sourceforge.net/LICENSE.txt
+PJL Compressing Filter  1.7                 net.sourceforge.pjl-comp-filter             Apache License Version 2.0                                              http://sourceforge.net/projects/pjl-comp-filter/
+PowerMock               1.5.4               org.powermock                               Apache License Version 2.0                                              https://code.google.com/p/powermock/
+SLF4J                   1.7.7               org.slf4j                                   MIT License.                                                            http://slf4j.org/license.html
+Spock                   0.7-groovy-2.0      org.spockframework                          Apache License Version 2.0                                              https://code.google.com/p/spock/
+Spring Framework        3.1.1.RELEASE       org.springframework                         Apache License Version 2.0                                              https://github.com/spring-projects/spring-framework
+Xalan-Java              2.7.1               xalan                                       Apache License Version 2.0                                              http://xalan.apache.org/old/xalan-j/index.html
+??? XML Commons             2.0.2               xml-apis                                    Apache License Version 2.0                                              http://xerces.apache.org/xml-commons/licenses.html
+XML Unit                1.3                 xmlunit                                     BSD License                                                             http://sourceforge.net/projects/xmlunit/
+Yammer Metrics          2.2.0               com.yammer.metrics                          Apache License Version 2.0                                              http://metrics.codahale.com/about/release-notes/

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -5,7 +5,7 @@ You must agree to the terms of this license and abide by them before using,
 modifying, or distributing Repose or the Repose source code contained within
 this distribution.
 
-Some dependencies are under other licenses.
+Repose has a number of dependencies that are covered by separate licenses, listed below.
 
 By using, modifying, or distributing Repose you may also be subject to the
 terms of those licenses.

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -15,52 +15,74 @@ Below is the full list of dependencies.
 By contributing to this project, you agree to abide to the terms and conditions
 outlined in CONTRIBUTORS.txt.
 
-Name                    Dependency version  POM groupId                                 Licenses                                                                Source
-----------------------  ------------------  -----------------------------------------   --------------------------------------------------------------------    ----------------------------------------------------------------------------------------------------------
-Akka                    2.2.3               com.typesafe.akka                           Apache License Version 2.0                                              http://doc.akka.io/docs/akka/snapshot/project/licenses.html
-Apache Commons CLI      1.2                 commons-cli                                 Apache License Version 2.0                                              http://commons.apache.org/proper/commons-cli/dependencies.html
-Apache Commons Codec    1.7                 commons-codec                               Apache License Version 2.0                                              http://www.apache.org/licenses/
-Apache Commons IO       2.4                 commons-io                                  Apache License Version 2.0                                              http://www.apache.org/licenses/
-Apache Commons Lang     2.6                 commons-lang                                Apache License Version 2.0                                              http://projects.apache.org/projects/commons_lang.html
-Apache Tomcat           7.0.42              org.apache.tomcat.embed                     Apache License Version 2.0                                              http://tomcat.apache.org/legal.html
-Apache Xerces           2.12.0-rax          xerces                                      Apache License Version 2.0                                              http://xerces.apache.org/xml-commons/licenses.html
-API Checker             1.0.22              com.rackspace.papi.components.api-checker   Apache License Version 2.0                                              https://github.com/rackerlabs/api-checker/blob/master/LICENSE.txt
-CGLib                   2.2.2               cglib                                       Apache License Version 1.1                                              http://cglib.sourceforge.net/license.html
-DeProxy                 0.21                org.rackspace                               MIT License                                                             https://github.com/rackerlabs/deproxy/blob/master/LICENSE
-EHCache                 2.6.0               net.sf.ehcache                              Apache License Version 2.0                                              http://ehcache.org/about/license
-Glassfish               3.1                 org.glassfish                               Common Development and Distribution License (CDDL - Version 1.1)        https://glassfish.java.net/license.html
-                                                                                        GNU General Public License, version 2 with the "Classpath Exception"
-Groovy                  2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
-Groovy                  2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
-Guava                   14.0.1              com.google.guava                            Apache License Version 2.0                                              https://code.google.com/p/guava-libraries/
-Hamcrest                1.3                 org.hamcrest                                New BSD License.                                                        https://code.google.com/p/hamcrest/
-HttpComponents          4.2.5               org.apache.httpcomponents                   Apache License Version 2.0                                              http://hc.apache.org/httpcomponents-client-4.2.x/license.html
-Jackson                 1.9.13              org.codehaus.jackson                        Apache License Version 2.0                                              http://wiki.fasterxml.com/JacksonDownload
-                                                                                        GNU Lesser General Public License, version 2.1
-Java EE                 6                   javax                                       Oracle Specific License                                                 http://www.oracle.com/technetwork/java/javase/downloads/366879
-Java Transaction API    1.1                 javax.transaction                           Oracle Specific License                                                 http://download.oracle.com/otndocs/jcp/jta-1.1-spec-oth-JSpec/jta-1.1-spec-oth-JSpec-license.html
-JavaMail                1.4.4               javax.mail                                  Common Development and Distribution License (CDDL - Version 1.1)        https://java.net/projects/javamail/pages/License
-                                                                                        GNU General Public License, version 2 with the "Classpath Exception"
-JaxB                    0.6.3               org.jvnet.jaxb2_commons                     CDDL v1.1 and GPL v2.                                                   https://jaxb.java.net/
-JBoss Java EE 6         1.0.0.Final         org.jboss.spec                              None listed for this specific version, future versions use              http://repo1.maven.org/maven2/org/jboss/spec/jboss-javaee-6.0/3.0.1.Final/jboss-javaee-6.0-3.0.1.Final.pom
-Specification APIs                                                                      GNU Lesser General Public License, Version 2.1
-Jersey                  1.16                com.sun.jersey                              Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
-                                                                                        GNU General Public License, version 2 with the “Classpath Exception"
-Jetty                   9.2.0.v20140526     org.eclipse.jetty                           Apache License 2.0                                                      http://www.eclipse.org/jetty/licenses.php
-                                                                                        Eclipse Public License 1.0
-Joda-Time               2.2                 joda-time                                   Apache License Version 2.0                                              http://joda-time.sourceforge.net/license.html
-json-schema-validator   2.1.7               com.github.fge                              Licensed under LGPL 3.0.                                                https://github.com/fge/json-schema-validator
-JUnit                   4.11                junit                                       IBM's Common Public License Version 0.5                                 http://junit.sourceforge.net/doc/faq/faq.htm#overview_7
-linkedin-utils          1.8.0               org.linkedin                                Apache License Version 2.0                                              http://mvnrepository.com/artifact/org.linkedin/org.linkedin.util-groovy/1.7.2
-Log4J                   2.1                 log4j                                       Apache License Version 2.0                                              https://logging.apache.org/log4j/2.x/license.html
-Mockito                 1.9.5               org.mockito                                 MIT License.                                                            https://code.google.com/p/mockito/wiki/License
-Mockrunner              1.0.0               com.mockrunner                              Mockrunner specific license                                             http://mockrunner.sourceforge.net/LICENSE.txt
-PJL Compressing Filter  1.7                 net.sourceforge.pjl-comp-filter             Apache License Version 2.0                                              http://sourceforge.net/projects/pjl-comp-filter/
-PowerMock               1.5.4               org.powermock                               Apache License Version 2.0                                              https://code.google.com/p/powermock/
-SLF4J                   1.7.7               org.slf4j                                   MIT License.                                                            http://slf4j.org/license.html
-Spock                   0.7-groovy-2.0      org.spockframework                          Apache License Version 2.0                                              https://code.google.com/p/spock/
-Spring Framework        3.1.1.RELEASE       org.springframework                         Apache License Version 2.0                                              https://github.com/spring-projects/spring-framework
-Xalan-Java              2.7.1               xalan                                       Apache License Version 2.0                                              http://xalan.apache.org/old/xalan-j/index.html
-??? XML Commons             2.0.2               xml-apis                                    Apache License Version 2.0                                              http://xerces.apache.org/xml-commons/licenses.html
-XML Unit                1.3                 xmlunit                                     BSD License                                                             http://sourceforge.net/projects/xmlunit/
-Yammer Metrics          2.2.0               com.yammer.metrics                          Apache License Version 2.0                                              http://metrics.codahale.com/about/release-notes/
+Name                        Dependency version  POM groupId                                 Licenses                                                                Source
+--------------------------  ------------------  -----------------------------------------   --------------------------------------------------------------------    ----------------------------------------------------------------------------------------------------------
+Apache Commons CLI          1.2                 commons-cli                                 Apache License Version 2.0                                              http://commons.apache.org/proper/commons-cli/dependencies.html
+Apache Commons Codec        1.10                commons-codec                               Apache License Version 2.0                                              http://www.apache.org/licenses/
+Apache Commons IO           2.4                 commons-io                                  Apache License Version 2.0                                              http://www.apache.org/licenses/
+Apache Commons Lang         3.3.2               commons-lang3                               Apache License Version 2.0                                              http://projects.apache.org/projects/commons_lang.html
+Apache Commons Pool         1.6                 commons-pool                                Apache License Version 2.0                                              http://projects.apache.org/projects/commons_pool.html
+Apache Jena                 1.1.1               org.apache.jena                             Apache License Version 2.0                                              http://jena.apache.org/
+Apache Tomcat               7.0.42              org.apache.tomcat                           Apache License Version 2.0                                              http://tomcat.apache.org/legal.html
+Apache Tomcat Embedded      7.0.42              org.apache.tomcat.embed                     Apache License Version 2.0                                              http://tomcat.apache.org/legal.html
+Apache Xerces               2.12.0-rax          xerces                                      Apache License Version 2.0                                              http://xerces.apache.org/xml-commons/licenses.html
+API Checker                 1.0.22              com.rackspace.papi.components.api-checker   Apache License Version 2.0                                              https://github.com/rackerlabs/api-checker/blob/master/LICENSE.txt
+CGLib                       2.2.2               cglib                                       Apache License Version 1.1                                              http://cglib.sourceforge.net/license.html
+DeProxy                     0.21                org.rackspace                               MIT License                                                             https://github.com/rackerlabs/deproxy/blob/master/LICENSE
+EHCache                     2.6.0               net.sf.ehcache                              Apache License Version 2.0                                              http://ehcache.org/about/license
+Glassfish                   3.1                 org.glassfish                               Common Development and Distribution License (CDDL - Version 1.1)        https://glassfish.java.net/license.html
+                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
+Glassfish Embedded          3.1.2.2             org.glassfish.main.extras                   Common Development and Distribution License (CDDL - Version 1.1)        https://glassfish.java.net/license.html
+                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
+Groovy                      2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
+Guava                       14.0.1              com.google.guava                            Apache License Version 2.0                                              https://code.google.com/p/guava-libraries/
+Hamcrest                    1.3                 org.hamcrest                                New BSD License                                                         https://code.google.com/p/hamcrest/
+Handlebars                  2.0.0               com.github.jknack                           Apache License Version 2.0                                              https://github.com/jknack/handlebars.java
+HttpComponents              4.2.5               org.apache.httpcomponents                   Apache License Version 2.0                                              http://hc.apache.org/httpcomponents-client-4.2.x/license.html
+Jackson                     2.4.0               com.fasterxml.jackson.core                  Apache License Version 2.0                                              http://wiki.fasterxml.com/JacksonDownload
+                                                                                            GNU Lesser General Public License, version 2.1
+Java EE                     6.0                 javax                                       Oracle Specific License                                                 http://www.oracle.com/technetwork/java/javase/downloads/366879
+Java Binding (JSR 222)      0.6.3               org.jvnet.jaxb2_commons                     CDDL v1.1 and GPL v2                                                    https://jaxb.java.net/
+Java Inject (JSR 330)       1                   javax.inject                                Apache License Version 2.0                                              https://jcp.org/en/jsr/detail?id=330
+Java Mail (JSR 919)         1.4.4               javax.mail                                  Common Development and Distribution License (CDDL - Version 1.1)        https://java.net/projects/javamail/pages/License
+Java REST (JSR 311)         2.0.1               javax.ws.rs                                 Common Development and Distribution License (CDDL - Version 1.1)        https://jax-rs-spec.java.net/
+Java Transaction (JSR 907)  1.1                 javax.transaction                           Oracle Specific License                                                 http://download.oracle.com/otndocs/jcp/jta-1.1-spec-oth-JSpec/jta-1.1-spec-oth-JSpec-license.html
+                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
+JBoss Java EE 6             1.0.0.Final         org.jboss.spec                              None listed for this specific version, future versions use              http://repo1.maven.org/maven2/org/jboss/spec/jboss-javaee-6.0/3.0.1.Final/jboss-javaee-6.0-3.0.1.Final.pom
+Specification APIs                                                                          GNU Lesser General Public License, Version 2.1
+Jersey                      1.19                com.sun.jersey                              Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
+                                                                                            GNU General Public License, version 2 with the “Classpath Exception"
+Jersey Common               2.14                org.glassfish.jersey.core                   Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
+                                                                                            GNU General Public License, version 2 with the “Classpath Exception"
+Jersey Test Framework       1.0.3.1             com.sun.jersey.test.framework               Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
+                                                                                            GNU General Public License, version 2 with the “Classpath Exception"
+Jetbrains Annotations       13.0                org.jetbrains                               Apache License Version 2.0                                              http://mvnrepository.com/artifact/org.jetbrains/annotations/13.0
+Jetty                       9.2.0.v20140526     org.eclipse.jetty                           Apache License Version 2.0                                              http://www.eclipse.org/jetty/licenses.php
+                                                                                            Eclipse Public License 1.0
+Joda Convert                1.7                 org.joda                                    Apache License Version 2.0                                              http://www.joda.org/joda-convert/
+Joda Time                   2.7                 joda-time                                   Apache License Version 2.0                                              http://joda-time.sourceforge.net/license.html
+JUnit                       4.12                junit                                       IBM's Common Public License Version 0.5                                 http://junit.sourceforge.net/doc/faq/faq.htm#overview_7
+linkedin-utils              1.8.0               org.linkedin                                Apache License Version 2.0                                              http://mvnrepository.com/artifact/org.linkedin/org.linkedin.util-groovy/1.7.2
+Log4J                       2.1                 log4j                                       Apache License Version 2.0                                              https://logging.apache.org/log4j/2.x/license.html
+Mockito                     1.9.5               org.mockito                                 MIT License                                                             https://code.google.com/p/mockito/wiki/License
+Mockrunner                  1.0.0(0.4.1)        com.mockrunner                              Mockrunner specific license                                             http://mockrunner.sourceforge.net/LICENSE.txt
+PJL Compressing Filter      1.7                 net.sourceforge.pjl-comp-filter             Apache License Version 2.0                                              http://sourceforge.net/projects/pjl-comp-filter/
+PowerMock                   1.5.4               org.powermock                               Apache License Version 2.0                                              https://code.google.com/p/powermock/
+SLF4J                       1.7.7               org.slf4j                                   MIT License                                                             http://slf4j.org/license.html
+Saxon                       9.4.0.9             net.sf.saxon                                Mozilla Public License version 2.0                                      http://saxon.sourceforge.net/
+Scala Lang                  2.10.3              org.scala-lang                              Scala Specific License                                                  http://www.scala-lang.org/license.html
+ScalaTest                   2.2.0               org.scalatest                               Apache License Version 2.0                                              http://www.scalatest.org/
+Scopt                       3.2.0               com.github.scopt                            MIT License                                                             https://github.com/scopt/scopt
+Spock                       0.7-groovy-2.0      org.spockframework                          Apache License Version 2.0                                              https://code.google.com/p/spock/
+Spray JSON                  1.2.6               io.spray                                    Apache License Version 2.0                                              https://github.com/spray/spray-json
+Spring Framework            4.1.4.RELEASE       org.springframework                         Apache License Version 2.0                                              https://github.com/spring-projects/spring-framework
+Typesafe Akka               2.2.3               com.typesafe.akka                           Apache License Version 2.0                                              http://doc.akka.io/docs/akka/snapshot/project/licenses.html
+Typesafe Config             1.2.1               com.typesafe                                Apache License Version 2.0                                              https://github.com/typesafehub/config#license
+Typesafe Play-JSON          2.3.4               com.typesafe.play                           Apache License Version 2.0                                              https://github.com/playframework/playframework
+Typesafe Scala Logging      2.1.2               com.typesafe.scala-logging                  Apache License Version 2.0                                              https://github.com/typesafehub/scala-logging
+Xalan-Java                  2.7.1               xalan                                       Apache License Version 2.0                                              http://xalan.apache.org/old/xalan-j/index.html
+XML Calabash                0.9.38              com.xmlcalabash                             None listed for this specific version, future versions use              https://search.maven.org/remotecontent?filepath=com/xmlcalabash/xmlcalabash/1.0.32-96/xmlcalabash-1.0.32-96.pom
+                                                                                            Common Development and Distribution License (CDDL - Version 1.1)
+                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
+XML Unit                    1.3                 xmlunit                                     BSD License                                                             http://sourceforge.net/projects/xmlunit/
+Yammer Metrics              2.2.0               com.yammer.metrics                          Apache License Version 2.0                                              http://metrics.codahale.com/about/release-notes/

--- a/DEPENDENCIES.txt
+++ b/DEPENDENCIES.txt
@@ -15,43 +15,6 @@ Below is the full list of dependencies.
 By contributing to this project, you agree to abide to the terms and conditions
 outlined in CONTRIBUTORS.txt.
 
-Apache Commons CLI          1.2                 commons-cli                                 Apache License Version 2.0                                              http://commons.apache.org/proper/commons-cli/dependencies.html
-Apache Tomcat               7.0.42              org.apache.tomcat                           Apache License Version 2.0                                              http://tomcat.apache.org/legal.html
-Apache Tomcat Embedded      7.0.42              org.apache.tomcat.embed                     Apache License Version 2.0                                              http://tomcat.apache.org/legal.html
-CGLib                       2.2.2               cglib                                       Apache License Version 1.1                                              http://cglib.sourceforge.net/license.html
-DeProxy                     0.21                org.rackspace                               MIT License                                                             https://github.com/rackerlabs/deproxy/blob/master/LICENSE
-Glassfish                   3.1                 org.glassfish                               Common Development and Distribution License (CDDL - Version 1.1)        https://glassfish.java.net/license.html
-                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
-Glassfish Embedded          3.1.2.2             org.glassfish.main.extras                   Common Development and Distribution License (CDDL - Version 1.1)        https://glassfish.java.net/license.html
-                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
-Groovy                      2.1.3               org.codehaus.groovy                         Apache License Version 2.0                                              http://groovy.codehaus.org/License+Information
-Hamcrest                    1.3                 org.hamcrest                                New BSD License                                                         https://code.google.com/p/hamcrest/
-Java EE                     6.0                 javax                                       Oracle Specific License                                                 http://www.oracle.com/technetwork/java/javase/downloads/366879
-Java Inject (JSR 330)       1                   javax.inject                                Apache License Version 2.0                                              https://jcp.org/en/jsr/detail?id=330
-Java Mail (JSR 919)         1.4.4               javax.mail                                  Common Development and Distribution License (CDDL - Version 1.1)        https://java.net/projects/javamail/pages/License
-Java Transaction (JSR 907)  1.1                 javax.transaction                           Oracle Specific License                                                 http://download.oracle.com/otndocs/jcp/jta-1.1-spec-oth-JSpec/jta-1.1-spec-oth-JSpec-license.html
-                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
-JBoss Java EE 6             1.0.0.Final         org.jboss.spec                              None listed for this specific version, future versions use              http://repo1.maven.org/maven2/org/jboss/spec/jboss-javaee-6.0/3.0.1.Final/jboss-javaee-6.0-3.0.1.Final.pom
-Specification APIs                                                                          GNU Lesser General Public License, Version 2.1
-Jersey Common               2.14                org.glassfish.jersey.core                   Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
-                                                                                            GNU General Public License, version 2 with the “Classpath Exception"
-Jersey Test Framework       1.0.3.1             com.sun.jersey.test.framework               Common Development and Distribution License (CDDL - Version 1.1)        https://jersey.java.net/license.html
-                                                                                            GNU General Public License, version 2 with the “Classpath Exception"
-Jetbrains Annotations       13.0                org.jetbrains                               Apache License Version 2.0                                              http://mvnrepository.com/artifact/org.jetbrains/annotations/13.0
-JUnit                       4.12                junit                                       IBM's Common Public License Version 0.5                                 http://junit.sourceforge.net/doc/faq/faq.htm#overview_7
-linkedin-utils              1.8.0               org.linkedin                                Apache License Version 2.0                                              http://mvnrepository.com/artifact/org.linkedin/org.linkedin.util-groovy/1.7.2
-Log4J                       2.1                 log4j                                       Apache License Version 2.0                                              https://logging.apache.org/log4j/2.x/license.html
-Mockito                     1.9.5               org.mockito                                 MIT License                                                             https://code.google.com/p/mockito/wiki/License
-Mockrunner                  1.0.0(0.4.1)        com.mockrunner                              Mockrunner specific license                                             http://mockrunner.sourceforge.net/LICENSE.txt
-PJL Compressing Filter      1.7                 net.sourceforge.pjl-comp-filter             Apache License Version 2.0                                              http://sourceforge.net/projects/pjl-comp-filter/
-PowerMock                   1.5.4               org.powermock                               Apache License Version 2.0                                              https://code.google.com/p/powermock/
-ScalaTest                   2.2.0               org.scalatest                               Apache License Version 2.0                                              http://www.scalatest.org/
-Spock                       0.7-groovy-2.0      org.spockframework                          Apache License Version 2.0                                              https://code.google.com/p/spock/
-XML Calabash                0.9.38              com.xmlcalabash                             None listed for this specific version, future versions use              https://search.maven.org/remotecontent?filepath=com/xmlcalabash/xmlcalabash/1.0.32-96/xmlcalabash-1.0.32-96.pom
-                                                                                            Common Development and Distribution License (CDDL - Version 1.1)
-                                                                                            GNU General Public License, version 2 with the "Classpath Exception"
-XML Unit                    1.3                 xmlunit                                     BSD License                                                             http://sourceforge.net/projects/xmlunit/
-
 Name                        Dependency version  POM groupId                                 Licenses                                                                Source
 --------------------------  ------------------  -----------------------------------------   --------------------------------------------------------------------    ----------------------------------------------------------------------------------------------------------
 Apache Commons Codec        1.10                commons-codec                               Apache License Version 2.0                                              http://www.apache.org/licenses/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -14,4 +14,6 @@ limitations under the License.
 
 NOTE: Saxon EE features require the user to obtain their own commercial license.
 
-See https://repose.atlassian.net/wiki/display/REPOSE/License for a list of Repose dependencies and their licenses.
+See DEPENDENCIES.txt for a list of Repose dependencies and their licenses.
+
+Contributors should also review CONTRIBUTORS.txt.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,11 @@ This will build the documentation pdfs in the generated "target/docbkx/" directo
 ##Notes Regarding Licensing##
 
 
-All files contained with this distribution of Repose are licensed
-under the Apache License v2.0 (http://www.apache.org/licenses/LICENSE-2.0).
-You must agree to the terms of this license and abide by it before
-viewing, utilizing, modifying, or distributing the source code contained
-within this distribution.
-
+Original files contained with this distribution of Repose are licensed under the Apache License v2.0
+(http://www.apache.org/licenses/LICENSE-2.0).
+You must agree to the terms of this license and abide by them before using, modifying, or distributing
+Repose or the Repose source code contained within this distribution.
+Some dependencies are under other licenses.
+By using, modifying, or distributing Repose you may also be subject to the terms of those licenses.
+See the full list of dependencies in DEPENDENCIES.txt.
+By contributing to this project, you agree to abide to the terms and conditions outlined in CONTRIBUTORS.txt.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ name mappings are listed below.
 
 
 ##Repose Documentation##
+
 Documentation is included with the source files and may be built with the maven command:  
 <pre>
     export MAVEN_OPTS='-Xmx512m -XX:MaxPermSize=256m'
@@ -157,12 +158,19 @@ This will build the documentation pdfs in the generated "target/docbkx/" directo
 
 ##Notes Regarding Licensing##
 
+Original files contained with this distribution of Repose are licensed under
+the Apache License v2.0 (http://www.apache.org/licenses/LICENSE-2.0).
 
-Original files contained with this distribution of Repose are licensed under the Apache License v2.0
-(http://www.apache.org/licenses/LICENSE-2.0).
-You must agree to the terms of this license and abide by them before using, modifying, or distributing
-Repose or the Repose source code contained within this distribution.
+You must agree to the terms of this license and abide by them before using,
+modifying, or distributing Repose or the Repose source code contained within
+this distribution.
+
 Some dependencies are under other licenses.
-By using, modifying, or distributing Repose you may also be subject to the terms of those licenses.
+
+By using, modifying, or distributing Repose you may also be subject to the
+terms of those licenses.
+
 See the full list of dependencies in DEPENDENCIES.txt.
-By contributing to this project, you agree to abide to the terms and conditions outlined in CONTRIBUTORS.txt.
+
+By contributing to this project, you agree to abide to the terms and conditions
+outlined in CONTRIBUTORS.txt.

--- a/repose-aggregator/commons/pom.xml
+++ b/repose-aggregator/commons/pom.xml
@@ -22,16 +22,6 @@
         <module>configuration</module>
     </modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.5</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <!-- TODO: Read this -> http://www.stack.nl/~dimitri/doxygen/custcmd.html -->

--- a/repose-aggregator/components/filters/add-header/pom.xml
+++ b/repose-aggregator/components/filters/add-header/pom.xml
@@ -65,8 +65,6 @@
         <dependency>
             <groupId>com.mockrunner</groupId>
             <artifactId>mockrunner-servlet</artifactId>
-            <version>1.0.0</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- super handy lazy logging! -->

--- a/repose-aggregator/components/filters/content-type-stripper/pom.xml
+++ b/repose-aggregator/components/filters/content-type-stripper/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/components/filters/forwarded-proto/pom.xml
+++ b/repose-aggregator/components/filters/forwarded-proto/pom.xml
@@ -56,8 +56,6 @@
         <dependency>
             <groupId>com.mockrunner</groupId>
             <artifactId>mockrunner-servlet</artifactId>
-            <version>1.0.0</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- Lazy logging -->

--- a/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
+++ b/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
@@ -42,8 +42,6 @@
         <dependency>
             <groupId>com.mockrunner</groupId>
             <artifactId>mockrunner-servlet</artifactId>
-            <version>1.0.0</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/components/filters/pom.xml
+++ b/repose-aggregator/components/filters/pom.xml
@@ -103,21 +103,6 @@
             </dependency>
 
             <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.7</version>
-            </dependency>
-
-            <!-- many filters are pulling in Guava, probably thanks to core using it -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>14.0.1</version>
-                <!-- same version core is using -->
-            </dependency>
-
-
-            <dependency>
                 <groupId>org.openrepose</groupId>
                 <artifactId>http-delegation</artifactId>
                 <version>${http.delegation.version}</version>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/pom.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/pom.xml
@@ -48,8 +48,6 @@
         <dependency>
             <groupId>com.mockrunner</groupId>
             <artifactId>mockrunner-servlet</artifactId>
-            <version>1.0.0</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- These three are required because of our coupling between filters and core -->

--- a/repose-aggregator/components/filters/rate-limiting/pom.xml
+++ b/repose-aggregator/components/filters/rate-limiting/pom.xml
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>1.16</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/components/filters/translation/pom.xml
+++ b/repose-aggregator/components/filters/translation/pom.xml
@@ -86,17 +86,19 @@
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
 
-        <!--
         <dependency>
-          <groupId>net.sf.joost</groupId>
-          <artifactId>joost</artifactId>
-          <version>0.9.1</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
-        -->
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-lgpl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
@@ -108,7 +110,6 @@
             <artifactId>scala-library</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.10</artifactId>

--- a/repose-aggregator/components/filters/translation/src/main/java/org/openrepose/filters/translation/httpx/processor/TranslationPreProcessor.java
+++ b/repose-aggregator/components/filters/translation/src/main/java/org/openrepose/filters/translation/httpx/processor/TranslationPreProcessor.java
@@ -19,7 +19,7 @@
  */
 package org.openrepose.filters.translation.httpx.processor;
 
-import org.codehaus.jackson.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactory;
 import org.openrepose.commons.utils.http.media.MediaType;
 import org.openrepose.filters.translation.httpx.processor.cdata.UnknownContentStreamProcessor;
 import org.openrepose.filters.translation.httpx.processor.common.InputStreamProcessor;

--- a/repose-aggregator/components/filters/translation/src/main/java/org/openrepose/filters/translation/httpx/processor/json/JsonxStreamProcessor.java
+++ b/repose-aggregator/components/filters/translation/src/main/java/org/openrepose/filters/translation/httpx/processor/json/JsonxStreamProcessor.java
@@ -19,9 +19,9 @@
  */
 package org.openrepose.filters.translation.httpx.processor.json;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import org.openrepose.commons.utils.Destroyable;
 import org.openrepose.commons.utils.thread.DestroyableThreadWrapper;
 import org.openrepose.filters.translation.httpx.processor.common.Element;

--- a/repose-aggregator/components/filters/translation/src/main/java/org/openrepose/filters/translation/httpx/processor/json/elements/ElementFactory.java
+++ b/repose-aggregator/components/filters/translation/src/main/java/org/openrepose/filters/translation/httpx/processor/json/elements/ElementFactory.java
@@ -19,7 +19,7 @@
  */
 package org.openrepose.filters.translation.httpx.processor.json.elements;
 
-import org.codehaus.jackson.JsonToken;
+import com.fasterxml.jackson.core.JsonToken;
 import org.openrepose.filters.translation.httpx.processor.common.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/repose-aggregator/components/filters/versioning/pom.xml
+++ b/repose-aggregator/components/filters/versioning/pom.xml
@@ -63,14 +63,20 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-lgpl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-lgpl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/repose-aggregator/components/filters/versioning/src/test/java/org/openrepose/filters/versioning/util/ContentTransformerTest.java
+++ b/repose-aggregator/components/filters/versioning/src/test/java/org/openrepose/filters/versioning/util/ContentTransformerTest.java
@@ -22,7 +22,7 @@ package org.openrepose.filters.versioning.util;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.custommonkey.xmlunit.Diff;
 import org.junit.Before;
 import org.junit.Test;

--- a/repose-aggregator/components/pom.xml
+++ b/repose-aggregator/components/pom.xml
@@ -23,15 +23,4 @@
         <module>filters</module>
         <module>cli-utils</module>
     </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.7</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>
-

--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -21,9 +21,6 @@
         <reposeVersionName>Dirk</reposeVersionName>
         <sonar.jacoco.itReportPath>${project.basedir}/../../target/jacoco-it.exec</sonar.jacoco.itReportPath>
         <test.artifact.version>2.1</test.artifact.version>
-
-        <!-- The fasterXML Jackson deps aren't in managed dependencies, because they're only in core right now -->
-        <fasterxml.jackson.version>2.2.2</fasterxml.jackson.version>
     </properties>
 
     <dependencies>
@@ -240,19 +237,16 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${fasterxml.jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${fasterxml.jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.version}</version>
         </dependency>
         <!-- END OF json Support for log4j2 configuration files -->
 

--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -33,7 +33,6 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- stuff pulled in from the classloader project -->

--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -33,6 +33,7 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- stuff pulled in from the classloader project -->

--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -259,7 +259,6 @@
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>1.0.2</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -92,7 +92,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0.1</version>
         </dependency>
 
         <dependency>
@@ -108,7 +107,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
         </dependency>
 
         <dependency>
@@ -155,7 +153,6 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.6</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/core/core-service-api/pom.xml
+++ b/repose-aggregator/core/core-service-api/pom.xml
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0.1</version>
         </dependency>
     </dependencies>
 

--- a/repose-aggregator/experimental/exception-filter/pom.xml
+++ b/repose-aggregator/experimental/exception-filter/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
         </dependency>
         <!-- For Javax.servlet library support -->
         <dependency>
@@ -28,12 +27,6 @@
             <artifactId>javax.servlet</artifactId>
             <version>3.1</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.2</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/repose-aggregator/experimental/servlet-contract-filter/pom.xml
+++ b/repose-aggregator/experimental/servlet-contract-filter/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
         </dependency>
         <!-- For Javax.servlet library support -->
         <dependency>
@@ -28,12 +27,6 @@
             <artifactId>javax.servlet</artifactId>
             <version>3.1</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.2</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/repose-aggregator/experimental/tightly-coupled-filter/pom.xml
+++ b/repose-aggregator/experimental/tightly-coupled-filter/pom.xml
@@ -35,12 +35,6 @@
             <version>3.1</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.2</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/repose-aggregator/extensions/pom.xml
+++ b/repose-aggregator/extensions/pom.xml
@@ -23,14 +23,4 @@
         <module>api-validator</module>
         <module>extensions-filter-bundle</module>
     </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.7</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/repose-aggregator/external/pjl-compressingFilter/pom.xml
+++ b/repose-aggregator/external/pjl-compressingFilter/pom.xml
@@ -64,7 +64,13 @@
 
         <dependency>
             <groupId>com.mockrunner</groupId>
-            <artifactId>mockrunner-servlet</artifactId>
+            <!-- The new library causes:
+            java.lang.NoSuchMethodError: javax.servlet.http.HttpServletResponse.getHeader(Ljava/lang/String;)Ljava/lang/String;
+	        at org.openrepose.external.pjlcompression.CompressingHttpServletResponse.mustNotCompress(CompressingHttpServletResponse.java:482) -->
+            <!--artifactId>mockrunner-servlet</artifactId-->
+            <artifactId>mockrunner</artifactId>
+            <version>0.4.1</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/external/pjl-compressingFilter/pom.xml
+++ b/repose-aggregator/external/pjl-compressingFilter/pom.xml
@@ -64,9 +64,7 @@
 
         <dependency>
             <groupId>com.mockrunner</groupId>
-            <artifactId>mockrunner</artifactId>
-            <version>0.4.1</version>
-            <scope>test</scope>
+            <artifactId>mockrunner-servlet</artifactId>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/external/service-clients/auth/pom.xml
+++ b/repose-aggregator/external/service-clients/auth/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.8</version>
         </dependency>
 
         <!--Apache Pool Support-->

--- a/repose-aggregator/functional-tests/mocks-servlet/pom.xml
+++ b/repose-aggregator/functional-tests/mocks-servlet/pom.xml
@@ -23,7 +23,8 @@
     <dependencies>
         <dependency>
             <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-server</artifactId>
+            <artifactId>jersey-servlet</artifactId>
+            <version>${jersey.version}</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/functional-tests/mocks-servlet/pom.xml
+++ b/repose-aggregator/functional-tests/mocks-servlet/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>1.9.1</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/functional-tests/spock-functional-test/pom.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/pom.xml
@@ -101,13 +101,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
@@ -180,8 +173,6 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.8</version>
-            <!-- same version as used elsewhere -->
         </dependency>
     </dependencies>
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/RequestSizeTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/RequestSizeTest.groovy
@@ -20,7 +20,7 @@
 package features.core.powerfilter
 
 import framework.ReposeValveTest
-import org.apache.commons.lang.RandomStringUtils
+import org.apache.commons.lang3.RandomStringUtils
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.Header
 import org.rackspace.deproxy.MessageChain

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/datastore/DistDatastoreServiceGetTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/datastore/DistDatastoreServiceGetTest.groovy
@@ -20,7 +20,7 @@
 package features.services.datastore
 
 import framework.ReposeValveTest
-import org.apache.commons.lang.RandomStringUtils
+import org.apache.commons.lang3.RandomStringUtils
 import org.openrepose.commons.utils.io.ObjectSerializer
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/datastore/DistDatastoreServicePutTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/datastore/DistDatastoreServicePutTest.groovy
@@ -20,7 +20,7 @@
 package features.services.datastore
 
 import framework.ReposeValveTest
-import org.apache.commons.lang.RandomStringUtils
+import org.apache.commons.lang3.RandomStringUtils
 import org.openrepose.commons.utils.io.ObjectSerializer
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/ReposeConfigurationProvider.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/ReposeConfigurationProvider.groovy
@@ -21,7 +21,7 @@ package framework
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
-import org.apache.commons.lang.text.StrSubstitutor
+import org.apache.commons.lang3.text.StrSubstitutor
 import org.linkedin.util.clock.SystemClock
 
 /**

--- a/repose-aggregator/functional-tests/test-support/pom.xml
+++ b/repose-aggregator/functional-tests/test-support/pom.xml
@@ -38,18 +38,16 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-lgpl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-xc</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/functional-tests/test-support/pom.xml
+++ b/repose-aggregator/functional-tests/test-support/pom.xml
@@ -25,6 +25,11 @@
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-servlet</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.openrepose</groupId>

--- a/repose-aggregator/functional-tests/test-support/pom.xml
+++ b/repose-aggregator/functional-tests/test-support/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>1.9.1</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
@@ -142,6 +142,21 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </src>
                                         </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </src>
+                                        </data>
                                     </dataSet>
                                 </configuration>
                             </execution>

--- a/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
@@ -154,6 +154,21 @@
                                                 <filemode>444</filemode>
                                             </mapper>
                                             <src>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </src>
+                                        </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </src>
                                         </data>

--- a/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
@@ -139,6 +139,21 @@
                                                 <filemode>444</filemode>
                                             </mapper>
                                             <src>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </src>
+                                        </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </src>
                                         </data>

--- a/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
@@ -127,6 +127,21 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </src>
                                         </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </src>
+                                        </data>
                                     </dataSet>
                                 </configuration>
                             </execution>

--- a/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
@@ -139,6 +139,21 @@
                                                 <filemode>444</filemode>
                                             </mapper>
                                             <src>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </src>
+                                        </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </src>
                                         </data>

--- a/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
@@ -127,6 +127,21 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </src>
                                         </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </src>
+                                        </data>
                                     </dataSet>
                                 </configuration>
                             </execution>

--- a/repose-aggregator/installation/deb/repose-valve/pom.xml
+++ b/repose-aggregator/installation/deb/repose-valve/pom.xml
@@ -317,6 +317,21 @@
                                                 <filemode>444</filemode>
                                             </mapper>
                                             <src>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </src>
+                                        </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </src>
                                         </data>

--- a/repose-aggregator/installation/deb/repose-valve/pom.xml
+++ b/repose-aggregator/installation/deb/repose-valve/pom.xml
@@ -305,6 +305,21 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </src>
                                         </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </src>
+                                        </data>
                                     </dataSet>
                                 </configuration>
                             </execution>

--- a/repose-aggregator/installation/deb/repose-war/pom.xml
+++ b/repose-aggregator/installation/deb/repose-war/pom.xml
@@ -261,6 +261,21 @@
                                                 <filemode>444</filemode>
                                             </mapper>
                                             <src>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </src>
+                                        </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </src>
                                         </data>

--- a/repose-aggregator/installation/deb/repose-war/pom.xml
+++ b/repose-aggregator/installation/deb/repose-war/pom.xml
@@ -249,6 +249,21 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </src>
                                         </data>
+
+                                        <!--This adds the dependencies file on installation.-->
+                                        <data>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>
+                                                    /usr/share/doc/${artifactName}
+                                                </prefix>
+                                                <filemode>444</filemode>
+                                            </mapper>
+                                            <src>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </src>
+                                        </data>
                                     </dataSet>
                                 </configuration>
                             </execution>

--- a/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
@@ -165,6 +165,11 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </location>
                                         </source>
+                                        <source>
+                                            <location>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </location>
+                                        </source>
                                     </sources>
                                 </mapping>
                             </mappings>

--- a/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
@@ -167,6 +167,11 @@
                                         </source>
                                         <source>
                                             <location>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </location>
+                                        </source>
+                                        <source>
+                                            <location>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </location>
                                         </source>

--- a/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
@@ -140,6 +140,11 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </location>
                                         </source>
+                                        <source>
+                                            <location>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </location>
+                                        </source>
                                     </sources>
                                 </mapping>
                             </mappings>

--- a/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
@@ -142,6 +142,11 @@
                                         </source>
                                         <source>
                                             <location>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </location>
+                                        </source>
+                                        <source>
+                                            <location>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </location>
                                         </source>

--- a/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
@@ -139,6 +139,11 @@
                                         </source>
                                         <source>
                                             <location>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </location>
+                                        </source>
+                                        <source>
+                                            <location>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </location>
                                         </source>

--- a/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
@@ -137,6 +137,11 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </location>
                                         </source>
+                                        <source>
+                                            <location>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </location>
+                                        </source>
                                     </sources>
                                 </mapping>
                             </mappings>

--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -277,6 +277,11 @@
                                         </source>
                                         <source>
                                             <location>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </location>
+                                        </source>
+                                        <source>
+                                            <location>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </location>
                                         </source>

--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -275,6 +275,11 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </location>
                                         </source>
+                                        <source>
+                                            <location>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </location>
+                                        </source>
                                     </sources>
                                 </mapping>
                             </mappings>

--- a/repose-aggregator/installation/rpm/repose-war/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-war/pom.xml
@@ -228,6 +228,11 @@
                                                 ${basedir}/../../../../LICENSE.txt
                                             </location>
                                         </source>
+                                        <source>
+                                            <location>
+                                                ${basedir}/../../../../DEPENDENCIES.txt
+                                            </location>
+                                        </source>
                                     </sources>
                                 </mapping>
                             </mappings>

--- a/repose-aggregator/installation/rpm/repose-war/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-war/pom.xml
@@ -230,6 +230,11 @@
                                         </source>
                                         <source>
                                             <location>
+                                                ${basedir}/../../../../CONTRIBUTORS.txt
+                                            </location>
+                                        </source>
+                                        <source>
+                                            <location>
                                                 ${basedir}/../../../../DEPENDENCIES.txt
                                             </location>
                                         </source>

--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -25,7 +25,7 @@
         <akka.version>2.2.3</akka.version>
         <powermock.version>1.5.4</powermock.version>
         <jersey.version>1.19</jersey.version>
-        <jackson.version>1.9.13</jackson.version>
+        <jackson.version>2.4.0</jackson.version>
         <yammer.version>2.2.0</yammer.version>
         <jetty.version>9.2.0.v20140526</jetty.version>
         <!-- NOTE: the saxon version should match that of API-checker, because there is saxon in core :( -->
@@ -139,23 +139,18 @@
             TODO: codehaus.jackson is super old! We should be using com.fasterxml.jackson stuff. It's different though
             -->
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-core-lgpl</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-lgpl</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-xc</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-jaxrs</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>

--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -24,7 +24,7 @@
         <gmaven.version>1.5</gmaven.version>
         <akka.version>2.2.3</akka.version>
         <powermock.version>1.5.4</powermock.version>
-        <jersey.version>1.16</jersey.version>
+        <jersey.version>1.19</jersey.version>
         <jackson.version>1.9.13</jackson.version>
         <yammer.version>2.2.0</yammer.version>
         <jetty.version>9.2.0.v20140526</jetty.version>
@@ -210,6 +210,16 @@
                 <artifactId>commons-io</artifactId>
                 <version>2.4</version>
             </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.3.2</version>
+            </dependency>
 
             <dependency>
                 <groupId>net.sf.ehcache</groupId>
@@ -291,7 +301,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.2</version>
+                <version>2.7</version>
             </dependency>
 
             <!--For SLF4J/Log4J 2.x logging support-->
@@ -357,6 +367,11 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>14.0.1</version>
+            </dependency>
 
             <!-- Handy jetbrains annotations for use in the IDE, doesn't hurt anything else -->
             <dependency>
@@ -401,7 +416,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/repose-aggregator/services/datastore/impl/pom.xml
+++ b/repose-aggregator/services/datastore/impl/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0.1</version>
         </dependency>
 
         <dependency>
@@ -83,7 +82,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/services/rate-limiting-service/pom.xml
+++ b/repose-aggregator/services/rate-limiting-service/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/services/service-client/impl/pom.xml
+++ b/repose-aggregator/services/service-client/impl/pom.xml
@@ -53,8 +53,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>15.0</version>
-            <classifier>cdi1.0</classifier>
         </dependency>
 
         <dependency>

--- a/scripts/DependencyCheckHelper.sh
+++ b/scripts/DependencyCheckHelper.sh
@@ -16,7 +16,7 @@ GROUP_IDS=(
     commons-cli
     commons-codec
     commons-io
-    commons-lang
+    commons-lang3
     org.apache.tomcat.embed
     xerces
     com.rackspace.papi.components.api-checker
@@ -28,7 +28,7 @@ GROUP_IDS=(
     com.google.guava
     org.hamcrest
     org.apache.httpcomponents
-    org.codehaus.jackson
+    com.fasterxml.jackson.core
     javax
     javax.transaction
     javax.mail
@@ -49,7 +49,6 @@ GROUP_IDS=(
     org.spockframework
     org.springframework
     xalan
-#    xml-apis # Removed as per below.
     xmlunit
     com.yammer.metrics
 )
@@ -60,20 +59,20 @@ echo "All of the known direct dependencies that need the"
 echo "version numbers confirmed against what is documented:"
 echo "--------------------------------------------------------------------------------"
 for groupId in ${GROUP_IDS[*]} ; do
-    egrep "\[INFO\] \\+\\- " $TARGET_DIR/mvn_dependency_tree.out | cut -d' ' -f3 | sort -u | grep $groupId
+    egrep "\[INFO\] \\+\\- " $TARGET_DIR/mvn_dependency_tree.out | cut -d' ' -f3 | cut -d':' -f1-4 | sort -u | grep "${groupId}:"
 done
 
 # Build the exclusion set based on all known direct dependencies.
 EXCLUDE=
 for groupId in ${GROUP_IDS[*]} ; do
-    EXCLUDE="$EXCLUDE -e $groupId"
+    EXCLUDE="$EXCLUDE -e ${groupId}:"
 done
 
 echo ""
 echo "================================================================================"
 echo "All direct dependencies that are not currently documented:"
 echo "--------------------------------------------------------------------------------"
-egrep "\[INFO\] \\+\\- " $TARGET_DIR/mvn_dependency_tree.out | cut -d' ' -f3 | sort -u | grep -v -e org.openrepose $EXCLUDE
+egrep "\[INFO\] \\+\\- " $TARGET_DIR/mvn_dependency_tree.out | cut -d' ' -f3 | cut -d':' -f1-4 | sort -u | grep -v -e org.openrepose $EXCLUDE
 
 # All of the UN-known and UN-documented direct dependencies.
 GROUP_IDS_TOO=`egrep "\[INFO\] \\+\\- " $TARGET_DIR/mvn_dependency_tree.out | cut -d' ' -f3 | sort -u | grep -v -e org.openrepose $EXCLUDE | cut -d":" -f1 | sort -u`
@@ -83,14 +82,9 @@ for groupId in ${GROUP_IDS_TOO[*]} ; do
     EXCLUDE_TOO="$EXCLUDE_TOO -e $groupId"
 done
 
-echo ""
-echo "================================================================================"
-echo "This is documented as a direct dependency, but currently is only a transient:"
-echo "--------------------------------------------------------------------------------"
-grep xml-apis $TARGET_DIR/mvn_dependency_tree.out
-
-echo ""
-echo "================================================================================"
-echo "All transient dependencies that are not already documented as direct dependencies:"
-echo "--------------------------------------------------------------------------------"
-egrep "\[INFO\] \|" $TARGET_DIR/mvn_dependency_tree.out | cut -d'-' -f2- | cut -d' ' -f2- | sort -u | grep -v -e org.openrepose $EXCLUDE $EXCLUDE_TOO
+# These were determined to not be of importance at this time.
+#echo ""
+#echo "================================================================================"
+#echo "All transient dependencies that are not already documented as direct dependencies:"
+#echo "--------------------------------------------------------------------------------"
+#egrep "\[INFO\] \|" $TARGET_DIR/mvn_dependency_tree.out | cut -d'-' -f2- | cut -d' ' -f2- | sort -u | grep -v -e org.openrepose $EXCLUDE $EXCLUDE_TOO

--- a/scripts/DependencyCheckHelper.sh
+++ b/scripts/DependencyCheckHelper.sh
@@ -49,7 +49,7 @@ GROUP_IDS=(
     joda-time
     junit
     org.linkedin
-    log4j
+    org.apache.logging.log4j
     org.mockito
     com.mockrunner
     net.sourceforge.pjl-comp-filter
@@ -82,7 +82,7 @@ for groupId in ${GROUP_IDS[*]} ; do
 done
 
 # Build the exclusion set based on all known direct dependencies.
-EXCLUDE=
+EXCLUDE=" -e ':test$'"
 for groupId in ${GROUP_IDS[*]} ; do
     EXCLUDE="$EXCLUDE -e ${groupId}:"
 done

--- a/scripts/DependencyCheckHelper.sh
+++ b/scripts/DependencyCheckHelper.sh
@@ -12,11 +12,13 @@ mvn dependency:tree > $TARGET_DIR/mvn_dependency_tree.out
 
 # All of the known and documented direct dependencies.
 GROUP_IDS=(
-    com.typesafe.akka
     commons-cli
     commons-codec
     commons-io
     commons-lang3
+    commons-pool
+    org.apache.jena
+    org.apache.tomcat
     org.apache.tomcat.embed
     xerces
     com.rackspace.papi.components.api-checker
@@ -24,20 +26,27 @@ GROUP_IDS=(
     org.rackspace
     net.sf.ehcache
     org.glassfish
+    org.glassfish.main.extras
     org.codehaus.groovy
     com.google.guava
     org.hamcrest
+    com.github.jknack
     org.apache.httpcomponents
     com.fasterxml.jackson.core
     javax
-    javax.transaction
-    javax.mail
     org.jvnet.jaxb2_commons
+    javax.inject
+    javax.mail
+    javax.ws.rs
+    javax.transaction
     org.jboss.spec
     com.sun.jersey
+    org.glassfish.jersey.core
+    com.sun.jersey.test.framework
+    org.jetbrains
     org.eclipse.jetty
+    org.joda
     joda-time
-    com.github.fge
     junit
     org.linkedin
     log4j
@@ -46,9 +55,19 @@ GROUP_IDS=(
     net.sourceforge.pjl-comp-filter
     org.powermock
     org.slf4j
+    net.sf.saxon
+    org.scala-lang
+    org.scalatest
+    com.github.scopt
     org.spockframework
+    io.spray
     org.springframework
+    com.typesafe.akka
+    com.typesafe
+    com.typesafe.play
+    com.typesafe.scala-logging
     xalan
+    com.xmlcalabash
     xmlunit
     com.yammer.metrics
 )

--- a/scripts/DependencyCheckHelper.sh
+++ b/scripts/DependencyCheckHelper.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#REPOSE_DIR=<REPOSE_DIR>/scripts
+SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
+REPOSE_DIR=$SCRIPT_DIR/..
+TARGET_DIR=$REPOSE_DIR/target
+
+cd $REPOSE_DIR
+mkdir -p $TARGET_DIR
+
+echo "Building the Maven Dependency Tree..."
+mvn dependency:tree > $TARGET_DIR/mvn_dependency_tree.out
+
+# All of the known and documented direct dependencies.
+GROUP_IDS=(
+    com.typesafe.akka
+    commons-cli
+    commons-codec
+    commons-io
+    commons-lang
+    org.apache.tomcat.embed
+    xerces
+    com.rackspace.papi.components.api-checker
+    cglib
+    org.rackspace
+    net.sf.ehcache
+    org.glassfish
+    org.codehaus.groovy
+    com.google.guava
+    org.hamcrest
+    org.apache.httpcomponents
+    org.codehaus.jackson
+    javax
+    javax.transaction
+    javax.mail
+    org.jvnet.jaxb2_commons
+    org.jboss.spec
+    com.sun.jersey
+    org.eclipse.jetty
+    joda-time
+    com.github.fge
+    junit
+    org.linkedin
+    log4j
+    org.mockito
+    com.mockrunner
+    net.sourceforge.pjl-comp-filter
+    org.powermock
+    org.slf4j
+    org.spockframework
+    org.springframework
+    xalan
+#    xml-apis # Removed as per below.
+    xmlunit
+    com.yammer.metrics
+)
+
+echo ""
+echo "================================================================================"
+echo "All of the known direct dependencies that need the"
+echo "version numbers confirmed against what is documented:"
+echo "--------------------------------------------------------------------------------"
+for groupId in ${GROUP_IDS[*]} ; do
+    egrep "\[INFO\] \\+\\- " $TARGET_DIR/mvn_dependency_tree.out | cut -d' ' -f3 | sort -u | grep $groupId
+done
+
+# Build the exclusion set based on all known direct dependencies.
+EXCLUDE=
+for groupId in ${GROUP_IDS[*]} ; do
+    EXCLUDE="$EXCLUDE -e $groupId"
+done
+
+echo ""
+echo "================================================================================"
+echo "All direct dependencies that are not currently documented:"
+echo "--------------------------------------------------------------------------------"
+egrep "\[INFO\] \\+\\- " $TARGET_DIR/mvn_dependency_tree.out | cut -d' ' -f3 | sort -u | grep -v -e org.openrepose $EXCLUDE
+
+# All of the UN-known and UN-documented direct dependencies.
+GROUP_IDS_TOO=`egrep "\[INFO\] \\+\\- " $TARGET_DIR/mvn_dependency_tree.out | cut -d' ' -f3 | sort -u | grep -v -e org.openrepose $EXCLUDE | cut -d":" -f1 | sort -u`
+
+EXCLUDE_TOO=
+for groupId in ${GROUP_IDS_TOO[*]} ; do
+    EXCLUDE_TOO="$EXCLUDE_TOO -e $groupId"
+done
+
+echo ""
+echo "================================================================================"
+echo "This is documented as a direct dependency, but currently is only a transient:"
+echo "--------------------------------------------------------------------------------"
+grep xml-apis $TARGET_DIR/mvn_dependency_tree.out
+
+echo ""
+echo "================================================================================"
+echo "All transient dependencies that are not already documented as direct dependencies:"
+echo "--------------------------------------------------------------------------------"
+egrep "\[INFO\] \|" $TARGET_DIR/mvn_dependency_tree.out | cut -d'-' -f2- | cut -d' ' -f2- | sort -u | grep -v -e org.openrepose $EXCLUDE $EXCLUDE_TOO


### PR DESCRIPTION
Added the new DEPENDENCIES.txt file, normalized our dependency versions where possible, and consolidated dependency management where smart.

A lot of the versions were normalized to the highest version in use unless there was a reason not too.