### PR TITLE
Rep 2357: Generate and add a x-trans-id to feed invalidation requests

### DIFF
--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationFilter.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationFilter.java
@@ -91,7 +91,7 @@ public class ClientAuthenticationFilter implements Filter {
         private boolean initialized = false;
         @Override
         public void configurationUpdated(SystemModel configurationObject) throws UpdateFailedException {
-            handlerFactory.setSystemModel(configurationObject);
+            handlerFactory.setOutboundTracing(configurationObject.isTracingHeader());
             initialized = true;
         }
 

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationFilter.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationFilter.java
@@ -19,12 +19,14 @@
  */
 package org.openrepose.filters.clientauth;
 
+import org.openrepose.commons.config.manager.UpdateFailedException;
 import org.openrepose.core.filter.FilterConfigHelper;
 import org.openrepose.core.filter.logic.impl.FilterLogicHandlerDelegate;
 import org.openrepose.core.services.config.ConfigurationService;
 import org.openrepose.core.services.datastore.DatastoreService;
 import org.openrepose.core.services.httpclient.HttpClientService;
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
+import org.openrepose.core.systemmodel.SystemModel;
 import org.openrepose.filters.clientauth.config.ClientAuthConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,7 @@ public class ClientAuthenticationFilter implements Filter {
     private final AkkaServiceClient akkaServiceClient;
     private String config;
     private ClientAuthenticationHandlerFactory handlerFactory;
+    private SystemModelConfigurationListener systemModelConfigurationListener;
 
     @Inject
     public ClientAuthenticationFilter(DatastoreService datastoreService,
@@ -62,6 +65,7 @@ public class ClientAuthenticationFilter implements Filter {
     public void destroy() {
         handlerFactory.stopFeeds();
         configurationService.unsubscribeFrom(config, handlerFactory);
+        configurationService.unsubscribeFrom("system-model.cfg.xml", systemModelConfigurationListener);
     }
 
     @Override
@@ -76,5 +80,24 @@ public class ClientAuthenticationFilter implements Filter {
         handlerFactory = new ClientAuthenticationHandlerFactory(datastoreService.getDefaultDatastore(), httpClientService, akkaServiceClient);
         URL xsdURL = getClass().getResource("/META-INF/schema/config/client-auth-n-configuration.xsd");
         configurationService.subscribeTo(filterConfig.getFilterName(), config, xsdURL, handlerFactory, ClientAuthConfig.class);
+        URL smXsdURL = getClass().getResource("/META-INF/schema/system-model/system-model.xsd");
+        systemModelConfigurationListener = new SystemModelConfigurationListener();
+        configurationService.subscribeTo("", "system-model.cfg.xml", smXsdURL, systemModelConfigurationListener, SystemModel.class);
+
+    }
+
+    private class SystemModelConfigurationListener implements org.openrepose.commons.config.manager.UpdateListener<SystemModel> {
+
+        private boolean initialized = false;
+        @Override
+        public void configurationUpdated(SystemModel configurationObject) throws UpdateFailedException {
+            handlerFactory.setSystemModel(configurationObject);
+            initialized = true;
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return initialized;
+        }
     }
 }

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationHandlerFactory.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationHandlerFactory.java
@@ -114,6 +114,7 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
     }
 
     public void setOutboundTracing(boolean isOutboundTracing) {
+        manager.setOutboundTracing(isOutboundTracing);
         this.isOutboundTracing = isOutboundTracing;
     }
 

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationHandlerFactory.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationHandlerFactory.java
@@ -29,6 +29,7 @@ import org.openrepose.core.filter.logic.AbstractConfiguredFilterHandlerFactory;
 import org.openrepose.core.services.datastore.Datastore;
 import org.openrepose.core.services.httpclient.HttpClientService;
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
+import org.openrepose.core.systemmodel.SystemModel;
 import org.openrepose.filters.clientauth.atomfeed.AuthFeedReader;
 import org.openrepose.filters.clientauth.atomfeed.FeedListenerManager;
 import org.openrepose.filters.clientauth.atomfeed.sax.SaxAuthFeedReader;
@@ -66,6 +67,7 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
     private UriMatcher uriMatcher;
     private FeedListenerManager manager;
     private AkkaServiceClient akkaServiceClient;
+    private SystemModel systemModel;
 
 
     public ClientAuthenticationHandlerFactory(Datastore datastore, HttpClientService httpClientService, AkkaServiceClient akkaServiceClient) {
@@ -110,6 +112,10 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
             return null;
         }
         return authenticationModule;
+    }
+
+    public void setSystemModel(SystemModel systemModel) {
+        this.systemModel = systemModel;
     }
 
     private class ClientAuthConfigurationListener implements UpdateListener<ClientAuthConfig> {
@@ -168,7 +174,8 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
                         new ServiceClient(modifiedConfig.getOpenstackAuth().getConnectionPoolId(), httpClientService),
                         akkaServiceClient,
                         feed.getUri(),
-                        feed.getId());
+                        feed.getId(),
+                        systemModel);
 
                 //if the atom feed is authed, but no auth uri, user, and pass are configured we will use the same credentials we use for auth admin operations
                 if (feed.isIsAuthed()) {

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationHandlerFactory.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationHandlerFactory.java
@@ -29,7 +29,6 @@ import org.openrepose.core.filter.logic.AbstractConfiguredFilterHandlerFactory;
 import org.openrepose.core.services.datastore.Datastore;
 import org.openrepose.core.services.httpclient.HttpClientService;
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
-import org.openrepose.core.systemmodel.SystemModel;
 import org.openrepose.filters.clientauth.atomfeed.AuthFeedReader;
 import org.openrepose.filters.clientauth.atomfeed.FeedListenerManager;
 import org.openrepose.filters.clientauth.atomfeed.sax.SaxAuthFeedReader;
@@ -67,7 +66,7 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
     private UriMatcher uriMatcher;
     private FeedListenerManager manager;
     private AkkaServiceClient akkaServiceClient;
-    private SystemModel systemModel;
+    private boolean isOutboundTracing;
 
 
     public ClientAuthenticationHandlerFactory(Datastore datastore, HttpClientService httpClientService, AkkaServiceClient akkaServiceClient) {
@@ -114,8 +113,8 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
         return authenticationModule;
     }
 
-    public void setSystemModel(SystemModel systemModel) {
-        this.systemModel = systemModel;
+    public void setOutboundTracing(boolean isOutboundTracing) {
+        this.isOutboundTracing = isOutboundTracing;
     }
 
     private class ClientAuthConfigurationListener implements UpdateListener<ClientAuthConfig> {
@@ -175,7 +174,7 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
                         akkaServiceClient,
                         feed.getUri(),
                         feed.getId(),
-                        systemModel);
+                        isOutboundTracing);
 
                 //if the atom feed is authed, but no auth uri, user, and pass are configured we will use the same credentials we use for auth admin operations
                 if (feed.isIsAuthed()) {

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/AuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/AuthFeedReader.java
@@ -21,5 +21,5 @@ package org.openrepose.filters.clientauth.atomfeed;
 
 public interface AuthFeedReader {
 
-    CacheKeys getCacheKeys() throws FeedException;
+    CacheKeys getCacheKeys(String traceID) throws FeedException;
 }

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/AuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/AuthFeedReader.java
@@ -22,4 +22,5 @@ package org.openrepose.filters.clientauth.atomfeed;
 public interface AuthFeedReader {
 
     CacheKeys getCacheKeys(String traceID) throws FeedException;
+    void setOutboundTracing(boolean isOutboundTracing);
 }

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -20,6 +20,7 @@
 package org.openrepose.filters.clientauth.atomfeed;
 
 import org.openrepose.commons.utils.http.CommonHttpHeader;
+import org.openrepose.core.logging.TracingKey;
 import org.openrepose.core.services.datastore.Datastore;
 import org.openrepose.filters.clientauth.common.AuthGroupCache;
 import org.openrepose.filters.clientauth.common.AuthTokenCache;
@@ -82,10 +83,11 @@ public class FeedCacheInvalidator implements Runnable {
     public void run() {
 
         // Generate trans-id here so it is the same between multiple pages
-        String traceID = UUID.randomUUID().toString();
         while (!done) {
+            String traceID = UUID.randomUUID().toString();
 
-            MDC.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
+            MDC.put(TracingKey.TRACING_KEY, traceID);
+
             LOG.debug("Beginning Feed Cache Invalidator Thread request.");
 
             List<String> userKeys = new ArrayList<>();

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -40,7 +40,7 @@ public class FeedCacheInvalidator implements Runnable {
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(FeedCacheInvalidator.class);
     private static final long DEFAULT_CHECK_INTERVAL = 5000;
     private boolean done = false;
-    private List<AuthFeedReader> feeds = new ArrayList<AuthFeedReader>();
+    private List<AuthFeedReader> feeds = new ArrayList<>();
     private AuthTokenCache tknCache;
     private AuthGroupCache grpCache;
     private AuthUserCache usrCache;

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -121,7 +121,7 @@ public class FeedCacheInvalidator implements Runnable {
      */
     private List<String> getTokensForUser(List<String> keys) {
 
-        List<String> tokenKeys = new ArrayList<String>();
+        List<String> tokenKeys = new ArrayList<>();
         for (String key : keys) {
             Set<String> tkns = usrCache.getUserTokenList(key);
             if (tkns != null) {

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -85,7 +85,7 @@ public class FeedCacheInvalidator implements Runnable {
             // Iterate through atom feeds to retrieve tokens and users to invalidate from Repose cache
             for (AuthFeedReader rdr : feeds) {
                 try {
-                    CacheKeys keys = rdr.getCacheKeys();
+                    CacheKeys keys = rdr.getCacheKeys(traceID);
                     userKeys.addAll(keys.getUserKeys());
                     tokenKeys.addAll(keys.getTokenKeys());
                 } catch (FeedException e) {

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /*
  * Listener class to iterate through AuthFeedReaders and retrieve items to delete from the cache
@@ -77,10 +78,15 @@ public class FeedCacheInvalidator implements Runnable {
 
     @Override
     public void run() {
+
+        // Generate trans-id here so it is the same between multiple pages
+        String traceID = UUID.randomUUID().toString();
         while (!done) {
 
-            List<String> userKeys = new ArrayList<String>();
-            List<String> tokenKeys = new ArrayList<String>();
+            LOG.debug("Feed invalidation request for trans-id: " + traceID);
+
+            List<String> userKeys = new ArrayList<>();
+            List<String> tokenKeys = new ArrayList<>();
 
             // Iterate through atom feeds to retrieve tokens and users to invalidate from Repose cache
             for (AuthFeedReader rdr : feeds) {

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -81,7 +81,7 @@ public class FeedCacheInvalidator implements Runnable {
 
     @Override
     public void run() {
-        
+
         while (!done) {
             // Generate trans-id here so it is the same between multiple pages
             String traceID = UUID.randomUUID().toString();

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -127,7 +127,7 @@ public class FeedCacheInvalidator implements Runnable {
             if (tkns != null) {
                 tokenKeys.addAll(tkns);
                 //removes user item from cache
-                usrCache.deleteCacheItem(key); //removes user item from cache
+                usrCache.deleteCacheItem(key);
                 LOG.debug("Invalidating tokens from user " + key);
             }
         }

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -75,7 +75,12 @@ public class FeedCacheInvalidator implements Runnable {
 
     public void setFeeds(List<AuthFeedReader> feeds) {
         this.feeds = feeds;
+    }
 
+    public void setOutboundTracing(boolean isOutboundTracing) {
+        for (AuthFeedReader afr : feeds) {
+            afr.setOutboundTracing(isOutboundTracing);
+        }
     }
 
     @Override

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -19,6 +19,7 @@
  */
 package org.openrepose.filters.clientauth.atomfeed;
 
+import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.core.services.datastore.Datastore;
 import org.openrepose.filters.clientauth.common.AuthGroupCache;
 import org.openrepose.filters.clientauth.common.AuthTokenCache;
@@ -26,6 +27,7 @@ import org.openrepose.filters.clientauth.common.AuthUserCache;
 import org.openrepose.filters.clientauth.common.EndpointsCache;
 import org.openrepose.filters.clientauth.openstack.OsAuthCachePrefix;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -83,7 +85,8 @@ public class FeedCacheInvalidator implements Runnable {
         String traceID = UUID.randomUUID().toString();
         while (!done) {
 
-            LOG.debug("Feed invalidation request for trans-id: " + traceID);
+            MDC.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
+            LOG.debug("Beginning Feed Cache Invalidator Thread request.");
 
             List<String> userKeys = new ArrayList<>();
             List<String> tokenKeys = new ArrayList<>();

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -19,7 +19,6 @@
  */
 package org.openrepose.filters.clientauth.atomfeed;
 
-import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.core.logging.TracingKey;
 import org.openrepose.core.services.datastore.Datastore;
 import org.openrepose.filters.clientauth.common.AuthGroupCache;

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -81,9 +81,9 @@ public class FeedCacheInvalidator implements Runnable {
 
     @Override
     public void run() {
-
-        // Generate trans-id here so it is the same between multiple pages
+        
         while (!done) {
+            // Generate trans-id here so it is the same between multiple pages
             String traceID = UUID.randomUUID().toString();
 
             MDC.put(TracingKey.TRACING_KEY, traceID);

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -83,7 +83,7 @@ public class FeedCacheInvalidator implements Runnable {
 
         // Generate trans-id here so it is the same between multiple pages
         String traceID = UUID.randomUUID().toString();
-        while (!isDone()) {
+        while (!done) {
 
             MDC.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
             LOG.debug("Beginning Feed Cache Invalidator Thread request.");
@@ -153,6 +153,4 @@ public class FeedCacheInvalidator implements Runnable {
     public void done() {
         done = true;
     }
-
-    public boolean isDone() { return done; }
 }

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -83,7 +83,7 @@ public class FeedCacheInvalidator implements Runnable {
 
         // Generate trans-id here so it is the same between multiple pages
         String traceID = UUID.randomUUID().toString();
-        while (!done) {
+        while (!isDone()) {
 
             MDC.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
             LOG.debug("Beginning Feed Cache Invalidator Thread request.");
@@ -153,4 +153,6 @@ public class FeedCacheInvalidator implements Runnable {
     public void done() {
         done = true;
     }
+
+    public boolean isDone() { return done; }
 }

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedListenerManager.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedListenerManager.java
@@ -62,5 +62,7 @@ public class FeedListenerManager {
         }
     }
 
-
+    public void setOutboundTracing(boolean isOutboundTracing) {
+        listener.setOutboundTracing(isOutboundTracing);
+    }
 }

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
@@ -65,13 +65,13 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
     private AkkaServiceClient akkaServiceClient;
     private boolean isOutboundTracing = false;
 
-    public SaxAuthFeedReader(ServiceClient client, AkkaServiceClient akkaClient, String feedHead, String feedId, boolean systemModel) {
+    public SaxAuthFeedReader(ServiceClient client, AkkaServiceClient akkaClient, String feedHead, String feedId, boolean isOutboundTracing) {
         this.client = client;
         this.feedHead = feedHead;
         this.targetFeed = feedHead;
         this.feedId = feedId;
         this.akkaServiceClient = akkaClient;
-        this.isOutboundTracing = systemModel;
+        this.isOutboundTracing = isOutboundTracing;
         factory = SAXParserFactory.newInstance();
         factory.setNamespaceAware(true);
     }

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
@@ -63,7 +63,7 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
     private AdminTokenProvider provider;
 
     private AkkaServiceClient akkaServiceClient;
-    private boolean systemModel = false;
+    private boolean isOutboundTracing = false;
 
     public SaxAuthFeedReader(ServiceClient client, AkkaServiceClient akkaClient, String feedHead, String feedId, boolean systemModel) {
         this.client = client;
@@ -71,9 +71,13 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
         this.targetFeed = feedHead;
         this.feedId = feedId;
         this.akkaServiceClient = akkaClient;
-        this.systemModel = systemModel;
+        this.isOutboundTracing = systemModel;
         factory = SAXParserFactory.newInstance();
         factory.setNamespaceAware(true);
+    }
+
+    public void setOutboundTracing(boolean isOutboundTracing) {
+        this.isOutboundTracing = isOutboundTracing;
     }
 
     public void setAuthed(String uri, String user, String pass) throws AuthServiceException {
@@ -116,7 +120,7 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
         ServiceClientResponse resp;
         final Map<String, String> headers = new HashMap<>();
 
-        if (systemModel) {
+        if (isOutboundTracing) {
             headers.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
         }
 
@@ -135,7 +139,7 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
                     } catch (AuthServiceException e) {
                         throw new FeedException("Failed to obtain credentials.", e);
                     }
-                    if (systemModel) {
+                    if (isOutboundTracing) {
                         headers.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
                     }
                     headers.put(CommonHttpHeader.AUTH_TOKEN.toString(), adminToken);

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
@@ -130,6 +130,7 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
                     } catch (AuthServiceException e) {
                         throw new FeedException("Failed to obtain credentials.", e);
                     }
+                    headers.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
                     headers.put(CommonHttpHeader.AUTH_TOKEN.toString(), adminToken);
                     resp = client.get(targetFeed, headers);
                 } else { // case where we're getting back 401s and the client has not configured auth credentials for this feed.

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
@@ -84,14 +84,14 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
     }
 
     @Override
-    public CacheKeys getCacheKeys() throws FeedException {
+    public CacheKeys getCacheKeys(String traceID) throws FeedException {
 
         moreData = true;
         ServiceClientResponse resp;
         resultKeys = new FeedCacheKeys();
         while (moreData) {
 
-            resp = getFeed();
+            resp = getFeed(traceID);
 
             if (resp.getStatus() == HttpServletResponse.SC_OK) {
 
@@ -112,7 +112,7 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
         return resultKeys;
     }
 
-    private ServiceClientResponse getFeed() throws FeedException {
+    private ServiceClientResponse getFeed(String traceID) throws FeedException {
 
         ServiceClientResponse resp;
         final Map<String, String> headers = new HashMap<String, String>();

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
@@ -113,12 +113,12 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
         ServiceClientResponse resp;
         final Map<String, String> headers = new HashMap<>();
 
+        /* TODO: check if necessary to add trans id header */
         headers.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
         if (isAuthed) {
             headers.put(CommonHttpHeader.AUTH_TOKEN.toString(), adminToken);
         }
         resp = client.get(targetFeed, headers);
-
 
         switch (resp.getStatus()) {
             case HttpServletResponse.SC_OK:
@@ -130,6 +130,7 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
                     } catch (AuthServiceException e) {
                         throw new FeedException("Failed to obtain credentials.", e);
                     }
+                    /* TODO: check if necessary to add trans id header */
                     headers.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
                     headers.put(CommonHttpHeader.AUTH_TOKEN.toString(), adminToken);
                     resp = client.get(targetFeed, headers);

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
@@ -46,7 +46,6 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SaxAuthFeedReader.class);
     private final String feedId;
     private final String feedHead;
-    List<String> cacheKeys = new ArrayList<String>();
     private String targetFeed;
     private String curResource;
     private ServiceClient client;

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
@@ -36,10 +36,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /*
  * Simple Atom Feed reader using Jersey + Sax Parser specifically for RS Identity Feed
@@ -115,8 +112,9 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
     private ServiceClientResponse getFeed(String traceID) throws FeedException {
 
         ServiceClientResponse resp;
-        final Map<String, String> headers = new HashMap<String, String>();
+        final Map<String, String> headers = new HashMap<>();
 
+        headers.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
         if (isAuthed) {
             headers.put(CommonHttpHeader.AUTH_TOKEN.toString(), adminToken);
         }

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/AuthFeedListenerTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/AuthFeedListenerTest.java
@@ -42,6 +42,7 @@ import java.util.*;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -142,7 +143,7 @@ public class AuthFeedListenerTest {
         keys.addTokenKey("token1");
         keys.addUserKey("224277258");
 
-        when(rdr.getCacheKeys()).thenReturn(keys);
+        when(rdr.getCacheKeys(anyString())).thenReturn(keys);
 
     }
 

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
@@ -71,16 +71,19 @@ public class FeedCacheInvalidatorTest {
     }
 
     @Test
-    public void shouldIncludeTraceInLog() {
+    public void shouldIncludeTraceInLog() throws Exception {
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
 
-        FeedCacheInvalidator fci = FeedCacheInvalidator.openStackInstance(datastore);
-        //fci.run();
+        FeedCacheInvalidator fci = FeedCacheInvalidator.openStackInstance(datastore, 1000);
+        Thread t = new Thread(fci);
+        t.start();
+        Thread.sleep(2000);
         fci.done();
 
         assertThat(app.getEvents(), contains("Beginning Feed Cache Invalidator Thread request."));
+        assertThat(app.getEvents(), contains("GUID:"));
     }
 
     private Matcher<List<LogEvent>> contains(final String msg) {

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
@@ -1,0 +1,7 @@
+package org.openrepose.filters.clientauth.atomfeed;
+
+/**
+ * Created by mega8795 on 7/17/15.
+ */
+public class FeedCacheInvalidatorTest {
+}

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
@@ -1,7 +1,47 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
 package org.openrepose.filters.clientauth.atomfeed;
 
-/**
- * Created by mega8795 on 7/17/15.
- */
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import static org.mockito.Mockito.*;
+
 public class FeedCacheInvalidatorTest {
+    FeedCacheInvalidator fci;
+
+    @Before
+    public void setUp() {
+        /*
+        * TODO: figure out how to mock singleton
+        * fci.run() not invoked, but need to mock fci for checking if while loop is done
+        */
+        fci = mock(FeedCacheInvalidator.class);
+    }
+
+    @Test
+    public void shouldSaveTraceIDInMDC() {
+        when(fci.isDone()).thenReturn(false).thenReturn(true);
+        fci.run();
+        assert (MDC.get("X-Trans-Id") != null);
+        verify(fci, times(2)).isDone();
+    }
 }

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
@@ -19,29 +19,87 @@
  */
 package org.openrepose.filters.clientauth.atomfeed;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.MDC;
+import org.openrepose.commons.utils.http.ServiceClient;
+import org.openrepose.commons.utils.http.ServiceClientResponse;
+import org.openrepose.core.services.datastore.Datastore;
+import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
+import org.openrepose.filters.clientauth.atomfeed.sax.SaxAuthFeedReader;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class FeedCacheInvalidatorTest {
-    FeedCacheInvalidator fci;
+    private ServiceClient client;
+    private AkkaServiceClient akkaClient;
+    private ServiceClientResponse resp1, resp2, resp3;
+    private SaxAuthFeedReader reader;
+    private Datastore datastore;
+
+    private ListAppender app;
 
     @Before
-    public void setUp() {
-        /*
-        * TODO: figure out how to mock singleton
-        * fci.run() not invoked, but need to mock fci for checking if while loop is done
-        */
-        fci = mock(FeedCacheInvalidator.class);
+    public void setUp() throws FileNotFoundException {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        app = ((ListAppender) (ctx.getConfiguration().getAppender("List0"))).clear();
+
+        client = mock(ServiceClient.class);
+        akkaClient = mock(AkkaServiceClient.class);
+        datastore = mock(Datastore.class);
+
+        InputStream fileReader1 = getClass().getResourceAsStream(File.separator + "META-INF" + File.separator + "feed.xml");
+        InputStream fileReader2 = getClass().getResourceAsStream(File.separator + "META-INF" + File.separator + "empty-feed.xml");
+        resp1 = new ServiceClientResponse(200, fileReader1);
+
+        resp2 = new ServiceClientResponse(200, fileReader2);
+        when(client.getPoolSize()).thenReturn(100);
+
     }
 
     @Test
-    public void shouldSaveTraceIDInMDC() {
-        when(fci.isDone()).thenReturn(false).thenReturn(true);
-        fci.run();
-        assert (MDC.get("X-Trans-Id") != null);
-        verify(fci, times(2)).isDone();
+    public void shouldIncludeTraceInLog() {
+        when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
+        when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
+                anyMap())).thenReturn(resp2);
+
+        FeedCacheInvalidator fci = FeedCacheInvalidator.openStackInstance(datastore);
+        //fci.run();
+        fci.done();
+
+        assertThat(app.getEvents(), contains("Beginning Feed Cache Invalidator Thread request."));
+    }
+
+    private Matcher<List<LogEvent>> contains(final String msg) {
+        return new TypeSafeMatcher<List<LogEvent>>() {
+            @Override
+            protected boolean matchesSafely(final List<LogEvent> events) {
+                boolean rtn = false;
+                LogEvent event;
+                for (Iterator<LogEvent> iterator = events.iterator(); !rtn && iterator.hasNext(); ) {
+                    event = iterator.next();
+                    rtn = event.getMessage().getFormattedMessage().contains(msg);
+                }
+                return rtn;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("The List of Log Events contained a Formatted Message of: \"" + msg + "\"");
+            }
+        };
     }
 }

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
@@ -28,20 +28,13 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrepose.commons.utils.http.ServiceClient;
-import org.openrepose.commons.utils.http.ServiceClientResponse;
 import org.openrepose.core.services.datastore.Datastore;
-import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
-import org.openrepose.filters.clientauth.atomfeed.sax.SaxAuthFeedReader;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class FeedCacheInvalidatorTest {
     private Datastore datastore;
@@ -49,7 +42,7 @@ public class FeedCacheInvalidatorTest {
     private ListAppender app;
 
     @Before
-    public void setUp() throws FileNotFoundException {
+    public void setUp() {
         LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
         app = ((ListAppender) (ctx.getConfiguration().getAppender("List0"))).clear();
         datastore = mock(Datastore.class);

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidatorTest.java
@@ -44,10 +44,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class FeedCacheInvalidatorTest {
-    private ServiceClient client;
-    private AkkaServiceClient akkaClient;
-    private ServiceClientResponse resp1, resp2, resp3;
-    private SaxAuthFeedReader reader;
     private Datastore datastore;
 
     private ListAppender app;
@@ -56,26 +52,11 @@ public class FeedCacheInvalidatorTest {
     public void setUp() throws FileNotFoundException {
         LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
         app = ((ListAppender) (ctx.getConfiguration().getAppender("List0"))).clear();
-
-        client = mock(ServiceClient.class);
-        akkaClient = mock(AkkaServiceClient.class);
         datastore = mock(Datastore.class);
-
-        InputStream fileReader1 = getClass().getResourceAsStream(File.separator + "META-INF" + File.separator + "feed.xml");
-        InputStream fileReader2 = getClass().getResourceAsStream(File.separator + "META-INF" + File.separator + "empty-feed.xml");
-        resp1 = new ServiceClientResponse(200, fileReader1);
-
-        resp2 = new ServiceClientResponse(200, fileReader2);
-        when(client.getPoolSize()).thenReturn(100);
-
     }
 
     @Test
     public void shouldIncludeTraceInLog() throws Exception {
-        when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
-        when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
-                anyMap())).thenReturn(resp2);
-
         FeedCacheInvalidator fci = FeedCacheInvalidator.openStackInstance(datastore, 1000);
         Thread t = new Thread(fci);
         t.start();
@@ -83,7 +64,6 @@ public class FeedCacheInvalidatorTest {
         fci.done();
 
         assertThat(app.getEvents(), contains("Beginning Feed Cache Invalidator Thread request."));
-        assertThat(app.getEvents(), contains("GUID:"));
     }
 
     private Matcher<List<LogEvent>> contains(final String msg) {

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedListenerManagerTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/FeedListenerManagerTest.java
@@ -42,6 +42,7 @@ import java.util.*;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -141,7 +142,7 @@ public class FeedListenerManagerTest {
         keys.addTokenKey("token1");
         keys.addUserKey("user1");
 
-        when(rdr.getCacheKeys()).thenReturn(keys);
+        when(rdr.getCacheKeys(anyString())).thenReturn(keys);
 
     }
 

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
@@ -73,7 +73,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", null);
+        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", false);
         CacheKeys keys = reader.getCacheKeys("key");
 
         String[] users = {"224277258", //User from atom feed
@@ -89,7 +89,7 @@ public class SaxAuthFeedReaderTest {
 
         resp3 = new ServiceClientResponse(401, null);
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp3);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", null);
+        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", false);
         CacheKeys keys = reader.getCacheKeys("key");
 
         assertThat("Should log 401 with atom feed configured without auth",
@@ -101,7 +101,7 @@ public class SaxAuthFeedReaderTest {
 
         resp3 = new ServiceClientResponse(503, null);
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp3);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", null);
+        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", false);
 
         CacheKeys keys = reader.getCacheKeys("key");
 
@@ -114,7 +114,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", null);
+        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", false);
         CacheKeys keys = reader.getCacheKeys("key");
 
         String[] users = {"224277258", //User from atom feed

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
@@ -73,7 +73,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId");
+        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", null);
         CacheKeys keys = reader.getCacheKeys("key");
 
         String[] users = {"224277258", //User from atom feed
@@ -89,7 +89,7 @@ public class SaxAuthFeedReaderTest {
 
         resp3 = new ServiceClientResponse(401, null);
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp3);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId");
+        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", null);
         CacheKeys keys = reader.getCacheKeys("key");
 
         assertThat("Should log 401 with atom feed configured without auth",
@@ -101,7 +101,7 @@ public class SaxAuthFeedReaderTest {
 
         resp3 = new ServiceClientResponse(503, null);
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp3);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId");
+        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", null);
 
         CacheKeys keys = reader.getCacheKeys("key");
 
@@ -114,7 +114,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId");
+        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", null);
         CacheKeys keys = reader.getCacheKeys("key");
 
         String[] users = {"224277258", //User from atom feed

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
@@ -78,7 +78,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
         reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId");
-        CacheKeys keys = reader.getCacheKeys();
+        CacheKeys keys = reader.getCacheKeys("key");
 
         String[] users = {"224277258", //User from atom feed
                 "4a2b42f4-6c63-11e1-815b-7fcbcf67f549"}; //TRR User from feed
@@ -94,7 +94,7 @@ public class SaxAuthFeedReaderTest {
         resp3 = new ServiceClientResponse(401, null);
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp3);
         reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId");
-        CacheKeys keys = reader.getCacheKeys();
+        CacheKeys keys = reader.getCacheKeys("key");
 
         assertThat("Should log 401 with atom feed configured without auth",
                 app.getEvents(), contains("Feed at http://some.junit.test.feed/at/somepath requires Authentication. Please reconfigure Feed atomId with valid credentials and/or configure isAuthed to true"));
@@ -107,7 +107,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp3);
         reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId");
 
-        CacheKeys keys = reader.getCacheKeys();
+        CacheKeys keys = reader.getCacheKeys("key");
 
         assertThat(app.getEvents(), contains("Unable to retrieve atom feed from FeedatomId: http://some.junit.test.feed/at/somepath\n Response Code: 503"));
     }
@@ -119,7 +119,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
         reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId");
-        CacheKeys keys = reader.getCacheKeys();
+        CacheKeys keys = reader.getCacheKeys("key");
 
         String[] users = {"224277258", //User from atom feed
                 "4a2b42f4-6c63-11e1-815b-7fcbcf67f549"}; //TRR User from feed
@@ -131,7 +131,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp3);
 
-        reader.getCacheKeys();
+        reader.getCacheKeys("key");
 
         assertThat(app.getEvents(), contains("Feed atomId not found at: https://test.feed.atomhopper.rackspace.com/some/" +
                 "identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward" +

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
@@ -20,12 +20,8 @@
 package org.openrepose.filters.clientauth.atomfeed.sax;
 
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.test.appender.ListAppender;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.openrepose.commons.utils.http.ServiceClient;
@@ -36,9 +32,9 @@ import org.openrepose.filters.clientauth.atomfeed.CacheKeys;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.util.Iterator;
-import java.util.List;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.Matchers.anyMap;
@@ -97,7 +93,7 @@ public class SaxAuthFeedReaderTest {
         CacheKeys keys = reader.getCacheKeys("key");
 
         assertThat("Should log 401 with atom feed configured without auth",
-                app.getEvents(), contains("Feed at http://some.junit.test.feed/at/somepath requires Authentication. Please reconfigure Feed atomId with valid credentials and/or configure isAuthed to true"));
+                app.getMessages(), hasItem(containsString("Feed at http://some.junit.test.feed/at/somepath requires Authentication. Please reconfigure Feed atomId with valid credentials and/or configure isAuthed to true")));
     }
 
     @Test
@@ -109,7 +105,7 @@ public class SaxAuthFeedReaderTest {
 
         CacheKeys keys = reader.getCacheKeys("key");
 
-        assertThat(app.getEvents(), contains("Unable to retrieve atom feed from FeedatomId: http://some.junit.test.feed/at/somepath\n Response Code: 503"));
+        assertThat(app.getMessages(), hasItem(containsString("Unable to retrieve atom feed from FeedatomId: http://some.junit.test.feed/at/somepath\n Response Code: 503")));
     }
 
     @Test
@@ -133,28 +129,8 @@ public class SaxAuthFeedReaderTest {
 
         reader.getCacheKeys("key");
 
-        assertThat(app.getEvents(), contains("Feed atomId not found at: https://test.feed.atomhopper.rackspace.com/some/" +
+        assertThat(app.getMessages(), hasItem(containsString("Feed atomId not found at: https://test.feed.atomhopper.rackspace.com/some/" +
                 "identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward" +
-                "\nResetting feed target to: http://some.junit.test.feed/at/somepath"));
-    }
-
-    private Matcher<List<LogEvent>> contains(final String msg) {
-        return new TypeSafeMatcher<List<LogEvent>>() {
-            @Override
-            protected boolean matchesSafely(final List<LogEvent> events) {
-                boolean rtn = false;
-                LogEvent event;
-                for (Iterator<LogEvent> iterator = events.iterator(); !rtn && iterator.hasNext(); ) {
-                    event = iterator.next();
-                    rtn = event.getMessage().getFormattedMessage().contains(msg);
-                }
-                return rtn;
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("The List of Log Events contained a Formatted Message of: \"" + msg + "\"");
-            }
-        };
+                "\nResetting feed target to: http://some.junit.test.feed/at/somepath")));
     }
 }

--- a/repose-aggregator/components/filters/client-auth/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/components/filters/client-auth/src/test/resources/log4j2-test.xml
@@ -4,7 +4,9 @@
         <Console name="STDOUT">
             <PatternLayout pattern="GUID:%X{traceGuid} - %d %-4r [%t] %-5p %c - %m%n"/>
         </Console>
-        <List name="List0"/>
+        <List name="List0">
+            <PatternLayout pattern="GUID:%X{traceGuid} - %m%n"/>
+        </List>
     </Appenders>
     <Loggers>
         <Root level="debug">

--- a/repose-aggregator/components/filters/client-auth/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/components/filters/client-auth/src/test/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration>
     <Appenders>
         <Console name="STDOUT">
-            <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>
+            <PatternLayout pattern="GUID:%X{traceGuid} - %d %-4r [%t] %-5p %c - %m%n"/>
         </Console>
         <List name="List0"/>
     </Appenders>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
@@ -25,6 +25,7 @@ import framework.mocks.MockIdentityService
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.Response
+import org.slf4j.MDC
 
 /**
  B-48277
@@ -227,6 +228,8 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
         fakeIdentityService.validateTokenCount == 0
         fakeIdentityService.getGroupsCount == 0
         mc.handlings[0].endpoint == originEndpoint
+
+        MDC.get("X-Trans-Id") != null
 
 
         when: "Identity atom feed has a Update User Event"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
@@ -228,9 +228,9 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
         fakeIdentityService.validateTokenCount == 0
         fakeIdentityService.getGroupsCount == 0
         mc.handlings[0].endpoint == originEndpoint
+        /* TODO: another x-trans-id is added as a header, not the one for invalidation */
         mc.receivedResponse.headers.contains("x-trans-id")
-        MDC.get("X-Trans-Id") != null
-
+        MDC.get("x-trans-id") != null
 
         when: "Identity atom feed has a Update User Event"
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
@@ -228,7 +228,7 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
         fakeIdentityService.validateTokenCount == 0
         fakeIdentityService.getGroupsCount == 0
         mc.handlings[0].endpoint == originEndpoint
-
+        mc.receivedResponse.headers.contains("x-trans-id")
         MDC.get("X-Trans-Id") != null
 
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
@@ -169,12 +169,14 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
         when: "identity atom feed has an entry that should invalidate the tenant associated with this X-Auth-Token"
         // change identity atom feed
 
+
         fakeIdentityService.with {
             fakeIdentityService.validateTokenHandler = {
                 tokenId, request, xml ->
                     new Response(404)
             }
         }
+
         fakeIdentityService.resetCounts()
         fakeAtomFeed.hasEntry = true
         atomEndpoint.defaultHandler = fakeAtomFeed.handler
@@ -189,8 +191,8 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
                 [
                         url           : reposeEndpoint,
                         method        : 'GET',
-                        headers       : ['X-Auth-Token': fakeIdentityService.client_token],
-                        defaultHandler: fakeIdentityService.handler
+                        headers       : ['X-Auth-Token': fakeIdentityService.client_token]
+                        //defaultHandler: fakeIdentityService.handler
                 ])
 
         then: "Repose should not have the token in the cache any more, so it try to validate it, which will fail and result in a 401"
@@ -309,7 +311,7 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
                         url           : reposeEndpoint,
                         method        : 'GET',
                         headers       : ['X-Auth-Token': fakeIdentityService.client_token],
-                        defaultHandler: fakeIdentityService.handler
+                        //defaultHandler: fakeIdentityService.handler
                 ])
 
         then: "Repose should not have the token in the cache any more, so it try to validate it, which will fail and result in a 401"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
@@ -25,7 +25,6 @@ import framework.mocks.MockIdentityService
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.Response
-import org.slf4j.MDC
 
 /**
  B-48277
@@ -228,9 +227,6 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
         fakeIdentityService.validateTokenCount == 0
         fakeIdentityService.getGroupsCount == 0
         mc.handlings[0].endpoint == originEndpoint
-        /* TODO: another x-trans-id is added as a header, not the one for invalidation */
-        mc.receivedResponse.headers.contains("x-trans-id")
-        MDC.get("x-trans-id") != null
 
         when: "Identity atom feed has a Update User Event"
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/cache/InvalidateCacheUsingAtomFeedTest.groovy
@@ -197,6 +197,9 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
         mc.receivedResponse.code == '401'
         mc.handlings.size() == 0
         fakeIdentityService.validateTokenCount == 1
+        mc.orphanedHandlings.each {
+            e -> assert e.request.headers.contains("x-trans-id")
+        }
     }
 
 
@@ -313,5 +316,8 @@ class InvalidateCacheUsingAtomFeedTest extends ReposeValveTest {
         mc.receivedResponse.code == '401'
         mc.handlings.size() == 0
         fakeIdentityService.validateTokenCount == 1
+        mc.orphanedHandlings.each {
+            e -> assert e.request.headers.contains("x-trans-id")
+        }
     }
 }


### PR DESCRIPTION
A x-trans-id is logged and added as a header for each invalidation request.