### PR TITLE
REP-2388 Handle multiple x-pp-groups values on one line

### DIFF
--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/HeaderInteractor.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/HeaderInteractor.java
@@ -58,7 +58,7 @@ public interface HeaderInteractor {
      * @return the highest quality value(s)
      * @throws QualityFormatException when quantity exists but cannot be parsed
      */
-    List<String> getPreferredHeader(String headerName);
+    List<String> getPreferredHeaders(String headerName);
 
     /**
      * Returns the header value(s) with the highest quality, but will try to split all headers on commas before trying
@@ -69,7 +69,7 @@ public interface HeaderInteractor {
      * @return the value(s) with the highest quality after headers have been split
      * @throws QualityFormatException when quantity is present but cannot be parsed
      */
-    List<String> getPreferredSplittableHeader(String headerName);
+    List<String> getPreferredSplittableHeaders(String headerName);
 
     /**
      * Adds the specified header with the header name and header value pair.

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/HeaderInteractor.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/HeaderInteractor.java
@@ -47,7 +47,7 @@ public interface HeaderInteractor {
      * @param headerName the name of the header to get values for
      * @return a flattened list of values with all of the first header's values appearing before the second, the second before the third, etc.
      */
-    List<String> getSplittableHeader(String headerName);
+    List<String> getSplittableHeaders(String headerName);
 
     /**
      * Returns the header value(s) with the highest quality. The default quality is 1.0 if unspecified.

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/HeaderInteractor.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/HeaderInteractor.java
@@ -50,25 +50,26 @@ public interface HeaderInteractor {
     List<String> getSplittableHeader(String headerName);
 
     /**
-     * Returns the header value with the highest quality. The default quality is 1.0 if unspecified.
+     * Returns the header value(s) with the highest quality. The default quality is 1.0 if unspecified.
      * This treats each header entry as if it's one value, should there be multiple values per header entry
      * exceptions are likely to occur.
      *
      * @param headerName the name of the header to get the preferred value for
-     * @return the highest qualitied value
+     * @return the highest quality value(s)
      * @throws QualityFormatException when quantity exists but cannot be parsed
      */
-    String getPreferredHeader(String headerName);
+    List<String> getPreferredHeader(String headerName);
 
     /**
-     * Returns the header value with the highest quality, but will try to split all headers on commas before trying to evaluate.
+     * Returns the header value(s) with the highest quality, but will try to split all headers on commas before trying
+     * to evaluate.
      * The default quality is 1.0 if unspecified.
      *
      * @param headerName the name of the header to get the preferred value for
-     * @return the value with the highest quality after headers ahve been split
+     * @return the value(s) with the highest quality after headers have been split
      * @throws QualityFormatException when quantity is present but cannot be parsed
      */
-    String getPreferredSplittableHeader(String headerName);
+    List<String> getPreferredSplittableHeader(String headerName);
 
     /**
      * Adds the specified header with the header name and header value pair.

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -68,7 +68,7 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest, inputStream
     if (removedHeaders.contains(headerName)) {
       List[String]()
     } else {
-        headerMap.getOrElse(headerName, super.getHeaders(headerName).asScala.toList)
+      headerMap.getOrElse(headerName, super.getHeaders(headerName).asScala.toList)
     }
   }
 

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -67,9 +67,8 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest, inputStream
   def getHeadersScala(headerName: String): List[String] = {
     if (removedHeaders.contains(headerName)) {
       List[String]()
-    }
-    else {
-      headerMap.getOrElse(headerName, super.getHeaders(headerName).asScala.toList)
+    } else {
+        headerMap.getOrElse(headerName, super.getHeaders(headerName).asScala.toList)
     }
   }
 
@@ -123,7 +122,7 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest, inputStream
     }
 
     getFun(headerName) match {
-      case Nil => null
+      case Nil => Nil
       case nonEmptyList =>
         nonEmptyList.map(headerValue => HeaderValue(parseValue(headerValue), parseQuality(headerValue))) // split the value and parameters, parse the quality
           .groupBy(_.quality) // group by quality

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -144,5 +144,5 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest, inputStream
 
   def getSplittableHeaderScala(headerName: String): List[String] = getHeadersScala(headerName).foldLeft(List.empty[String])((list, s) => list ++ s.split(","))
 
-  override def getSplittableHeader(headerName: String): util.List[String] = getSplittableHeaderScala(headerName).asJava
+  override def getSplittableHeaders(headerName: String): util.List[String] = getSplittableHeaderScala(headerName).asJava
 }

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -131,9 +131,9 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest, inputStream
     }
   }
 
-  override def getPreferredHeader(headerName: String): util.List[String] = getPreferredHeader(headerName, getHeadersScala).asJava
+  override def getPreferredHeaders(headerName: String): util.List[String] = getPreferredHeader(headerName, getHeadersScala).asJava
 
-  override def getPreferredSplittableHeader(headerName: String): util.List[String] = getPreferredHeader(headerName, getSplittableHeaderScala).asJava
+  override def getPreferredSplittableHeaders(headerName: String): util.List[String] = getPreferredHeader(headerName, getSplittableHeaderScala).asJava
 
   override def replaceHeader(headerName: String, headerValue: String): Unit = {
     headerMap = headerMap + (headerName -> List(headerValue))

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -29,12 +29,6 @@ import org.apache.http.client.utils.DateUtils
 import scala.collection.JavaConverters._
 import scala.collection.immutable.{TreeMap, TreeSet}
 
-/**
- * Created with IntelliJ IDEA.
- * User: adrian
- * Date: 5/27/15
- * Time: 10:25 AM
- */
 class HttpServletRequestWrapper(originalRequest: HttpServletRequest, inputStream: ServletInputStream)
   extends javax.servlet.http.HttpServletRequestWrapper(originalRequest)
   with HeaderInteractor {

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -471,54 +471,54 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
     }
   }
 
