### PR TITLE
Sandboxed functional tests

### DIFF
--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/ReposeJettyServer.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/ReposeJettyServer.scala
@@ -82,7 +82,7 @@ class ReposeJettyServer(val clusterId: String,
     //Set up connectors
     val httpConnector: Option[ServerConnector] = httpPort.map { port =>
       val conn = new ServerConnector(s)
-      if(testMode) {
+      if (testMode) {
         conn.setPort(0)
       } else {
         conn.setPort(port)
@@ -102,7 +102,7 @@ class ReposeJettyServer(val clusterId: String,
         cf.setKeyManagerPassword(ssl.getKeyPassword)
 
         val sslConnector = new ServerConnector(s, cf)
-        if(testMode) {
+        if (testMode) {
           sslConnector.setPort(0)
         } else {
           sslConnector.setPort(port)
@@ -177,11 +177,11 @@ class ReposeJettyServer(val clusterId: String,
   }
   private var isShutdown = false
 
-  def runningHttpPort:Int = {
+  def runningHttpPort: Int = {
     httpConnector.map(_.getLocalPort).getOrElse(0)
   }
 
-  def runningHttpsPort:Int = {
+  def runningHttpsPort: Int = {
     httpsConnector.map(_.getLocalPort).getOrElse(0)
   }
 

--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/ReposeJettyServer.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/ReposeJettyServer.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,8 @@ class ReposeJettyServer(val clusterId: String,
                         val nodeId: String,
                         val httpPort: Option[Int],
                         val httpsPort: Option[Int],
-                        sslConfig: Option[SslConfiguration]) {
+                        sslConfig: Option[SslConfiguration],
+                        testMode: Boolean = false) {
 
   val config = ConfigFactory.load("springConfiguration.conf")
 
@@ -74,6 +75,8 @@ class ReposeJettyServer(val clusterId: String,
    */
   val server: Server = {
     val s = new Server()
+
+    //If I'm in test mode, then randomly select ports and register that port somehow with JMX...
 
     //Set up connectors
     val httpConnector: Option[Connector] = httpPort.map { port =>

--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/ReposeJettyServer.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/ReposeJettyServer.scala
@@ -71,21 +71,26 @@ class ReposeJettyServer(val clusterId: String,
   appContext.setParent(nodeContext) //Use the local node context, not the core context
   appContext.scan(config.getString("powerFilterSpringContextPath"))
   /**
-   * Create the jetty server for this guy
+   * Create the jetty server for this guy,
+   * and get back the connectors so I can ask for ports for them :D
    */
-  val server: Server = {
+  val (httpConnector: Option[ServerConnector], httpsConnector: Option[ServerConnector], server: Server) = {
     val s = new Server()
 
     //If I'm in test mode, then randomly select ports and register that port somehow with JMX...
 
     //Set up connectors
-    val httpConnector: Option[Connector] = httpPort.map { port =>
+    val httpConnector: Option[ServerConnector] = httpPort.map { port =>
       val conn = new ServerConnector(s)
-      conn.setPort(port)
+      if(testMode) {
+        conn.setPort(0)
+      } else {
+        conn.setPort(port)
+      }
       conn
     }
 
-    val httpsConnector: Option[Connector] = httpsPort.map { port =>
+    val httpsConnector: Option[ServerConnector] = httpsPort.map { port =>
       val cf = new SslContextFactory()
 
       //TODO: do we make this a URL for realsies?
@@ -97,7 +102,11 @@ class ReposeJettyServer(val clusterId: String,
         cf.setKeyManagerPassword(ssl.getKeyPassword)
 
         val sslConnector = new ServerConnector(s, cf)
-        sslConnector.setPort(port)
+        if(testMode) {
+          sslConnector.setPort(0)
+        } else {
+          sslConnector.setPort(port)
+        }
 
         //Handle the Protocols and Ciphers
         //varargs are annoying, so lets deal with this using the scala methods
@@ -137,7 +146,8 @@ class ReposeJettyServer(val clusterId: String,
     }
 
     //Hook up the port connectors!
-    s.setConnectors(connectors)
+    //Have to coerce the stuff here, because it makes it happier
+    s.setConnectors(connectors.asInstanceOf[Array[Connector]])
 
     val contextHandler = new ServletContextHandler()
     contextHandler.setContextPath("/")
@@ -163,9 +173,17 @@ class ReposeJettyServer(val clusterId: String,
 
     s.setHandler(contextHandler)
 
-    s
+    (httpConnector, httpsConnector, s)
   }
   private var isShutdown = false
+
+  def getHttpPort:Int = {
+    httpConnector.map(_.getLocalPort).getOrElse(0)
+  }
+
+  def getHttpsPort:Int = {
+    httpsConnector.map(_.getLocalPort).getOrElse(0)
+  }
 
   def start() = {
     if (isShutdown) {
@@ -180,7 +198,7 @@ class ReposeJettyServer(val clusterId: String,
    */
   def restart(): ReposeJettyServer = {
     shutdown()
-    new ReposeJettyServer(clusterId, nodeId, httpPort, httpsPort, sslConfig)
+    new ReposeJettyServer(clusterId, nodeId, httpPort, httpsPort, sslConfig, testMode)
   }
 
   /**

--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/ReposeJettyServer.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/ReposeJettyServer.scala
@@ -177,11 +177,11 @@ class ReposeJettyServer(val clusterId: String,
   }
   private var isShutdown = false
 
-  def getHttpPort:Int = {
+  def runningHttpPort:Int = {
     httpConnector.map(_.getLocalPort).getOrElse(0)
   }
 
-  def getHttpsPort:Int = {
+  def runningHttpsPort:Int = {
     httpsConnector.map(_.getLocalPort).getOrElse(0)
   }
 

--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/Valve.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/Valve.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,6 +72,9 @@ class Valve {
       opt[Unit]('k', "insecure") action { (_, c) =>
         c.copy(insecure = true)
       } text "Ignore all SSL certificates validity and operate Very insecurely. Default: off (validate certs)"
+      opt[Unit]("test-mode") action { (_, c) =>
+        c.copy(testMode = true)
+      }
       opt[Unit]("show-ssl-params") action { (_, c) =>
         c.copy(showSslParams = true)
       } text "Display SSL Ciphers and Protocols, sorted by enabled by default and all available"
@@ -140,7 +143,7 @@ class Valve {
 
         //make it go
         //TODO: possibly a try/catch around this guy to deal with exceptions
-        valveRunner.run(valveConfig.configDirectory.getAbsolutePath, valveConfig.insecure)
+        valveRunner.run(valveConfig.configDirectory.getAbsolutePath, valveConfig.insecure, valveConfig.testMode)
       }
     } getOrElse {
       //Not a valid config!
@@ -170,7 +173,8 @@ class Valve {
                          insecure: Boolean = false,
                          showVersion: Boolean = false,
                          showUsage: Boolean = false,
-                         showSslParams: Boolean = false
+                         showSslParams: Boolean = false,
+                         testMode: Boolean = false
                           )
 
 }

--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/jmx/ValvePortMXBean.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/jmx/ValvePortMXBean.scala
@@ -7,5 +7,5 @@ object ValvePortMXBean {
 trait ValvePortMXBean {
   def getPort(clusterId: String, nodeId: String): Int
 
-  def getName():String
+  def getSslPort(clusterId: String, nodeId: String): Int
 }

--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/jmx/ValvePortMXBean.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/jmx/ValvePortMXBean.scala
@@ -1,0 +1,11 @@
+package org.openrepose.valve.jmx
+
+object ValvePortMXBean {
+  final val OBJECT_NAME = "org.openrepose.valve.jmx:type=ValvePort"
+}
+
+trait ValvePortMXBean {
+  def getPort(clusterId: String, nodeId: String): Int
+
+  def getName():String
+}

--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/jmx/ValvePortMXBeanImpl.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/jmx/ValvePortMXBeanImpl.scala
@@ -1,0 +1,32 @@
+package org.openrepose.valve.jmx
+
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Named
+
+import org.springframework.jmx.export.annotation.{ManagedAttribute, ManagedResource}
+
+
+@Named
+@ManagedResource(
+  objectName = "org.openrepose.valve.jmx:type=ValvePort",
+  description = "Get the ports from valve in test mode"
+)
+class ValvePortMXBeanImpl extends ValvePortMXBean {
+
+  val nodePorts = new ConcurrentHashMap[String, Int]()
+
+  def key(clusterId: String, nodeId: String): String = {
+    clusterId + "-" + nodeId
+  }
+
+  @ManagedAttribute(description = "Returns the port of the selected node, or zero if it isn't set")
+  override def getPort(clusterId: String, nodeId: String): Int = {
+    nodePorts.get(key(clusterId, nodeId))
+  }
+
+  def setPort(clusterId: String, nodeId: String, port: Int): Unit = {
+    nodePorts.put(key(clusterId, nodeId), port)
+  }
+
+  override def getName(): String = ValvePortMXBean.OBJECT_NAME
+}

--- a/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/jmx/ValvePortMXBeanImpl.scala
+++ b/repose-aggregator/core/valve/src/main/scala/org/openrepose/valve/jmx/ValvePortMXBeanImpl.scala
@@ -14,6 +14,7 @@ import org.springframework.jmx.export.annotation.{ManagedAttribute, ManagedResou
 class ValvePortMXBeanImpl extends ValvePortMXBean {
 
   val nodePorts = new ConcurrentHashMap[String, Int]()
+  val nodeSslPorts = new ConcurrentHashMap[String, Int]()
 
   def key(clusterId: String, nodeId: String): String = {
     clusterId + "-" + nodeId
@@ -24,9 +25,23 @@ class ValvePortMXBeanImpl extends ValvePortMXBean {
     nodePorts.get(key(clusterId, nodeId))
   }
 
+  @ManagedAttribute(description = "Returns the SSL port of the selected node, or zero if it isn't set")
+  override def getSslPort(clusterId: String, nodeId: String): Int = {
+    nodeSslPorts.get(key(clusterId, nodeId))
+  }
+
+  def clearPort(clusterId: String, nodeId: String): Unit = {
+    val k = key(clusterId, nodeId)
+    nodePorts.remove(k)
+    nodeSslPorts.remove(k)
+  }
+
   def setPort(clusterId: String, nodeId: String, port: Int): Unit = {
     nodePorts.put(key(clusterId, nodeId), port)
   }
 
-  override def getName(): String = ValvePortMXBean.OBJECT_NAME
+  def setSslPort(clusterId: String, nodeId: String, port: Int): Unit = {
+    nodeSslPorts.put(key(clusterId, nodeId), port)
+  }
+
 }

--- a/repose-aggregator/core/valve/src/test/scala/org/openrepose/spring/ValveTestModeRunnerTest.scala
+++ b/repose-aggregator/core/valve/src/test/scala/org/openrepose/spring/ValveTestModeRunnerTest.scala
@@ -22,6 +22,7 @@ package org.openrepose.spring
 import java.lang.management.ManagementFactory
 import javax.management.{JMX, ObjectName}
 
+import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.junit.runner.RunWith
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.core.container.config.ContainerConfiguration
@@ -36,7 +37,7 @@ import scala.concurrent.{Await, Future}
 
 
 @RunWith(classOf[JUnitRunner])
-class ValveTestModeRunnerTest extends FunSpec with Matchers {
+class ValveTestModeRunnerTest extends FunSpec with Matchers with LazyLogging {
   val log = LoggerFactory.getLogger(this.getClass)
 
   val fakeConfigService = new FakeConfigService()
@@ -146,7 +147,10 @@ class ValveTestModeRunnerTest extends FunSpec with Matchers {
         updateContainerConfig("/valveTesting/without-keystore.xml")
 
         runner.getActiveNodes.size shouldBe 1
-        getValvePortMXBean.getPort("repose", "repose_node1") shouldNot be(0)
+        val port = getValvePortMXBean.getPort("repose", "repose_node1")
+        logger.debug(s"PORT IS: $port")
+        port shouldNot be(0)
+        port shouldNot be(10234) //It shouldn't match exactly what we configured...
       }
     }
     it("Starts up nodes as configured in the system-model when given a container config before a system-model") {
@@ -157,6 +161,10 @@ class ValveTestModeRunnerTest extends FunSpec with Matchers {
         updateSystemModel("/valveTesting/1node/system-model-1.cfg.xml")
 
         runner.getActiveNodes.size shouldBe 1
+        val port = getValvePortMXBean.getPort("repose", "repose_node1")
+        logger.debug(s"PORT IS: $port")
+        port shouldNot be(0)
+        port shouldNot be(10234) //It shouldn't match exactly what we configured...
       }
     }
   }

--- a/repose-aggregator/core/valve/src/test/scala/org/openrepose/spring/ValveTestModeRunnerTest.scala
+++ b/repose-aggregator/core/valve/src/test/scala/org/openrepose/spring/ValveTestModeRunnerTest.scala
@@ -1,0 +1,358 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package org.openrepose.spring
+
+import java.lang.management.ManagementFactory
+import javax.management.{JMX, ObjectName}
+
+import org.junit.runner.RunWith
+import org.openrepose.commons.config.manager.UpdateListener
+import org.openrepose.core.container.config.ContainerConfiguration
+import org.openrepose.core.systemmodel.SystemModel
+import org.openrepose.valve.jmx.ValvePortMXBean
+import org.openrepose.valve.spring.ValveRunner
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FunSpec, Matchers}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{Await, Future}
+
+
+@RunWith(classOf[JUnitRunner])
+class ValveTestModeRunnerTest extends FunSpec with Matchers {
+  val log = LoggerFactory.getLogger(this.getClass)
+
+  val fakeConfigService = new FakeConfigService()
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import scala.concurrent.duration._
+
+  /**
+   * For this class, the test mode is going to be true!
+   * @param configRoot
+   * @param insecure
+   * @param testMode
+   * @param f
+   * @return
+   */
+  def withRunner(configRoot: String = "/config/root",
+                 insecure: Boolean = false,
+                 testMode: Boolean = true)(f: ValveRunner => Unit) = {
+    val runner = new ValveRunner(fakeConfigService)
+    val runnerTask = Future {
+      runner.run(configRoot, insecure, testMode)
+    }
+
+    runnerTask.onFailure {
+      case t => fail("Future didn't go!", t)
+    }
+    try {
+      f(runner)
+    } finally {
+      runner.destroy()
+    }
+    Await.ready(runnerTask, 3 seconds)
+  }
+
+  def getValvePortMXBean: ValvePortMXBean = {
+    val mbs = ManagementFactory.getPlatformMBeanServer
+    val name = new ObjectName(ValvePortMXBean.OBJECT_NAME)
+    if (mbs.isRegistered(name)) {
+      println("Getting the registered mbean!")
+      val thing = JMX.newMBeanProxy(mbs, name, classOf[ValvePortMXBean])
+      thing
+    } else {
+      fail("Unable to get ValvePort MX Bean!")
+    }
+  }
+
+  def updateSystemModel(resource: String): UpdateListener[SystemModel] = {
+    val systemModelListener = fakeConfigService.getListener[SystemModel]("system-model.cfg.xml")
+    val systemModel = Marshaller.systemModel(resource)
+    systemModelListener.configurationUpdated(systemModel)
+    systemModelListener
+  }
+
+  def updateContainerConfig(resource: String): UpdateListener[ContainerConfiguration] = {
+    val containerListener = fakeConfigService.getListener[ContainerConfiguration]("container.cfg.xml")
+    val containerConfig = Marshaller.containerConfig(resource)
+    containerListener.configurationUpdated(containerConfig)
+    containerListener
+  }
+
+  it("has a blocking run method") {
+    val runner = new ValveRunner(fakeConfigService)
+
+    val future = Future {
+      runner.run("/root", false)
+    }
+    future.isCompleted shouldBe false
+
+    runner.destroy()
+    Await.ready(future, 1 second)
+    future.isCompleted shouldBe true
+  }
+
+  it("passes through configRoot and insecure to each node") {
+    pending
+  }
+
+  describe("Starting fresh") {
+    it("Does nothing if the container-config is updated before the system-model") {
+      withRunner() { runner =>
+        runner.getActiveNodes shouldBe empty
+
+        updateContainerConfig("/valveTesting/without-keystore.xml")
+
+        //it should not have triggered any nodes
+        runner.getActiveNodes shouldBe empty
+        getValvePortMXBean.getPort("repose", "repose_node1") shouldBe 0
+      }
+
+    }
+    it("doesn't start nodes if only the system-model has been configured") {
+      withRunner() { runner =>
+        runner.getActiveNodes shouldBe empty
+
+        updateSystemModel("/valveTesting/1node/system-model-1.cfg.xml")
+
+        //it should not have triggered any nodes
+        runner.getActiveNodes shouldBe empty
+        getValvePortMXBean.getPort("repose", "repose_node1") shouldBe 0
+      }
+    }
+    it("Starts up nodes as configured in the system-model when hit with a system model before a container config") {
+      withRunner() { runner =>
+        runner.getActiveNodes shouldBe empty
+
+        updateSystemModel("/valveTesting/1node/system-model-1.cfg.xml")
+        updateContainerConfig("/valveTesting/without-keystore.xml")
+
+        runner.getActiveNodes.size shouldBe 1
+        getValvePortMXBean.getPort("repose", "repose_node1") shouldNot be(0)
+      }
+    }
+    it("Starts up nodes as configured in the system-model when given a container config before a system-model") {
+      withRunner() { runner =>
+        runner.getActiveNodes shouldBe empty
+
+        updateContainerConfig("/valveTesting/without-keystore.xml")
+        updateSystemModel("/valveTesting/1node/system-model-1.cfg.xml")
+
+        runner.getActiveNodes.size shouldBe 1
+      }
+    }
+  }
+
+  describe("When started with a single node") {
+    def withSingleNodeRunner(f: ValveRunner => Unit) = {
+      withRunner() { runner =>
+        runner.getActiveNodes shouldBe empty
+        updateContainerConfig("/valveTesting/without-keystore.xml")
+        updateSystemModel("/valveTesting/1node/system-model-1.cfg.xml")
+        f(runner)
+      }
+    }
+
+    it("restarts that node when an update event to the container.cfg.xml happens") {
+      withSingleNodeRunner { runner =>
+        runner.getActiveNodes.size shouldBe 1
+        val node = runner.getActiveNodes.head
+
+        updateContainerConfig("/valveTesting/without-keystore.xml")
+        runner.getActiveNodes.size shouldBe 1
+        runner.getActiveNodes.head shouldNot be(node)
+      }
+    }
+    describe("When updating the system-model") {
+      it("A node needs to be changed if it's ports don't match") {
+        withSingleNodeRunner { runner =>
+          val node = runner.getActiveNodes.head
+          node.nodeId shouldBe "repose_node1"
+          node.httpPort.isDefined shouldBe (true)
+          node.httpPort.get shouldBe (10234)
+
+          updateSystemModel("/valveTesting/1node/change-node-1-port.xml")
+          runner.getActiveNodes.size shouldBe 1
+          runner.getActiveNodes.head shouldNot be(node)
+          runner.getActiveNodes.head.httpPort.isDefined shouldBe (true)
+          runner.getActiveNodes.head.httpPort.get shouldBe (10235)
+
+          val changedNode = runner.getActiveNodes.head
+          changedNode.nodeId shouldBe "repose_node1"
+        }
+      }
+      it("restarts the changed node") {
+        withSingleNodeRunner { runner =>
+          val node = runner.getActiveNodes.head
+          node.nodeId shouldBe "repose_node1"
+
+          updateSystemModel("/valveTesting/1node/change-node-1.xml")
+          runner.getActiveNodes.size shouldBe 1
+          runner.getActiveNodes.head shouldNot be(node)
+
+          val changedNode = runner.getActiveNodes.head
+          changedNode.nodeId shouldBe "le_repose_node"
+        }
+      }
+      it("will not do anything if the nodes are the same") {
+        withSingleNodeRunner { runner =>
+          val node = runner.getActiveNodes.head
+          node.nodeId shouldBe "repose_node1"
+
+          updateSystemModel("/valveTesting/1node/system-model-1.cfg.xml")
+          runner.getActiveNodes.size shouldBe 1
+          runner.getActiveNodes.head shouldBe node
+        }
+      }
+    }
+  }
+  describe("When started with multiple local nodes") {
+    def withTwoNodeRunner(f: ValveRunner => Unit) = {
+      withRunner() { runner =>
+        runner.getActiveNodes shouldBe empty
+        updateContainerConfig("/valveTesting/without-keystore.xml")
+        updateSystemModel("/valveTesting/2node/system-model-2.cfg.xml")
+        f(runner)
+      }
+    }
+
+    it("restarts all nodes when a change to the container.cfg.xml happens") {
+      withTwoNodeRunner { runner =>
+        runner.getActiveNodes.size shouldBe 2
+        val node1 = runner.getActiveNodes.find(_.nodeId == "repose_node1").get
+        val node2 = runner.getActiveNodes.find(_.nodeId == "repose_node2").get
+
+        updateContainerConfig("/valveTesting/without-keystore.xml")
+
+        runner.getActiveNodes.size shouldBe 2
+
+        val newNode1 = runner.getActiveNodes.find(_.nodeId == "repose_node1").get
+        val newNode2 = runner.getActiveNodes.find(_.nodeId == "repose_node2").get
+
+        newNode1 shouldNot be(node1)
+        newNode2 shouldNot be(node2)
+
+        newNode1.nodeId shouldBe node1.nodeId
+        newNode2.nodeId shouldBe node2.nodeId
+      }
+    }
+    describe("When updating the system-model") {
+      it("restarts only the changed nodes") {
+        withTwoNodeRunner { runner =>
+          val node2 = runner.getActiveNodes.find(_.nodeId == "repose_node2").get
+
+          updateSystemModel("/valveTesting/2node/change-node-2.xml")
+
+          runner.getActiveNodes.size shouldBe 2
+          val newNode2 = runner.getActiveNodes.find(_.nodeId == "le_changed_node").get
+          newNode2 shouldNot be(node2)
+        }
+      }
+      it("Stops removed nodes") {
+        withTwoNodeRunner { runner =>
+          runner.getActiveNodes.size shouldBe 2
+          val node1 = runner.getActiveNodes.find(_.nodeId == "repose_node1").get
+
+          updateSystemModel("/valveTesting/2node/remove-node-2.xml")
+          runner.getActiveNodes.size shouldBe 1
+          val stillNode1 = runner.getActiveNodes.head
+
+          stillNode1 shouldBe node1
+        }
+      }
+      it("starts new nodes") {
+        withTwoNodeRunner { runner =>
+          runner.getActiveNodes.size shouldBe 2
+          val node1 = runner.getActiveNodes.find(_.nodeId == "repose_node1").get
+          val node2 = runner.getActiveNodes.find(_.nodeId == "repose_node2").get
+
+          updateSystemModel("/valveTesting/2node/add-node-3.xml")
+
+          runner.getActiveNodes.size shouldBe 3
+          val newNode1 = runner.getActiveNodes.find(_.nodeId == "repose_node1").get
+          val newNode2 = runner.getActiveNodes.find(_.nodeId == "repose_node2").get
+          val newNode3 = runner.getActiveNodes.find(_.nodeId == "repose_node3").get
+
+          newNode1 shouldBe node1
+          newNode2 shouldBe node2
+
+          newNode3.nodeId shouldBe "repose_node3"
+        }
+      }
+      it("will not do anything if the nodes are the same") {
+        withTwoNodeRunner { runner =>
+          runner.getActiveNodes.size shouldBe 2
+          val node1 = runner.getActiveNodes.find(_.nodeId == "repose_node1").get
+          val node2 = runner.getActiveNodes.find(_.nodeId == "repose_node2").get
+
+          updateSystemModel("/valveTesting/2node/system-model-2.cfg.xml")
+
+          runner.getActiveNodes.size shouldBe 2
+          val newNode1 = runner.getActiveNodes.find(_.nodeId == "repose_node1").get
+          val newNode2 = runner.getActiveNodes.find(_.nodeId == "repose_node2").get
+
+          newNode1 shouldBe node1
+          newNode2 shouldBe node2
+        }
+      }
+    }
+  }
+
+  describe("Error states") {
+    it("if no local nodes are detected, it shuts down valve!") {
+      val runner = new ValveRunner(fakeConfigService)
+      val runnerTask = Future {
+        runner.run("/config/root", false)
+      }
+
+      runner.getActiveNodes shouldBe empty
+
+      updateContainerConfig("/valveTesting/without-keystore.xml")
+      updateSystemModel("/valveTesting/0node/system-model-0.cfg.xml")
+      runner.getActiveNodes shouldBe empty
+      val exitCode = Await.result(runnerTask, 1 second)
+      exitCode shouldBe 0
+    }
+  }
+
+  describe("Starting up in testing mode with automatic ports") {
+    def withSingleNodeTestRunner(f: ValveRunner => Unit) = {
+      withRunner(testMode = true) { runner =>
+        runner.getActiveNodes shouldBe empty
+        updateContainerConfig("/valveTesting/without-keystore.xml")
+        updateSystemModel("/valveTesting/1node/system-model-1.cfg.xml")
+        f(runner)
+      }
+    }
+
+    it("starts up a single local node, letting the JVM select the port and providing the port via JMX") {
+      pending
+      withSingleNodeTestRunner { runner =>
+        val node = runner.getActiveNodes.head
+        node.nodeId shouldBe "repose_node1"
+      }
+    }
+    it("starts up multiple local nodes, letting the JVM select ports for both, and providing both ports via JMX") {
+      pending
+    }
+  }
+
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/ReposeContainerLauncher.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/ReposeContainerLauncher.groovy
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeoutException
 
 import static org.linkedin.groovy.util.concurrent.GroovyConcurrentUtils.waitForCondition
 
+//TODO: Refactor this to just be a different command than the valve launcher :(
+//So much duplicated logic
 class ReposeContainerLauncher extends ReposeLauncher {
 
     int reposePort
@@ -181,5 +183,10 @@ class ReposeContainerLauncher extends ReposeLauncher {
     @Override
     void addToClassPath(String path) {
         classPaths.add(path)
+    }
+
+    @Override
+    void keepSandbox() {
+        //Nothing?
     }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/ReposeLauncher.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/ReposeLauncher.groovy
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,8 @@ abstract class ReposeLauncher {
     abstract boolean isUp();
 
     abstract void enableDebug()
+
+    abstract void keepSandbox()
 
     /**
      * This enables easier debugging from the actual code under test.


### PR DESCRIPTION
This depends on #1297.... Actually it doesn't, but I built upon that list of commits. 

This could be cherry-picked directly onto what is master to get us sandboxed functional tests without having any of the test-mode stuff.

Actually it cannot, it breaks all the log searching stuff, all the properties substitution of config files. It's a hot mess.