### PR TITLE
Updated the WAR pom to include the missing Log4J 2.x jars and to exclude the old commons-logging.

### DIFF
--- a/repose-aggregator/core/web-application/pom.xml
+++ b/repose-aggregator/core/web-application/pom.xml
@@ -53,7 +53,13 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
+            <artifactId>spring-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-logging</artifactId>
+                    <groupId>commons-logging</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -63,7 +69,7 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
+            <artifactId>spring-beans</artifactId>
         </dependency>
 
         <dependency>
@@ -71,6 +77,22 @@
             <artifactId>spring-core</artifactId>
         </dependency>
 
+        <!-- this replaces all commons-logging, but has to be manually added to each project that wants logging:( -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+
+        <!--For SLF4J/Log4J 2.x logging support-->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Also put the Spring dependencies in the same order as the Valve POM to make for easier comparisons.