### PR TITLE
Rep 1980 osv3 domain

### DIFF
--- a/repose-aggregator/commons/configuration/src/test/resources/unmarshallerValidator/xsd/openstack-identity-v3.xsd
+++ b/repose-aggregator/commons/configuration/src/test/resources/unmarshallerValidator/xsd/openstack-identity-v3.xsd
@@ -156,6 +156,15 @@
             </xs:annotation>
         </xs:attribute>
 
+        <xs:attribute name="domain-id" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Optional domain id to use when authenticating as an Admin User to OpenStack Identity.</html:p>
+                    <html:p>This will end up in the domain: { "id": HERE } JSON structure</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
         <xs:attribute name="uri" type="xs:anyURI" use="required">
             <xs:annotation>
                 <xs:documentation>

--- a/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
+++ b/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
@@ -118,6 +118,11 @@
             <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-server</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/config/openstack-identity-v3.xsd
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/config/openstack-identity-v3.xsd
@@ -156,6 +156,14 @@
             </xs:annotation>
         </xs:attribute>
 
+        <xs:attribute name="domain" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Optional domain to use when authenticating as an Admin User to OpenStack Identity.</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
         <xs:attribute name="uri" type="xs:anyURI" use="required">
             <xs:annotation>
                 <xs:documentation>

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/config/openstack-identity-v3.xsd
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/config/openstack-identity-v3.xsd
@@ -156,10 +156,11 @@
             </xs:annotation>
         </xs:attribute>
 
-        <xs:attribute name="domain" type="xs:string" use="optional">
+        <xs:attribute name="domain-id" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    <html:p>Optional domain to use when authenticating as an Admin User to OpenStack Identity.</html:p>
+                    <html:p>Optional domain id to use when authenticating as an Admin User to OpenStack Identity.</html:p>
+                    <html:p>This will end up in the domain: { "id": HERE } JSON structure</html:p>
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/examples/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/examples/openstack-identity-v3.cfg.xml
@@ -12,6 +12,6 @@
     <openstack-identity-service
             username="admin_username"
             password="admin_password"
-            domain="some.domain"
+            domain-id="some.domain"
             uri="http://identity.example.com"/>
 </openstack-identity-v3>

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/examples/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/examples/openstack-identity-v3.cfg.xml
@@ -9,5 +9,9 @@
         <uri-pattern>/application\.wadl$</uri-pattern>
     </white-list>
 
-    <openstack-identity-service username="admin_username" password="admin_password" uri="http://identity.example.com"/>
+    <openstack-identity-service
+            username="admin_username"
+            password="admin_password"
+            domain="some.domain"
+            uri="http://identity.example.com"/>
 </openstack-identity-v3>

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/objects/OpenStackIdentityV3Objects.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/objects/OpenStackIdentityV3Objects.scala
@@ -124,7 +124,7 @@ case class AuthResponse(token: AuthenticateResponse
                          ) extends Serializable
 
 case class Domain(id: Option[String] = None,
-                  name: String,
+                  name: Option[String] = None,
                   enabled: Option[Boolean] = None
                    ) extends Serializable
 

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3API.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3API.scala
@@ -68,12 +68,18 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
         case _ => None
       }
 
+      val userDomain = Option(config.getOpenstackIdentityService.getDomainId) match {
+        case x:Some[String] => Some(Domain(id = x))
+        case _ => None
+      }
+
       AuthRequestRoot(
         AuthRequest(
           AuthIdentityRequest(
             methods = List("password"),
             password = Some(PasswordCredentials(
               UserNamePasswordRequest(
+                domain = userDomain,
                 name = Some(username),
                 password = password
               )

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/test/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3APITest.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/test/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3APITest.scala
@@ -76,7 +76,7 @@ class OpenStackIdentityV3APITest extends FunSpec with BeforeAndAfter with Matche
 
     it("builds a JSON auth token request with a domain ID"){
       //Modify the identity config to include the domain
-      identityConfig.getOpenstackIdentityService.setDomain("867530nieeein")
+      identityConfig.getOpenstackIdentityService.setDomainId("867530nieeein")
       identityV3API = new OpenStackIdentityV3API(identityConfig, mockDatastore, mockAkkaServiceClient)
 
       val mockServiceClientResponse = mock[ServiceClientResponse]
@@ -94,7 +94,7 @@ class OpenStackIdentityV3APITest extends FunSpec with BeforeAndAfter with Matche
         contains(
           """
             |{"auth":{"identity":{"methods":["password"],"password":{"user":{"domain":{"id":"867530nieeein"},"name":"user","password":"password"}}}}}
-          """.stripMargin
+          """.stripMargin.trim
         ),
         any[MediaType]
       )

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/withdomain/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/withdomain/openstack-identity-v3.cfg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0">
+
+    <openstack-identity-service username="admin-username"
+                                password="admin-password"
+                                domain-id="test-domain"
+                                uri="http://localhost:${identityPort}"
+                                xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"/>
+</openstack-identity-v3>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/AdminDomainTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/AdminDomainTest.groovy
@@ -58,13 +58,9 @@ class AdminDomainTest extends ReposeValveTest {
     def "Test send request with user token"() {
         given:
         def reqDomain = fakeIdentityV3Service.client_domainid
-        def reqUserId = fakeIdentityV3Service.client_userid
-
         fakeIdentityV3Service.with {
             client_token = UUID.randomUUID().toString()
             tokenExpiresAt = DateTime.now().plusDays(1)
-            client_domainid = reqDomain
-            client_userid = reqUserId
         }
 
         when: "User passes a request through repose"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/AdminDomainTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/AdminDomainTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.identityv3
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV3Service
+import org.joda.time.DateTime
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+/**
+ * Created by jennyvo on 4/22/15.
+ */
+class AdminDomainTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static MockIdentityV3Service fakeIdentityV3Service
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/identityv3/common", params)
+        repose.configurationProvider.applyConfigs("features/filters/identityv3/withdomain", params)
+        repose.start()
+        waitUntilReadyToServiceRequests('401')
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityV3Service = new MockIdentityV3Service(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort,
+                'identity service', null, fakeIdentityV3Service.handler)
+    }
+
+    def cleanupSpec() {
+        if (deproxy)
+            deproxy.shutdown()
+        if (repose)
+            repose.stop()
+    }
+
+    def "Test send request with user token"() {
+        given:
+        def reqDomain = fakeIdentityV3Service.client_domainid
+        def reqUserId = fakeIdentityV3Service.client_userid
+
+        fakeIdentityV3Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_domainid = reqDomain
+            client_userid = reqUserId
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/$reqDomain/",
+                method: 'GET',
+                headers: [
+                        'content-type'   : 'application/json',
+                        'X-Subject-Token': fakeIdentityV3Service.client_token,
+                ]
+        )
+
+        then: "Request body sent from repose to the origin service should contain"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        // check request post to identity to get token include domain
+        mc.orphanedHandlings[0].request.body.toString().contains("domain")
+        mc.orphanedHandlings[0].request.body.toString().contains("test-domain")
+
+    }
+}


### PR DESCRIPTION
This sets up the Openstack V3 API class to be able to append a 
```json
"domain":{
  "id": "someConfiguredId"
}
```
in the request for an admin token for the Openstack V3 filter.