-  describe("the getPreferredSplittableHeader method") {
+  describe("the getPreferredSplittableHeaders method") {
     it("Should return value with largest quality value") {
-      wrappedRequest.getPreferredSplittableHeader("cup") should contain theSameElementsAs List("blue")
+      wrappedRequest.getPreferredSplittableHeaders("cup") should contain theSameElementsAs List("blue")
     }
 
     it("Should return the first entity if the quantities are the same") {
-      wrappedRequest.getPreferredSplittableHeader("abc") should contain theSameElementsInOrderAs List("1", "2", "3")
+      wrappedRequest.getPreferredSplittableHeaders("abc") should contain theSameElementsInOrderAs List("1", "2", "3")
     }
 
     it("should give the highest quality even with the added value being highest") {
       wrappedRequest.addHeader("ornament", "star", 0.95)
-      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("star")
+      wrappedRequest.getPreferredSplittableHeaders("ornament") should contain theSameElementsInOrderAs List("star")
     }
 
     it("should give the highest quality even with an added value being in the middle") {
       wrappedRequest.addHeader("ornament", "star", 0.85)
-      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("santa")
+      wrappedRequest.getPreferredSplittableHeaders("ornament") should contain theSameElementsInOrderAs List("santa")
     }
 
     it("should give the highest value even if the originals were removed and then a new added") {
       wrappedRequest.removeHeader("cup")
       wrappedRequest.addHeader("cup", "red", 0.1)
-      wrappedRequest.getPreferredSplittableHeader("cup") should contain theSameElementsInOrderAs List("red")
+      wrappedRequest.getPreferredSplittableHeaders("cup") should contain theSameElementsInOrderAs List("red")
     }
 
     it("should give the highest single value wehn a value had been added, all removed, then another added") {
       wrappedRequest.addHeader("cup", "purple", 0.7)
       wrappedRequest.removeHeader("cup")
       wrappedRequest.addHeader("cup", "red", 0.1)
-      wrappedRequest.getPreferredSplittableHeader("cup") should contain theSameElementsInOrderAs List("red")
+      wrappedRequest.getPreferredSplittableHeaders("cup") should contain theSameElementsInOrderAs List("red")
     }
 
     it("should give the highest quality even with an appended value being highest") {
       wrappedRequest.appendHeader("ornament", "star", 0.95)
-      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("star")
+      wrappedRequest.getPreferredSplittableHeaders("ornament") should contain theSameElementsInOrderAs List("star")
     }
 
     it("should give the highest quality even with a replaced value being highest") {
       wrappedRequest.replaceHeader("ornament", "star", 0.95)
-      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("star")
+      wrappedRequest.getPreferredSplittableHeaders("ornament") should contain theSameElementsInOrderAs List("star")
     }
 
     it("should work with headers that are already split") {
-      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("santa")
+      wrappedRequest.getPreferredSplittableHeaders("ornament") should contain theSameElementsInOrderAs List("santa")
     }
 
     it("should give multiple ordered values when multiple values have the same quality") {
-      wrappedRequest.getPreferredSplittableHeader("foo") should contain theSameElementsInOrderAs List("bar", "baz")
+      wrappedRequest.getPreferredSplittableHeaders("foo") should contain theSameElementsInOrderAs List("bar", "baz")
     }
   }
 
@@ -570,38 +570,38 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
     }
   }
 
