### PR TITLE
Updated the destination hostname and removed the rate-limiting filter from the default system-model.cfg.xml

### DIFF
--- a/repose-aggregator/installation/bash/repose-test_system-model.cfg.patch
+++ b/repose-aggregator/installation/bash/repose-test_system-model.cfg.patch
@@ -1,19 +1,22 @@
---- system-model.cfg.xml	2014-12-18 11:50:10.413692638 -0600
-+++ system-model.cfg.xml	2014-12-18 11:51:37.073695724 -0600
-@@ -14,6 +14,7 @@
-       <filter name="ip-identity"/>
-       <filter name="header-identity"/>
-       -->
-+      <filter name="header-translation" />
-       <filter name="rate-limiting"/>
-     </filters>
-     <services>
+--- system-model.cfg.xml	2015-06-29 13:36:37.331833596 -0500
++++ system-model.cfg.xml	2015-06-29 13:41:55.651822461 -0500
+@@ -13,8 +13,9 @@
+             <!--
+             <filter name="ip-identity"/>
+             <filter name="header-identity"/>
+-            <filter name="rate-limiting"/>
+             -->
++            <filter name="header-translation"/>
++            <filter name="rate-limiting"/>
+         </filters>
+         <services>
+             <!--
 @@ -23,7 +24,7 @@
-     </services>
-     <destinations>
-       <!-- Update this endpoint if you want Repose to send requests to a different service -->
--      <endpoint id="open_repose" protocol="http" hostname="openrepose.org" root-path="/" port="80" default="true"/>
-+      <endpoint id="local_httpbin" protocol="http" hostname="localhost" root-path="/" port="8000" default="true"/>
-     </destinations>
-   </repose-cluster>
+         </services>
+         <destinations>
+             <!-- Update this endpoint if you want Repose to send requests to a different service -->
+-            <endpoint id="rackspace" protocol="http" hostname="rackspace.com" root-path="/" port="80" default="true"/>
++            <endpoint id="local_httpbin" protocol="http" hostname="localhost" root-path="/" port="8000" default="true"/>
+         </destinations>
+     </repose-cluster>
  </system-model>

--- a/repose-aggregator/installation/configs/core/system-model.cfg.xml
+++ b/repose-aggregator/installation/configs/core/system-model.cfg.xml
@@ -13,8 +13,8 @@
             <!--
             <filter name="ip-identity"/>
             <filter name="header-identity"/>
-            -->
             <filter name="rate-limiting"/>
+            -->
         </filters>
         <services>
             <!--
@@ -23,8 +23,7 @@
         </services>
         <destinations>
             <!-- Update this endpoint if you want Repose to send requests to a different service -->
-            <endpoint id="open_repose" protocol="http" hostname="openrepose.org" root-path="/" port="80"
-                      default="true"/>
+            <endpoint id="rackspace" protocol="http" hostname="rackspace.com" root-path="/" port="80" default="true"/>
         </destinations>
     </repose-cluster>
 </system-model>


### PR DESCRIPTION
Since the `openrepose.org` page was moved to GitHub pages over a year ago, the default installation and original test instructions would not work out of the box. The original test instructions, which made sense, assume the `openrepose.org` endpoint will return a redirect to `www.openrepose.org`. When the main page was moved to GitHub pages the redirect was flipped, that is `www.openrepose.org` redirected to `openrepose.org`. This in and of itself is not bad, but it is not behavior that is consistent with industry standards. This part was corrected on the the web page and DNS a couple of weeks ago.

Additionally there are also some games that GitHub pages plays that causes the following for the first several requests from a non-browser call:
```
$ curl -i openrepose.org
HTTP/1.1 302 Found
Pragma: no-cache
cache-control: no-cache
Location: /
Content-Length: 0
```
instead of the expected:
```
$ curl -i openrepose.org
HTTP/1.1 301 Moved Permanently
Server: GitHub.com
Content-Type: text/html
Location: http://www.openrepose.org/
Content-Length: 178
```
So I updated the destination hostname in the default system-model.cfg.xml to `rackspace.com` which does the expected redirect to `www.rackspace.com` all of the time.

I also removed the `rate-limiting` filter from the default system-model.cfg.xml so that tests could be performed with a standard browser. Since this filter requires the `X-PP-User` header, any out of the box test required the use a CLI tool or browser plugin (e.g. Postman) in order to test the default installation.

With these modifications, hitting a properly installed Repose instance with default settings from a browser will take you to `rackspace.com` which will redirect you to `www.rackspace.com`. This is a much simpler test of a default Repose installation. Another option would be to stand up a minimal cloud box at somewhere like `test.openrepose.org` and have it serve a simple **_"Repose is working!!!"_** page that we can track for new installs or provide a simple echo service similar to GUnicorn for testing.

These minor changes do not cause any backward incompatibilities and provides an easier way to document the installation for new users.