### PR TITLE
Ordering Rather Than Wrapping, Auto-Formatting, Test

### DIFF
--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/QualityFormatException.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/QualityFormatException.java
@@ -1,0 +1,13 @@
+package org.openrepose.commons.utils.servlet.http;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: adrian
+ * Date: 6/4/15
+ * Time: 10:37 AM
+ */
+public class QualityFormatException extends RuntimeException {
+    public QualityFormatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -84,7 +84,7 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest)
     val existingHeaders: List[String] = getHeadersScala(headerName) //this has to be done before we remove from the list,
                                                                     // because getting this list is partially based on the contents of the removed list
     if (removedHeaders.contains(headerName)) {
-      removedHeaders = removedHeaders.filterNot(_.equalsIgnoreCase(headerName))
+      removedHeaders = removedHeaders - headerName
     }
     headerMap = headerMap + (headerName -> (existingHeaders :+ headerValue))
   }
@@ -105,7 +105,7 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest)
 
   override def removeHeader(headerName: String): Unit = {
     removedHeaders = removedHeaders + headerName
-    headerMap = headerMap.filterKeys(!_.equalsIgnoreCase(headerName))
+    headerMap = headerMap - headerName
   }
 
   def getPreferredHeader(headerName: String, getFun: String => List[String]): String = {
@@ -131,7 +131,7 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest)
 
   override def replaceHeader(headerName: String, headerValue: String): Unit = {
     headerMap = headerMap + (headerName -> List(headerValue))
-    removedHeaders = removedHeaders.filterNot(_.equalsIgnoreCase(headerName))
+    removedHeaders = removedHeaders - headerName
   }
 
   override def replaceHeader(headerName: String, headerValue: String, quality: Double): Unit = replaceHeader(headerName, headerValue + ";q=" + quality)

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -61,16 +61,7 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest)
 
   override def getHeaders(headerName: String): util.Enumeration[String] = getHeadersScala(headerName).toIterator.asJavaEnumeration
 
