### PR TITLE
Test and Fix for Auth/Rate Limiting Bug

### DIFF
--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHeaderManager.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHeaderManager.java
@@ -44,7 +44,6 @@ public class OpenStackAuthenticationHeaderManager {
     private static final String X_AUTH_PROXY = "Proxy";
     // Hard code QUALITY for now as the auth component will have
     // the highest QUALITY in terms of using the user it supplies for rate limiting
-    private static final String QUALITY = ";q=1.0";
     private final String authToken;
     private final AuthToken cachableToken;
     private final Boolean isDelagable;
@@ -210,7 +209,7 @@ public class OpenStackAuthenticationHeaderManager {
      * The OpenStackServiceHeader is used for an OpenStack service
      */
     private void setUser() {
-        filterDirector.requestHeaderManager().appendHeader(PowerApiHeader.USER.toString(), cachableToken.getUsername() + QUALITY);
+        filterDirector.requestHeaderManager().appendHeader(PowerApiHeader.USER.toString(), cachableToken.getUsername());
 
         filterDirector.requestHeaderManager().putHeader(OpenStackServiceHeader.USER_NAME.toString(), cachableToken.getUsername());
         filterDirector.requestHeaderManager().putHeader(OpenStackServiceHeader.USER_ID.toString(), cachableToken.getUserId());
@@ -234,7 +233,7 @@ public class OpenStackAuthenticationHeaderManager {
      */
     private void setGroups() {
         for (AuthGroup group : groups) {
-            filterDirector.requestHeaderManager().appendHeader(PowerApiHeader.GROUPS.toString(), group.getId() + QUALITY);
+            filterDirector.requestHeaderManager().appendHeader(PowerApiHeader.GROUPS.toString(), group.getId());
         }
     }
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/authnandratelimiting/client-auth-n.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/authnandratelimiting/client-auth-n.cfg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/Client+Authentication+Filter -->
+<client-auth xmlns="http://docs.openrepose.org/repose/client-auth/v1.0">
+    <openstack-auth xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0" token-cache-timeout="300000" group-cache-timeout="300000">
+        <identity-service username="USERNAME" password="PASSWORD" uri="http://localhost:${identityPort}/v2.0"/>
+        <client-mapping id-regex="/v[^/]/(\-?\w+)/"/>
+    </openstack-auth>
+</client-auth>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/authnandratelimiting/rate-limiting.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/authnandratelimiting/rate-limiting.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->
+<rate-limiting xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
+    <request-endpoint uri-regex="/v[^/]/\d+/limits" include-absolute-limits="true" />
+
+    <limit-group groups="107" id="unlimited" default="false">
+        <limit id="nine" uri="*" uri-regex="/v[^/]/(\d+)/?.*" http-methods="GET" unit="SECOND" value="1000" />
+    </limit-group>
+
+    <limit-group groups="default" id="NovaDefault" default="true">
+        <limit id="nine" uri="*" uri-regex="/v[^/]/(\d+)/?.*" http-methods="GET" unit="SECOND" value="1" />
+    </limit-group>
+</rate-limiting>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/authnandratelimiting/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/authnandratelimiting/system-model.cfg.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+        <nodes>
+            <node id="node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+        <filters>
+            <filter name="client-auth"/>
+            <filter name="rate-limiting"/>
+        </filters>
+        <destinations>
+            <endpoint id="service" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
+                      default="true"/>
+        </destinations>
+    </repose-cluster>
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/authnandratelimiting/AuthNThenRateLimitingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/authnandratelimiting/AuthNThenRateLimitingTest.groovy
@@ -38,8 +38,7 @@ class AuthNThenRateLimitingTest extends ReposeValveTest {
 
         def params = properties.getDefaultTemplateParams()
         repose.configurationProvider.applyConfigs("common", params)
-        repose.configurationProvider.applyConfigs("features/filters/authnandratelimiting", params)
-        repose.enableSuspend()
+        repose.configurationProvider.applyConfigs("features/filters/authnandratelimiting", params)  
         repose.start()
     }
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/authnandratelimiting/AuthNThenRateLimitingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/authnandratelimiting/AuthNThenRateLimitingTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.authnandratelimiting
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityService
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import spock.lang.Shared
+
+class AuthNThenRateLimitingTest extends ReposeValveTest {
+    @Shared
+    def MockIdentityService fakeIdentityService
+
+    def setupSpec() {
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
+        deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+
+        def params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/authnandratelimiting", params)
+        repose.enableSuspend()
+        repose.start()
+    }
+
+    def setup() {
+        fakeIdentityService.resetHandlers()
+    }
+
+    def "should be rate limited by the specific group matching x-pp-group value, and not the default group"() {
+        given:
+        fakeIdentityService.with {
+            client_tenant = "6107362"
+        }
+
+        when:
+        deproxy.makeRequest(url: reposeEndpoint + "/v2/6107362/limits",
+                headers: ["x-auth-token": fakeIdentityService.client_token])//, "x-pp-user": "coreywright;q=1.0", "x-pp-groups": "107;q=1.0"])
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/v2/6107362/limits",
+                headers: ["x-auth-token": fakeIdentityService.client_token])
+
+        then:
+        mc.getReceivedResponse().getCode() == '200'
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -241,7 +241,7 @@ class MockIdentityService {
                 }
             }
 
-        } else if (nonQueryPath.startsWith("/users/")) {
+        } else if (nonQueryPath.startsWith("/v2.0/users/")) {
 
             if (isGetGroupsCallPath(nonQueryPath)) {
                 if (method == "GET") {
@@ -269,10 +269,10 @@ class MockIdentityService {
         return new Response(501);
     }
 
-    static final String getUserGlobalRolesCallPathRegex = /^\/users\/([^\/]+)\/roles/
-    static final String getGroupsCallPathRegex = /^\/users\/([^\/]+)\/RAX-KSGRP/
-    static final String getEndpointsCallPathRegex = /^\/tokens\/([^\/]+)\/endpoints/
-    static final String validateTokenCallPathRegex = /^\/tokens\/([^\/]+)\/?$/
+    static final String getUserGlobalRolesCallPathRegex = /^\/v2.0\/users\/([^\/]+)\/roles/
+    static final String getGroupsCallPathRegex = /^\/v2.0\/users\/([^\/]+)\/RAX-KSGRP/
+    static final String getEndpointsCallPathRegex = /^\/v2.0\/tokens\/([^\/]+)\/endpoints/
+    static final String validateTokenCallPathRegex = /^\/v2.0\/tokens\/([^\/]+)\/?$/
 
     public static boolean isGetUserGlobalRolesCallPath(String nonQueryPath) {
         return nonQueryPath ==~ getUserGlobalRolesCallPathRegex
@@ -291,11 +291,11 @@ class MockIdentityService {
     }
 
     public static boolean isGenerateTokenCallPath(String nonQueryPath) {
-        return nonQueryPath == "/tokens"
+        return nonQueryPath == "/v2.0/tokens"
     }
 
     public static boolean isTokenCallPath(String nonQueryPath) {
-        return nonQueryPath.startsWith("/tokens")
+        return nonQueryPath.startsWith("/v2.0/tokens")
     }
 
 
@@ -587,7 +587,7 @@ class MockIdentityService {
             """{
   "RAX-KSGRP:groups": [
     {
-        "id": "0",
+        "id": "107",
         "description": "Default Limits",
         "name": "Default"
     }
@@ -599,7 +599,7 @@ class MockIdentityService {
     def groupsXmlTemplate =
             """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <groups xmlns="http://docs.rackspace.com/identity/api/ext/RAX-KSGRP/v1.0">
-    <group id="0" name="Default">
+    <group id="107" name="Default">
         <description>Default Limits</description>
     </group>
 </groups>


### PR DESCRIPTION
This relates to https://repose.atlassian.net/browse/REP-2377

As you can see, the problem is the way the filter director and mutableservletrequest handle quality. Rather than treating quality as part of the header value, it is stored separately. See:
https://github.com/rackerlabs/repose/blob/master/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/http/header/HeaderValueImpl.java#L71

So currently, we use add header to add the "107;q=1.0" value which we've constructed to the "x-pp-groups" header. When the header is actually added, it is given a hard coded quality of 1.0. See:
https://github.com/rackerlabs/repose/blob/master/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/http/header/HeaderValueImpl.java#L44

When we try to get the preferred "x-pp-groups" header, we get "107;q=1.0" rather than simply "107" because the wrapper has made the distinction between value and quality, and treated the value we added as just the value.

~~This is also why manually passing the "x-pp-groups" header works. We don't use the filter director to add the header, it's just parsed from the request that we pass when we wrap it.~~

THIS IS WHY I REALLY, REALLY WANT TO SWITCH TO THE NEW WRAPPERS AND KILL THE OLD WRAPPERS AND FILTER DIRECTOR.

**EDIT**: An accurate explanation of the exact issue is in the PR comments below. Please read those.