-  describe("the getPreferredHeader method") {
+  describe("the getPreferredHeaders method") {
     it("Should return value with largest quality value for ornament") {
-      wrappedRequest.getPreferredHeader("ornament") should contain theSameElementsInOrderAs List("santa")
+      wrappedRequest.getPreferredHeaders("ornament") should contain theSameElementsInOrderAs List("santa")
     }
 
     it("should return added value if quality is larger than original") {
       wrappedRequest.addHeader("ornament", "reindeer", 0.95)
-      wrappedRequest.getPreferredHeader("ornament") should contain theSameElementsInOrderAs List("reindeer")
+      wrappedRequest.getPreferredHeaders("ornament") should contain theSameElementsInOrderAs List("reindeer")
     }
 
     it("should not return added value if quality is smaller than original") {
       wrappedRequest.addHeader("ornament", "reindeer", 0.85)
-      wrappedRequest.getPreferredHeader("ornament") should contain theSameElementsInOrderAs List("santa")
+      wrappedRequest.getPreferredHeaders("ornament") should contain theSameElementsInOrderAs List("santa")
     }
 
     it("should throw an exception when quality becomes unreadable in a single line") {
       wrappedRequest.appendHeader("ornament", "star", 0.95)
-      a[QualityFormatException] should be thrownBy wrappedRequest.getPreferredHeader("ornament")
+      a[QualityFormatException] should be thrownBy wrappedRequest.getPreferredHeaders("ornament")
     }
 
     it("should return an added value when it's the only value") {
       wrappedRequest.addHeader("butts", "butts", 0.5)
-      wrappedRequest.getPreferredHeader("butts") should contain theSameElementsInOrderAs List("butts")
+      wrappedRequest.getPreferredHeaders("butts") should contain theSameElementsInOrderAs List("butts")
     }
 
     it("No quality specified should set quality to 1") {
       wrappedRequest.addHeader("ornament", "reindeer")
-      wrappedRequest.getPreferredHeader("ornament") should contain theSameElementsInOrderAs List("reindeer")
+      wrappedRequest.getPreferredHeaders("ornament") should contain theSameElementsInOrderAs List("reindeer")
     }
 
     it("should give multiple ordered values when multiple values have the same quality") {
-      wrappedRequest.getPreferredHeader("foo") should contain theSameElementsInOrderAs List("bar", "baz")
+      wrappedRequest.getPreferredHeaders("foo") should contain theSameElementsInOrderAs List("bar", "baz")
     }
   }
 
@@ -690,7 +690,7 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
 
     it("should throw an exception when quality is garbage") {
       wrappedRequest.addHeader("cup", "butts;q=butts")
-      a[QualityFormatException] should be thrownBy wrappedRequest.getPreferredSplittableHeader("cup")
+      a[QualityFormatException] should be thrownBy wrappedRequest.getPreferredSplittableHeaders("cup")
     }
   }
 }

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -655,37 +655,37 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
     }
   }
 