-  override def getDateHeader(headerName: String): Long = {
-    Option(getHeader(headerName)) match {
-      case Some(headerValue) =>
-        Option(DateUtils.parseDate(headerValue)) match {
-          case Some(parsedDate) => parsedDate.getTime
-          case None => throw new IllegalArgumentException("Header value could not be converted to a date")
-        }
-      case None => -1
-    }
-  }
+  override def getDateHeader(headerName: String): Long = Option(getHeader(headerName)).map(DateUtils.parseDate(_).getTime).getOrElse(-1)
 
   override def getHeader(headerName: String): String = getHeadersScala(headerName).headOption.orNull
 

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -106,8 +106,13 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest)
 
   def getPreferredHeader(headerName: String, getFun: String => List[String]): String = {
     def parseQuality(headerValue: String): Double = {
-      headerValue.split(";").tail.find(param => "q".equalsIgnoreCase(param.split("=")(0).trim))
-        .map(_.split("=", 2)(1).toDouble).getOrElse(0.0)
+      try {
+        headerValue.split(";").tail.find(param => "q".equalsIgnoreCase(param.split("=")(0).trim))
+          .map(_.split("=", 2)(1).toDouble).getOrElse(1.0)
+      }
+      catch {
+        case e :NumberFormatException => throw new QualityFormatException("Quality was an unparseable value", e)
+      }
     }
 
     getFun(headerName) match {

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -72,7 +72,6 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
       wrappedRequest.getHeaderNamesScala should contain theSameElementsAs headerMap.keys.filterNot( _ == "foo")
     }
 
-    //todo: fix this test -- it should not be case sensitive
     it("should return the same list when Foo is added") {
       wrappedRequest.addHeader("Foo", "foo")
       wrappedRequest.getHeaderNamesScala should contain theSameElementsAs headerMap.keys
@@ -94,7 +93,6 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
       wrappedRequest.getHeaderNames.asScala.toList should contain theSameElementsAs headerMap.keys.filterNot( _ == "foo")
     }
 
-    //todo: fix this test -- it should not be case sensitive
     it("should return the same list when Foo is added") {
       wrappedRequest.addHeader("Foo", "foo")
       wrappedRequest.getHeaderNames.asScala.toList should contain theSameElementsAs headerMap.keys
@@ -523,10 +521,9 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
       wrappedRequest.getPreferredHeader("ornament") shouldBe "santa"
     }
 
-    //todo: fix this test -- shouldn't the higher quality value be returned?
-    it("should return the appropriate value when a higher quality is appended onto a line") {
+    it("should throw an exception when quality becomes unreadable in a single line") {
       wrappedRequest.appendHeader("ornament", "star", 0.95)
-      wrappedRequest.getPreferredHeader("ornament") shouldBe "weird penguin"
+      a [QualityFormatException] should be thrownBy wrappedRequest.getPreferredHeader("ornament")
     }
 
     it("should return an added value when it's the only value") {
@@ -625,6 +622,11 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
     it("should return empty list if header is removed") {
       wrappedRequest.removeHeader("abc")
       wrappedRequest.getSplittableHeader("abc").asScala.toList shouldBe empty
+    }
+
+    it("should throw an exception when quality is garbage") {
+      wrappedRequest.addHeader("cup", "butts;q=butts")
+      a [QualityFormatException] should be thrownBy wrappedRequest.getPreferredSplittableHeader("cup")
     }
   }
 }

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -41,7 +41,6 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
   val headerMap :Map[String, List[String]] = Map(
     "foo" -> List("bar", "baz"),
     "banana-phone" -> List("ring,ring,ring"),
-    "ghost" -> List("spooky;q=.90,sexy;q=1.0", "scary;q=.95"),
     "cup" -> List("blue,orange;q=0.5"),
     "ornament" -> List("weird penguin;q=0.8", "santa;q=0.9", "droopy tree;q=0.3"),
     "thumbs" -> List("2"),
@@ -60,22 +59,23 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
 
   describe("the getHeadersNamesSet method") {
     it("should return all the header names from the original request") {
-      wrappedRequest.getHeaderNamesSet should contain theSameElementsAs headerMap.keys
+      wrappedRequest.getHeaderNamesScala should contain theSameElementsAs headerMap.keys
     }
 
     it("should return all the header names including the ones that were added") {
       wrappedRequest.addHeader("butts", "butts")
-      wrappedRequest.getHeaderNamesSet should contain theSameElementsAs headerMap.keys ++ List("butts")
+      wrappedRequest.getHeaderNamesScala should contain theSameElementsAs headerMap.keys ++ List("butts")
     }
 
     it("should return a list that is missing any deleted headers") {
       wrappedRequest.removeHeader("foo")
-      wrappedRequest.getHeaderNamesSet should contain theSameElementsAs headerMap.keys.filterNot( _ == "foo")
+      wrappedRequest.getHeaderNamesScala should contain theSameElementsAs headerMap.keys.filterNot( _ == "foo")
     }
 
+    //todo: fix this test -- it should not be case sensitive
     it("should return the same list when Foo is added") {
       wrappedRequest.addHeader("Foo", "foo")
-      wrappedRequest.getHeaderNamesSet should contain theSameElementsAs headerMap.keys
+      wrappedRequest.getHeaderNamesScala should contain theSameElementsAs headerMap.keys
     }
   }
 
@@ -513,10 +513,6 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
       wrappedRequest.getPreferredHeader("ornament") shouldBe "santa"
     }
 
-    it("should return the value with the highest quality when multiple values are on the same line") {
-      wrappedRequest.getPreferredHeader("ghost") shouldBe "sexy"
-    }
-
     it("should return added value if quality is larger than original") {
       wrappedRequest.addHeader("ornament", "reindeer", 0.95)
       wrappedRequest.getPreferredHeader("ornament") shouldBe "reindeer"
@@ -527,6 +523,7 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
       wrappedRequest.getPreferredHeader("ornament") shouldBe "santa"
     }
 
+    //todo: fix this test -- shouldn't the higher quality value be returned?
     it("should return the appropriate value when a higher quality is appended onto a line") {
       wrappedRequest.appendHeader("ornament", "star", 0.95)
       wrappedRequest.getPreferredHeader("ornament") shouldBe "weird penguin"

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -94,6 +94,7 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
       wrappedRequest.getHeaderNames.asScala.toList should contain theSameElementsAs headerMap.keys.filterNot( _ == "foo")
     }
 
+    //todo: fix this test -- it should not be case sensitive
     it("should return the same list when Foo is added") {
       wrappedRequest.addHeader("Foo", "foo")
       wrappedRequest.getHeaderNames.asScala.toList should contain theSameElementsAs headerMap.keys

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -41,6 +41,7 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
   val headerMap :Map[String, List[String]] = Map(
     "foo" -> List("bar", "baz"),
     "banana-phone" -> List("ring,ring,ring"),
+    "ghost" -> List("spooky;q=.90,sexy;q=1.0", "scary;q=.95"),
     "cup" -> List("blue,orange;q=0.5"),
     "ornament" -> List("weird penguin;q=0.8", "santa;q=0.9", "droopy tree;q=0.3"),
     "thumbs" -> List("2"),
@@ -509,6 +510,10 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
   describe("the getPreferredHeader method") {
     it("Should return value with largest quality value for ornament") {
       wrappedRequest.getPreferredHeader("ornament") shouldBe "santa"
+    }
+
+    it("should return the value with the highest quality when multiple values are on the same line") {
+      wrappedRequest.getPreferredHeader("ghost") shouldBe "sexy"
     }
 
     it("should return added value if quality is larger than original") {


### PR DESCRIPTION
This PR includes a couple of suggestions I have. Sorry about the formatting mess. If you want to format your branch, I'll rebase off of it to clean this PR up. I believe using IntelliJ's auto-formatting is the right call since it provides consistency.

One of the big changes here is to use Scala TreeMap and TreeSet so that we can provide a case-insensitive ordering. The prevents the need to wrap header names. The idea was first implemented in api-checker, as you can see at: https://github.com/rackerlabs/api-checker/blob/master/core/src/main/scala/com/rackspace/com/papi/components/checker/util/HeaderMap.scala

I also reworked getSplittablePreferredHeader. In my opinion, it's much cleaner now. If you like it, we could do the same for getPreferredHeader.

I also added a test to show that getPreferredHeader does not work when there are multiple values on a single line. EDIT: Realized that this test was redundant with the appendHeader getPreferredHeader test, so I removed it and added a note to that test.