### PR TITLE
Rep 2355 rewrite trans id header

### DIFF
--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilter.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilter.java
@@ -352,6 +352,10 @@ public class PowerFilter extends DelegatingFilterProxy {
         final MutableHttpServletRequest mutableHttpRequest = MutableHttpServletRequest.wrap((HttpServletRequest) request, streamLimit);
         final MutableHttpServletResponse mutableHttpResponse = MutableHttpServletResponse.wrap(mutableHttpRequest, (HttpServletResponse) response);
 
+        if (currentSystemModel.get().isRewriteTracingHeader()) {
+            mutableHttpRequest.removeHeader(CommonHttpHeader.TRACE_GUID.toString());
+        }
+
         //Grab the traceGUID from the request if there is one, else create one
         String traceGUID;
         if (StringUtilities.isBlank(mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString()))) {

--- a/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
+++ b/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
@@ -102,4 +102,22 @@ class CoreSpringProviderTest extends FunSpec with Matchers with TestFilterBundle
     }
   }
 
+  describe("Repose Spring Properties") {
+    describe("Repose Version") {
+      it("is not 8") {
+        val reposeVersion = coreSpringProvider.getCoreContext.getEnvironment.getProperty(
+          ReposeSpringProperties.stripSpringValueStupidity(ReposeSpringProperties.CORE.REPOSE_VERSION))
+
+        reposeVersion should not startWith "8"
+
+        /*
+         * Before moving to version 8, the following updates should be made:
+         *
+         * - Refactor the 'tracing-header' and 'rewrite-tracing-header' System Model attributes to a new tracing
+         * element.
+         */
+      }
+    }
+  }
+
 }

--- a/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
+++ b/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
@@ -104,7 +104,7 @@ class CoreSpringProviderTest extends FunSpec with Matchers with TestFilterBundle
 
   describe("Repose Spring Properties") {
     describe("Repose Version") {
-      it("is not 8") {
+      it("is not 8 (timebomb)") {
         val reposeVersion = coreSpringProvider.getCoreContext.getEnvironment.getProperty(
           ReposeSpringProperties.stripSpringValueStupidity(ReposeSpringProperties.CORE.REPOSE_VERSION))
 

--- a/repose-aggregator/core/core-service-api/src/main/resources/META-INF/schema/system-model/system-model.xsd
+++ b/repose-aggregator/core/core-service-api/src/main/resources/META-INF/schema/system-model/system-model.xsd
@@ -46,6 +46,7 @@
         </xs:sequence>
 
         <xs:attribute name="tracing-header" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rewrite-tracing-header" type="xs:boolean" use="optional" default="false"/>
     </xs:complexType>
 
     <xs:complexType name="Cluster">

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/tracing/rewritetransid/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/tracing/rewritetransid/system-model.cfg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0" rewrite-tracing-header="true">
+    <repose-cluster id="repose-cluster">
+        <nodes>
+            <node id="node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+
+        <filters/>
+
+        <destinations>
+            <endpoint id="endpoint" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
+                      default="true"/>
+        </destinations>
+    </repose-cluster>
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/RewriteTracingHeaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/RewriteTracingHeaderTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.core.tracing
+
+import framework.ReposeValveTest
+import org.openrepose.commons.utils.http.CommonHttpHeader
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+class RewriteTracingHeaderTest extends ReposeValveTest {
+
+    def setupSpec() {
+        reposeLogSearch.cleanLog()
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort)
+
+        def params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/core/powerfilter/tracing", params)
+        repose.configurationProvider.applyConfigs("features/core/tracing/rewritetransid", params)
+
+        repose.start()
+    }
+
+    /*def cleanupSpec() {
+        deproxy.shutdown()
+
+        repose.stop()
+    }*/
+
+    def "should not pass the externally provided tracing header through the filter chain"() {
+        when:
+        MessageChain mc = deproxy.makeRequest(
+                url: reposeEndpoint, headers: [(CommonHttpHeader.TRACE_GUID.toString()): 'test-guid-for-rewrite'])
+        def requestId = mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue(
+                CommonHttpHeader.TRACE_GUID.toString())
+
+        then:
+        !requestId.equals('test-guid-for-rewrite')
+        requestId.matches('.+-.+-.+-.+-.+')
+    }
+
+    def "should pass a new tracing header through the filter chain if one was not provided"() {
+        when:
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, headers: [:])
+
+        then:
+        mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue(CommonHttpHeader.TRACE_GUID.toString())
+                .matches('.+-.+-.+-.+-.+')
+    }
+
+    def "should not return the externally provided tracing header if one was provided"() {
+        when:
+        MessageChain mc = deproxy.makeRequest(
+                url: reposeEndpoint, headers: [(CommonHttpHeader.TRACE_GUID.toString()): 'test-guid-for-rewrite'])
+        def requestId = mc.getReceivedResponse().getHeaders().getFirstValue(CommonHttpHeader.TRACE_GUID.toString())
+
+        then:
+        !requestId.equals('test-guid-for-rewrite')
+        requestId.matches('.+-.+-.+-.+-.+')
+    }
+
+    def "should return a tracing header if one was not provided"() {
+        when:
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, headers: [:])
+        def requestId = mc.getReceivedResponse().getHeaders().getFirstValue(CommonHttpHeader.TRACE_GUID.toString())
+
+        then:
+        requestId.matches('.+-.+-.+-.+-.+')
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/RewriteTracingHeaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/RewriteTracingHeaderTest.groovy
@@ -39,12 +39,6 @@ class RewriteTracingHeaderTest extends ReposeValveTest {
         repose.start()
     }
 
-    /*def cleanupSpec() {
-        deproxy.shutdown()
-
-        repose.stop()
-    }*/
-
     def "should not pass the externally provided tracing header through the filter chain"() {
         when:
         MessageChain mc = deproxy.makeRequest(


### PR DESCRIPTION
Added "rewrite-tracing-header" attribute to the system model as a boolean to allow users to configure Repose to ignore inbound transaction ids but still have tracing enabled.  The default value is false.

Update was made to PowerFilter.java to remove the "X-Trans-Id" header when the "rewrite-tracing-header" attribute is set to true.  PowerFilter.java does not have an existing unit test, and the class is complex enough that adding a unit test would take a significant amount of time.

I added a functional test (RewriteTracingHeaderTest.groovy) to verify that the request and the response get a new "X-Trans-Id" header whether or not one was passed into the original request.  I also ran the TracingHeaderDisabledTest to regression test the original behavior.

I also added a unit test to verify that the Repose version number does not start with 8 (i.e. when we move to version 8, the unit test will fail).  As a part of making a major version number change, we should refactor the tracing attributes on the system model into their own element.  The unit test includes this information in a comment.