### PR TITLE
pre-install scripts need updated due to formatting changes

### DIFF
--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -319,19 +319,19 @@
                                     if [ -f $SYSTEM_MODEL ]
                                     then
                                     # Detects if the Dist-Datastore filter is present in the system-model.cfg.xml file.
-                                    If the filter is an active component then this installation will fail.
-                                    if cat $SYSTEM_MODEL | sed '/<!--.*-->/d'| sed '/<!--/,/-->/d' | grep
-                                    'filter.*dist-datastore'
+                                    # If the filter is an active component then this installation will fail.
+                                    if cat $SYSTEM_MODEL | sed '/<!--.*-->/d'| sed '/<!--/,/-->/d' | \ 
+                                      grep 'filter.*dist-datastore'
                                     then
-                                    echo "Unable to upgrade. system-model.cfg.xml file contains the deprecated
-                                    dist-datastore filter. Please remove and re-run upgrade. For more information on the
-                                    upgrade:
+                                    echo "Unable to upgrade. system-model.cfg.xml file contains the deprecated \
+                                    dist-datastore filter. Please remove and re-run upgrade. For more information on  \
+                                    the upgrade: \
                                     https://repose.atlassian.net/wiki/display/REPOSE/Release+Notes#ReleaseNotes-Release3.0.0(InProgress:UpdatetoJava1.7,RemoveDDFilter,ModularizeDD,BugFixes)"
                                     exit 1
                                     fi
                                     else
                                     getent group repose &gt;&gt; /dev/null 2&gt;&amp;1 || groupadd -r repose
-                                    getent passwd repose &gt;&gt; /dev/null 2&gt;&amp;1 || useradd -r -g repose -s
+                                    getent passwd repose &gt;&gt; /dev/null 2&gt;&amp;1 || useradd -r -g repose -s \
                                     /sbin/nologin -d /usr/share/repose -c "Repose" repose
                                     fi
                                     exit 0

--- a/repose-aggregator/installation/rpm/repose-war/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-war/pom.xml
@@ -265,19 +265,19 @@
                                     if [ -f $SYSTEM_MODEL ]
                                     then
                                     # Detects if the Dist-Datastore filter is present in the system-model.cfg.xml file.
-                                    If the filter is an active component then this installation will fail.
-                                    if cat $SYSTEM_MODEL | sed '/<!--.*-->/d'| sed '/<!--/,/-->/d' | grep
-                                    'filter.*dist-datastore'
+                                    # If the filter is an active component then this installation will fail.
+                                    if cat $SYSTEM_MODEL | sed '/<!--.*-->/d'| sed '/<!--/,/-->/d' | \
+                                    grep 'filter.*dist-datastore'
                                     then
-                                    echo "Unable to upgrade. system-model.cfg.xml file contains the deprecated
-                                    dist-datastore filter. Please remove and re-run upgrade. For more information on the
-                                    upgrade:
+                                    echo "Unable to upgrade. system-model.cfg.xml file contains the deprecated \
+                                    dist-datastore filter. Please remove and re-run upgrade. For more information on \
+                                    the upgrade: \
                                     https://repose.atlassian.net/wiki/display/REPOSE/Release+Notes#ReleaseNotes-Release3.0.0(InProgress:UpdatetoJava1.7,RemoveDDFilter,ModularizeDD,BugFixes)"
                                     exit 1
                                     fi
                                     else
                                     getent group repose &gt;&gt; /dev/null 2&gt;&amp;1 || groupadd -r repose
-                                    getent passwd repose &gt;&gt; /dev/null 2&gt;&amp;1 || useradd -r -g repose -s
+                                    getent passwd repose &gt;&gt; /dev/null 2&gt;&amp;1 || useradd -r -g repose -s \
                                     /sbin/nologin -d /usr/share/repose -c "Repose" repose
                                     fi
                                     exit 0


### PR DESCRIPTION
Lines were truncated and chopped in shell scripts, cleaned up lines to preserve line length and still allow shell scripts to execute.