### PR TITLE
Added support for filters that don't need spring annotations

### DIFF
--- a/repose-aggregator/components/filters/content-type-stripper/src/main/scala/org/openrepose/filters/contenttypestripper/ContentTypeStripperFilter.scala
+++ b/repose-aggregator/components/filters/content-type-stripper/src/main/scala/org/openrepose/filters/contenttypestripper/ContentTypeStripperFilter.scala
@@ -31,7 +31,6 @@ import org.openrepose.commons.utils.servlet.http.MutableHttpServletRequest
 
 import scala.collection.JavaConversions.enumerationAsScalaIterator
 
-@Named
 class ContentTypeStripperFilter extends Filter {
 
   override def init(p1: FilterConfig): Unit = {}

--- a/repose-aggregator/components/filters/derp/src/main/scala/org/openrepose/filters/derp/DerpFilter.scala
+++ b/repose-aggregator/components/filters/derp/src/main/scala/org/openrepose/filters/derp/DerpFilter.scala
@@ -19,7 +19,6 @@
  */
 package org.openrepose.filters.derp
 
-import javax.inject.Named
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.ws.rs.core.MediaType
@@ -37,7 +36,6 @@ import scala.util.{Failure, Success}
  * This filter is header quality aware; the delegation header with the highest quality will be used to formulate a
  * response.
  */
-@Named
 class DerpFilter extends Filter with HttpDelegationManager with LazyLogging {
 
   override def init(filterConfig: FilterConfig): Unit = {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/contenttypestripper/ContentTypeStripperTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/contenttypestripper/ContentTypeStripperTest.groovy
@@ -80,6 +80,9 @@ class ContentTypeStripperTest extends ReposeValveTest {
         then:
         ((Handling) sentRequest).request.getHeaders().findAll("Content-Type").size() == 0
         ((Handling) sentRequest).request.body == (method == "GET" ? "" : requestBody) //We remove the body on a get when finally calling the service
+        // Verify Repose not throw error log for non anotation filter
+        reposeLogSearch.searchByString("Requested filter, *.ContentTypeStriperFilter is not an annotated Component. Make sure your filter is an annotated Spring Bean.").size() == 0
+
 
         where:
         desc                                                          | requestBody                           | method

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/derp/DerpResponseMessagingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/derp/DerpResponseMessagingTest.groovy
@@ -26,6 +26,7 @@ import org.rackspace.deproxy.MessageChain
 class DerpResponseMessagingTest extends ReposeValveTest {
 
     def setupSpec() {
+        reposeLogSearch.cleanLog()
         deproxy = new Deproxy()
         deproxy.addEndpoint(properties.targetPort)
 
@@ -44,5 +45,9 @@ class DerpResponseMessagingTest extends ReposeValveTest {
         then:
         messageChain.getHandlings().size() + messageChain.getOrphanedHandlings().size() == 0
         messageChain.getReceivedResponse().getBody().equals('Response messaging caught a 5xx response')
+
+        // Verify Repose not throw error log for non anotation filter
+        reposeLogSearch.searchByString("Requested filter, *.DerpFilter is not an annotated Component. Make sure your filter is an annotated Spring Bean.").size() == 0
+
     }
 }


### PR DESCRIPTION
I removed the Named annotation from DerpFilter and verified that the functional tests DerpAndClientAuthNDelegable.groovy, DerpAndDelegableQuality.groovy, and DerpResponseMessagingTest.groovy failed.  I also updated FilterContextFactoryTest.scala to remove the existing unit test that verifies that an unannotated filter should cause an exception to be thrown and added a test to verify it won't.  The unit and functional tests failed in the correct way.

I updated FilterContextFactory.java to first check if the Spring application context had any beans for the configured class, and if not then it'll try creating a new instance of that class using reflection.  I removed the exception handling for the case where we try to get the bean from the application context and it doesn't exist (since we first check now) and added exception handling for the case where we can't use reflection to create an instance of the class (e.g. if the class doesn't have a public no-arg constructor).

The check I added to see if the app context has any beans for the class is not ideal.  I didn't find a method to directly check if there were any beans for a class (as opposed to using a string).  Using exception handling as control flow seemed like a bad idea.  I resorted to getting the list of bean names for the class and checking whether or not I get back an empty array.

I verified that the functional and unit tests pass again after the update.