-  describe("the getSplittableHeader method") {
+  describe("the getSplittableHeaders method") {
     it("Should return the values in a header if splittable as a list") {
-      wrappedRequest.getSplittableHeader("abc").asScala.toList should contain theSameElementsAs List("1", "2", "3")
+      wrappedRequest.getSplittableHeaders("abc").asScala.toList should contain theSameElementsAs List("1", "2", "3")
     }
 
     it("should return a split list when a value is added") {
       wrappedRequest.addHeader("abc", "4")
-      wrappedRequest.getSplittableHeader("abc").asScala.toList should contain theSameElementsInOrderAs List("1", "2", "3", "4")
+      wrappedRequest.getSplittableHeaders("abc").asScala.toList should contain theSameElementsInOrderAs List("1", "2", "3", "4")
     }
 
     it("Should return a splittable list when added") {
       wrappedRequest.appendHeader("abc", "4")
-      wrappedRequest.getSplittableHeader("abc").asScala.toList should contain theSameElementsAs List("1", "2", "3", "4")
+      wrappedRequest.getSplittableHeaders("abc").asScala.toList should contain theSameElementsAs List("1", "2", "3", "4")
     }
 
     it("should split correctly when a replace is done") {
       wrappedRequest.replaceHeader("abc", "5,6,7,8")
-      wrappedRequest.getSplittableHeader("abc").asScala.toList should contain theSameElementsAs List("5", "6", "7", "8")
+      wrappedRequest.getSplittableHeaders("abc").asScala.toList should contain theSameElementsAs List("5", "6", "7", "8")
     }
 
     it("should return list for header that is already split") {
-      wrappedRequest.getSplittableHeader("foo").asScala.toList should contain theSameElementsAs List("bar", "baz")
+      wrappedRequest.getSplittableHeaders("foo").asScala.toList should contain theSameElementsAs List("bar", "baz")
     }
 
     it("should return empty list if header does not exist") {
-      wrappedRequest.getSplittableHeader("notAHeader").asScala.toList shouldBe empty
+      wrappedRequest.getSplittableHeaders("notAHeader").asScala.toList shouldBe empty
     }
 
     it("should return empty list if header is removed") {
       wrappedRequest.removeHeader("abc")
-      wrappedRequest.getSplittableHeader("abc").asScala.toList shouldBe empty
+      wrappedRequest.getSplittableHeaders("abc").asScala.toList shouldBe empty
     }
 
     it("should throw an exception when quality is garbage") {

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -33,12 +33,6 @@ import scala.collection.mutable
 
 import scala.io.Source
 
-/**
- * Created with IntelliJ IDEA.
- * User: adrian
- * Date: 5/27/15
- * Time: 10:39 AM
- */
 @RunWith(classOf[JUnitRunner])
 class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Matchers {
   var wrappedRequest: HttpServletRequestWrapper = _

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -19,7 +19,7 @@
  */
 package org.openrepose.commons.utils.servlet.http
 
-import java.io.{IOException, BufferedReader}
+import java.io.{BufferedReader, IOException}
 import java.util
 import javax.servlet.ServletInputStream
 
@@ -30,7 +30,6 @@ import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-
 import scala.io.Source
 
 @RunWith(classOf[JUnitRunner])
@@ -474,48 +473,52 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
 
   describe("the getPreferredSplittableHeader method") {
     it("Should return value with largest quality value") {
-      wrappedRequest.getPreferredSplittableHeader("cup") shouldBe "blue"
+      wrappedRequest.getPreferredSplittableHeader("cup") should contain theSameElementsAs List("blue")
     }
 
     it("Should return the first entity if the quantities are the same") {
-      wrappedRequest.getPreferredSplittableHeader("abc") shouldBe "1"
+      wrappedRequest.getPreferredSplittableHeader("abc") should contain theSameElementsInOrderAs List("1", "2", "3")
     }
 
     it("should give the highest quality even with the added value being highest") {
       wrappedRequest.addHeader("ornament", "star", 0.95)
-      wrappedRequest.getPreferredSplittableHeader("ornament") shouldBe "star"
+      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("star")
     }
 
-    it("should give the highest quality even with the an added value being in the middle") {
+    it("should give the highest quality even with an added value being in the middle") {
       wrappedRequest.addHeader("ornament", "star", 0.85)
-      wrappedRequest.getPreferredSplittableHeader("ornament") shouldBe "santa"
+      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("santa")
     }
 
-    it("should give the highest value even if the orignals were removed and then a new added") {
+    it("should give the highest value even if the originals were removed and then a new added") {
       wrappedRequest.removeHeader("cup")
       wrappedRequest.addHeader("cup", "red", 0.1)
-      wrappedRequest.getPreferredSplittableHeader("cup") shouldBe "red"
+      wrappedRequest.getPreferredSplittableHeader("cup") should contain theSameElementsInOrderAs List("red")
     }
 
     it("should give the highest single value wehn a value had been added, all removed, then another added") {
       wrappedRequest.addHeader("cup", "purple", 0.7)
       wrappedRequest.removeHeader("cup")
       wrappedRequest.addHeader("cup", "red", 0.1)
-      wrappedRequest.getPreferredSplittableHeader("cup") shouldBe "red"
+      wrappedRequest.getPreferredSplittableHeader("cup") should contain theSameElementsInOrderAs List("red")
     }
 
     it("should give the highest quality even with an appended value being highest") {
       wrappedRequest.appendHeader("ornament", "star", 0.95)
-      wrappedRequest.getPreferredSplittableHeader("ornament") shouldBe "star"
+      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("star")
     }
 
     it("should give the highest quality even with a replaced value being highest") {
       wrappedRequest.replaceHeader("ornament", "star", 0.95)
-      wrappedRequest.getPreferredSplittableHeader("ornament") shouldBe "star"
+      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("star")
     }
 
     it("should work with headers that are already split") {
-      wrappedRequest.getPreferredSplittableHeader("ornament") shouldBe "santa"
+      wrappedRequest.getPreferredSplittableHeader("ornament") should contain theSameElementsInOrderAs List("santa")
+    }
+
+    it("should give multiple ordered values when multiple values have the same quality") {
+      wrappedRequest.getPreferredSplittableHeader("foo") should contain theSameElementsInOrderAs List("bar", "baz")
     }
   }
 
@@ -569,17 +572,17 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
 
   describe("the getPreferredHeader method") {
     it("Should return value with largest quality value for ornament") {
-      wrappedRequest.getPreferredHeader("ornament") shouldBe "santa"
+      wrappedRequest.getPreferredHeader("ornament") should contain theSameElementsInOrderAs List("santa")
     }
 
     it("should return added value if quality is larger than original") {
       wrappedRequest.addHeader("ornament", "reindeer", 0.95)
-      wrappedRequest.getPreferredHeader("ornament") shouldBe "reindeer"
+      wrappedRequest.getPreferredHeader("ornament") should contain theSameElementsInOrderAs List("reindeer")
     }
 
     it("should not return added value if quality is smaller than original") {
       wrappedRequest.addHeader("ornament", "reindeer", 0.85)
-      wrappedRequest.getPreferredHeader("ornament") shouldBe "santa"
+      wrappedRequest.getPreferredHeader("ornament") should contain theSameElementsInOrderAs List("santa")
     }
 
     it("should throw an exception when quality becomes unreadable in a single line") {
@@ -589,16 +592,16 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfter with Mat
 
     it("should return an added value when it's the only value") {
       wrappedRequest.addHeader("butts", "butts", 0.5)
-      wrappedRequest.getPreferredHeader("butts") shouldBe "butts"
+      wrappedRequest.getPreferredHeader("butts") should contain theSameElementsInOrderAs List("butts")
     }
 
     it("No quality specified should set quality to 1") {
       wrappedRequest.addHeader("ornament", "reindeer")
-      wrappedRequest.getPreferredHeader("ornament") shouldBe "reindeer"
+      wrappedRequest.getPreferredHeader("ornament") should contain theSameElementsInOrderAs List("reindeer")
     }
 
-    it("should return the first occurrence of highest quality duplicate values") {
-      wrappedRequest.getPreferredHeader("foo") shouldBe "bar"
+    it("should give multiple ordered values when multiple values have the same quality") {
+      wrappedRequest.getPreferredHeader("foo") should contain theSameElementsInOrderAs List("bar", "baz")
     }
   }
 

--- a/repose-aggregator/components/filters/rate-limiting/src/main/java/org/openrepose/filters/ratelimiting/RateLimitingServiceHelper.java
+++ b/repose-aggregator/components/filters/rate-limiting/src/main/java/org/openrepose/filters/ratelimiting/RateLimitingServiceHelper.java
@@ -82,7 +82,7 @@ public class RateLimitingServiceHelper {
 
     public String getPreferredUser(HttpServletRequest request) {
         final HttpServletRequestWrapper mutableRequest = new HttpServletRequestWrapper(request);
-        final List<String> preferredUsers = mutableRequest.getPreferredSplittableHeader(PowerApiHeader.USER.toString());
+        final List<String> preferredUsers = mutableRequest.getPreferredSplittableHeaders(PowerApiHeader.USER.toString());
 
         String preferredUser = null;
         if (!preferredUsers.isEmpty()) {
@@ -95,7 +95,7 @@ public class RateLimitingServiceHelper {
     public List<String> getPreferredGroups(HttpServletRequest request) {
         final HttpServletRequestWrapper mutableRequest = new HttpServletRequestWrapper(request);
 
-        return mutableRequest.getPreferredSplittableHeader(PowerApiHeader.GROUPS.toString());
+        return mutableRequest.getPreferredSplittableHeaders(PowerApiHeader.GROUPS.toString());
     }
 
     private String decodeURI(String uri) {

--- a/repose-aggregator/components/filters/rate-limiting/src/main/java/org/openrepose/filters/ratelimiting/RateLimitingServiceHelper.java
+++ b/repose-aggregator/components/filters/rate-limiting/src/main/java/org/openrepose/filters/ratelimiting/RateLimitingServiceHelper.java
@@ -95,7 +95,7 @@ public class RateLimitingServiceHelper {
     public List<String> getPreferredGroups(HttpServletRequest request) {
         final HttpServletRequestWrapper mutableRequest = new HttpServletRequestWrapper(request);
 
-        return mutableRequest.getSplittableHeader(PowerApiHeader.GROUPS.toString());
+        return mutableRequest.getPreferredSplittableHeader(PowerApiHeader.GROUPS.toString());
     }
 
     private String decodeURI(String uri) {

--- a/repose-aggregator/components/filters/rate-limiting/src/main/java/org/openrepose/filters/ratelimiting/RateLimitingServiceHelper.java
+++ b/repose-aggregator/components/filters/rate-limiting/src/main/java/org/openrepose/filters/ratelimiting/RateLimitingServiceHelper.java
@@ -21,11 +21,9 @@ package org.openrepose.filters.ratelimiting;
 
 import com.sun.jersey.server.impl.provider.RuntimeDelegateImpl;
 import org.openrepose.commons.utils.http.PowerApiHeader;
-import org.openrepose.commons.utils.http.header.HeaderValue;
-import org.openrepose.commons.utils.http.header.HeaderValueImpl;
 import org.openrepose.commons.utils.http.media.MediaType;
 import org.openrepose.commons.utils.http.media.MimeType;
-import org.openrepose.commons.utils.servlet.http.MutableHttpServletRequest;
+import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper;
 import org.openrepose.core.services.ratelimit.RateLimitingService;
 import org.openrepose.core.services.ratelimit.config.RateLimitList;
 import org.openrepose.core.services.ratelimit.exception.OverLimitException;
@@ -37,7 +35,6 @@ import javax.ws.rs.ext.RuntimeDelegate;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 
 public class RateLimitingServiceHelper {
@@ -84,22 +81,21 @@ public class RateLimitingServiceHelper {
     }
 
     public String getPreferredUser(HttpServletRequest request) {
-        final MutableHttpServletRequest mutableRequest = MutableHttpServletRequest.wrap(request);
-        final HeaderValue userNameHeaderValue = mutableRequest.getPreferredHeader(PowerApiHeader.USER.toString(), new HeaderValueImpl(""));
+        final HttpServletRequestWrapper mutableRequest = new HttpServletRequestWrapper(request);
+        final List<String> preferredUsers = mutableRequest.getPreferredSplittableHeader(PowerApiHeader.USER.toString());
 
-        return userNameHeaderValue.getValue();
+        String preferredUser = null;
+        if (!preferredUsers.isEmpty()) {
+            preferredUser = preferredUsers.get(0);
+        }
+
+        return preferredUser;
     }
 
     public List<String> getPreferredGroups(HttpServletRequest request) {
-        final MutableHttpServletRequest mutableRequest = MutableHttpServletRequest.wrap(request);
-        final List<? extends HeaderValue> userGroup = mutableRequest.getPreferredHeaderValues(PowerApiHeader.GROUPS.toString(), null);
-        final List<String> groups = new ArrayList<String>();
+        final HttpServletRequestWrapper mutableRequest = new HttpServletRequestWrapper(request);
 
-        for (HeaderValue group : userGroup) {
-            groups.add(group.getValue());
-        }
-
-        return groups;
+        return mutableRequest.getSplittableHeader(PowerApiHeader.GROUPS.toString());
     }
 
     private String decodeURI(String uri) {

--- a/repose-aggregator/components/filters/rate-limiting/src/test/groovy/org/openrepose/filters/ratelimiting/RateLimitingServiceHelperTest.groovy
+++ b/repose-aggregator/components/filters/rate-limiting/src/test/groovy/org/openrepose/filters/ratelimiting/RateLimitingServiceHelperTest.groovy
@@ -30,13 +30,11 @@ import spock.lang.Unroll
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs.core.MediaType
 
-import static org.mockito.Matchers.*
 import static org.mockito.Mockito.*
 
 public class RateLimitingServiceHelperTest extends Specification {
     private static final String MOST_QUALIFIED_USER = "the best user of them all"
     private static final String MOST_QUALIFIED_GROUP = "the best group of them all"
-    def splodeDate = new GregorianCalendar(2015, Calendar.SEPTEMBER, 1)
 
     @Shared
     private RateLimitingServiceHelper helper = new RateLimitingServiceHelper(null, null, null)
@@ -45,12 +43,7 @@ public class RateLimitingServiceHelperTest extends Specification {
     private HttpServletRequest mockedRequest
 
     def setupSpec() {
-        List<String> headerNames = new LinkedList<String>()
-        headerNames.add(PowerApiHeader.USER.toString())
-
         mockedRequest = mock(HttpServletRequest.class)
-
-        when(mockedRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames))
     }
 
     def "when getting preferred MediaType, should get Java MediaType from Repose MimeType"() {
@@ -82,10 +75,8 @@ public class RateLimitingServiceHelperTest extends Specification {
 
     def "when getting preferred user, should return first user in list for users without quality factors present"() {
         given:
-        final List<String> headerNames = new LinkedList<String>();
-        headerNames.add(PowerApiHeader.USER.toString());
-
-        when(mockedRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames));
+        when(mockedRequest.getHeaderNames())
+                .thenReturn(Collections.enumeration(Collections.singletonList(PowerApiHeader.USER.toString())))
 
         List<String> headerValues = new LinkedList<String>()
         headerValues.add(MOST_QUALIFIED_USER)
@@ -103,10 +94,8 @@ public class RateLimitingServiceHelperTest extends Specification {
 
     def "when getting preferred group, should return most qualified groups"() {
         given:
-        final List<String> headerNames = new LinkedList<String>()
-        headerNames.add(PowerApiHeader.GROUPS.toString())
-
-        when(mockedRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames))
+        when(mockedRequest.getHeaderNames())
+                .thenReturn(Collections.enumeration(Collections.singletonList(PowerApiHeader.GROUPS.toString())))
 
         List<String> headerValues = new LinkedList<String>()
         headerValues.add("group-4;q=0.1")
@@ -130,10 +119,8 @@ public class RateLimitingServiceHelperTest extends Specification {
 
     def "when getting preferred group, should handle multiple values on a single line"() {
         given:
-        final List<String> headerNames = new LinkedList<String>()
-        headerNames.add(PowerApiHeader.GROUPS.toString())
-
-        when(mockedRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames))
+        when(mockedRequest.getHeaderNames())
+                .thenReturn(Collections.enumeration(Collections.singletonList(PowerApiHeader.GROUPS.toString())))
 
         List<String> headerValues = new LinkedList<String>()
         headerValues.add("group-1;q=0.1,group-2;q=0.1")
@@ -143,10 +130,10 @@ public class RateLimitingServiceHelperTest extends Specification {
         when(mockedRequest.getHeaders(PowerApiHeader.GROUPS.toString())).thenReturn(Collections.enumeration(headerValues))
 
         List<String> expected = new LinkedList<String>()
-        expected.add("group-5")
-        expected.add("group-4")
-        expected.add("group-2")
         expected.add("group-1")
+        expected.add("group-2")
+        expected.add("group-4")
+        expected.add("group-5")
 
         when:
         List<String> groups = helper.getPreferredGroups(mockedRequest)
@@ -156,6 +143,9 @@ public class RateLimitingServiceHelperTest extends Specification {
     }
 
     def "when getting preferred group, should return empty group list when no groups header is present"() {
+        given:
+        when(mockedRequest.getHeaders(PowerApiHeader.GROUPS.toString())).thenReturn(Collections.emptyEnumeration())
+
         when:
         List<String> groups = helper.getPreferredGroups(mockedRequest)
 
@@ -165,10 +155,8 @@ public class RateLimitingServiceHelperTest extends Specification {
 
     def "when getting preferred group, should return all groups when quality factor is not present"() {
         given:
-        final List<String> headerNames = new LinkedList<String>()
-        headerNames.add(PowerApiHeader.GROUPS.toString())
-
-        when(mockedRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames))
+        when(mockedRequest.getHeaderNames())
+                .thenReturn(Collections.enumeration(Collections.singletonList(PowerApiHeader.GROUPS.toString())))
 
         List<String> headerValues = new LinkedList<String>()
         headerValues.add(MOST_QUALIFIED_GROUP)
@@ -198,6 +186,7 @@ public class RateLimitingServiceHelperTest extends Specification {
         given:
         def RateLimitingService mockRlService = mock(RateLimitingService.class)
         def RateLimitingServiceHelper rateLimitingServiceHelper = new RateLimitingServiceHelper(mockRlService, null, null)
+        when(mockedRequest.getHeaders(PowerApiHeader.GROUPS.toString())).thenReturn(Collections.emptyEnumeration())
 
         MockHttpServletRequest request = new MockHttpServletRequest()
         request.setRequestURI(requestURI)

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/common/log4j2-test.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/common/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Logger name="org.openrepose" level="debug"/>
         <Logger name="org.rackspace.deproxy" level="info"/>
         <Logger name="org.springframework" level="warn"/>
-        <Logger name="intrafilter-logging" level="trace"/>
+        <Logger name="intrafilter-logging" level="info"/>
 
         <!-- I need debug info from JMX! -->
         <!-- useful: http://docs.oracle.com/javase/1.5.0/docs/guide/jmx/logging.html -->

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/common/log4j2-test.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/common/log4j2-test.xml
@@ -21,7 +21,7 @@
         <Logger name="org.openrepose" level="debug"/>
         <Logger name="org.rackspace.deproxy" level="info"/>
         <Logger name="org.springframework" level="warn"/>
-        <Logger name="intrafilter-logging" level="info"/>
+        <Logger name="intrafilter-logging" level="trace"/>
 
         <!-- I need debug info from JMX! -->
         <!-- useful: http://docs.oracle.com/javase/1.5.0/docs/guide/jmx/logging.html -->

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/common/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/common/header-translation.cfg.xml
@@ -27,5 +27,5 @@
     <!-- CSL headers -->
     <header original-name="x-pp-user" new-name="x-rax-username"/>
     <header original-name="x-tenant-name" new-name="x-rax-tenants"/>
-    <header original-name="x-roles" new-name="x-rax-roles"/>
+    <header original-name="x-roles" new-name="x-rax-roles" />
 </header-translation>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/header-translation.cfg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<header-translation xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
+    <header original-name="x-roles" new-name="x-pp-groups" remove-original="false"/>
+</header-translation>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/header-translation.cfg.xml
@@ -2,4 +2,5 @@
 
 <header-translation xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
     <header original-name="x-roles" new-name="x-pp-groups" remove-original="false"/>
+    <header original-name="Accept-encoding" new-name="something" remove-original="false"/>
 </header-translation>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/openstack-identity-v3.cfg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0">
+
+    <openstack-identity-service username="admin-username"
+                                password="admin-password"
+                                uri="http://localhost:${identityPort}"
+                                xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"/>
+</openstack-identity-v3>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/openstack-identity-v3.cfg.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0">
+<openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"
+                       cache-offset="0"
+                       token-cache-timeout="0">
 
     <openstack-identity-service username="admin-username"
                                 password="admin-password"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/rate-limiting.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/rate-limiting.cfg.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rate-limiting xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
 
-    <limit-group id="rack-role" groups="service:admin-role1" default="true">
-        <limit id="one" uri="*" uri-regex=".*" http-methods="ALL" unit="MINUTE" value="1"/>
+    <limit-group id="rax-roles" groups="test-admin" default="false">
+        <limit id="one" uri="/servers/*" uri-regex="/servers/(.*)" http-methods="ALL" unit="MINUTE" value="1"/>
     </limit-group>
-
 </rate-limiting>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/rate-limiting.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/rate-limiting.cfg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rate-limiting xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
+
+    <limit-group id="rack-role" groups="service:admin-role1" default="true">
+        <limit id="one" uri="*" uri-regex=".*" http-methods="ALL" unit="MINUTE" value="1"/>
+    </limit-group>
+
+</rate-limiting>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/ratelimitbyroletest/system-model.cfg.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+
+    <repose-cluster id="repose">
+        <nodes>
+            <node id="node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+        <filters>
+            <filter name="openstack-identity-v3"/>
+            <filter name="header-translation"/>
+            <filter name="rate-limiting"/>
+        </filters>
+        <destinations>
+            <endpoint id="service" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
+                      default="true"/>
+        </destinations>
+    </repose-cluster>
+
+
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/RateLimitingByRolesTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/RateLimitingByRolesTest.groovy
@@ -18,11 +18,13 @@
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.filters.ratelimiting
+
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityV3Service
 import org.joda.time.DateTime
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
+
 /**
  * Created by jennyvo on 7/2/15.
  * Test to prove that rate limit on role after using header translation to x-pp-groups

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/RateLimitingByRolesTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/RateLimitingByRolesTest.groovy
@@ -1,0 +1,128 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.ratelimiting
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV3Service
+import org.joda.time.DateTime
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+/**
+ * Created by jennyvo on 7/2/15.
+ * Test to prove that rate limit on role after using header translation to x-pp-groups
+ */
+class RateLimitingByRolesTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static MockIdentityV3Service fakeIdentityV3Service
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/ratelimiting/ratelimitbyroletest", params)
+        repose.start()
+        waitUntilReadyToServiceRequests('401')
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityV3Service = new MockIdentityV3Service(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort,
+                'identity service', null, fakeIdentityV3Service.handler)
+    }
+
+    def cleanupSpec() {
+        deproxy.shutdown()
+        repose.stop()
+    }
+
+    def "Test ratelimit on x-roles with translate header to x-pp-groups"() {
+        given:
+        def reqDomain = fakeIdentityV3Service.client_domainid
+        def reqUserId = fakeIdentityV3Service.client_userid
+
+        fakeIdentityV3Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_domainid = reqDomain
+            client_userid = reqUserId
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/$reqDomain/",
+                method: 'GET',
+                headers: [
+                        'content-type'   : 'application/json',
+                        'X-Subject-Token': fakeIdentityV3Service.client_token,
+                ]
+        )
+
+        then: "Request body sent from repose to the origin service should contain"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        mc.handlings[0].request.headers.contains("x-roles")
+        (mc.handlings[0].request.headers.findAll("x-pp-groups").toString()).contains("service:admin-role1")
+
+        when:
+        mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/$reqDomain/",
+                method: 'GET',
+                headers: [
+                        'content-type'   : 'application/json',
+                        'X-Subject-Token': fakeIdentityV3Service.client_token,
+                ]
+        )
+
+        then: "Request should be ratelimit"
+        mc.receivedResponse.code == "413"
+    }
+
+    def "Test will not ratelimit when set different roles"() {
+        given:
+        def reqDomain = fakeIdentityV3Service.client_domainid
+        def reqUserId = fakeIdentityV3Service.client_userid
+
+        fakeIdentityV3Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_domainid = reqDomain
+            client_userid = reqUserId
+            service_admin_role = "test-admin"
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/$reqDomain/",
+                method: 'GET',
+                headers: [
+                        'content-type'   : 'application/json',
+                        'X-Subject-Token': fakeIdentityV3Service.client_token,
+                ]
+        )
+
+        then: "Request body sent from repose to the origin service should contain"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        mc.handlings[0].request.headers.contains("x-roles")
+        (mc.handlings[0].request.headers.findAll("x-pp-groups").toString()).contains("test-admin")
+
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV3Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV3Service.groovy
@@ -705,18 +705,18 @@ class MockIdentityV3Service {
     {
         "roles": [
             {
-                "id": "--role-id--",
+                "id": "rack-role",
                 "links": {
                     "self": "http://identity:35357/v3/roles/--role-id--"
                 },
-                "name": "--role-name--",
+                "name": "rack-role",
             },
             {
-                "id": "--role-id--",
+                "id": "default",
                 "links": {
                     "self": "http://identity:35357/v3/roles/--role-id--"
                 },
-                "name": "--role-name--"
+                "name": "default-role"
             }
         ],
         "links": {


### PR DESCRIPTION
This fixes the bug in rate limiting where the header values for x-pp-groups were not being parsed -- the entire header line was used.