### PR TITLE
Vishal kedia master

### DIFF
--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/core/spring/CoreSpringProvider.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/core/spring/CoreSpringProvider.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -150,14 +150,12 @@ public class CoreSpringProvider {
             }
 
             coreContext.scan(coreScanPackage);
-            
-            final String extendedServicePackageNameKey = conf.getString("extendedServicePackageNameKey");
-            
-            final String extendedServicePackage = System.getProperty(extendedServicePackageNameKey);
-            
-            if (!Strings.isNullOrEmpty(extendedServicePackage)) {
+
+            //Additionally, if configured to, scan another package
+            if (conf.hasPath("extendedSpringContextPath")) {
+                final String extendedServicePackage = conf.getString("extendedSpringContextPath");
                 coreContext.scan(extendedServicePackage);
-                LOG.trace("extended services 'package' name for scan = {}", extendedServicePackage);
+                LOG.info("Scanning additional service path = {}", extendedServicePackage);
             }
 
             //Have to set up the JMX stuff by hand

--- a/repose-aggregator/core/core-lib/src/main/resources/springConfiguration.conf
+++ b/repose-aggregator/core/core-lib/src/main/resources/springConfiguration.conf
@@ -1,5 +1,4 @@
 coreSpringContextPath = org.openrepose.core
 nodeSpringContextPath = org.openrepose.nodeservice
 powerFilterSpringContextPath = org.openrepose.powerfilter
-extendedServicePackageNameKey = extendedServicePackageName 
 reposeVersion = "${project.version}"

--- a/repose-aggregator/core/core-lib/src/test/resources/springConfiguration.conf
+++ b/repose-aggregator/core/core-lib/src/test/resources/springConfiguration.conf
@@ -1,3 +1,3 @@
 coreSpringContextPath = org.openrepose.core.spring.test
 nodeSpringContextPath = org.openrepose.nodeservice.test
-extendedServicePackageNameKey = extendedServicePackageName 
+extendedSpringContextPath = com.anycompany.spring.test

--- a/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
+++ b/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,11 +31,10 @@ import com.anycompany.spring.test.TestBean
 
 @RunWith(classOf[JUnitRunner])
 class CoreSpringProviderTest extends FunSpec with Matchers with TestFilterBundlerHelper {
-  
-  System.setProperty("extendedServicePackageName", "com.anycompany.spring.test")
+
   val coreSpringProvider = CoreSpringProvider.getInstance()
   coreSpringProvider.initializeCoreContext("/etc/repose", false)
-  
+
 
   describe("The Core Spring Provider") {
     it("is a singleton as the primary interface") {
@@ -58,10 +57,11 @@ class CoreSpringProviderTest extends FunSpec with Matchers with TestFilterBundle
       derpBean shouldNot be(null)
       herpBean shouldNot be(null)
       fooBean shouldNot be(null)
-      
+
+      //Also assert that the custom package path beans got scanned
       val testBean = coreContext.getBean[TestBean](classOf[TestBean])
       val testFooBean = coreContext.getBean[TestFooBean](classOf[TestFooBean])
-      
+
       testBean shouldNot be(null)
       testFooBean shouldNot be(null)
 


### PR DESCRIPTION
Replaces #1304 by using the typesafe config library to it's full potential.

It works the same way:
```
java -DextendedSpringContextPath=com.somewhere -cp ./external.jar -jar repose-valve.jar -c /etc/repose
```

This will also scan the package `com.somewhere`, assuming it's provided by the external.jar