### PR TITLE
REP-2494 DerpFilter delegation message not making it to ResponseMessageHandler.

### DIFF
--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/MutableHttpServletResponse.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/servlet/http/MutableHttpServletResponse.java
@@ -302,9 +302,14 @@ public class MutableHttpServletResponse extends HttpServletResponseWrapper imple
 
     @Override
     public void sendError(int code, String message) {
-        super.setStatus(code);
-        this.message = message;
+        setStatus(code, message);
         error = true;
+    }
+
+    @Override
+    public void setStatus(int code, String message) {
+        super.setStatus(code, message);
+        this.message = message;
     }
 
     public boolean isError() {

--- a/repose-aggregator/components/filters/derp/src/main/scala/org/openrepose/filters/derp/DerpFilter.scala
+++ b/repose-aggregator/components/filters/derp/src/main/scala/org/openrepose/filters/derp/DerpFilter.scala
@@ -81,7 +81,7 @@ class DerpFilter extends Filter with HttpDelegationManager with LazyLogging {
     httpServletResponse.setContentLength(responseBody.length)
     httpServletResponse.setContentType(MediaType.TEXT_PLAIN)
     httpServletResponse.getWriter.write(responseBody)
-    httpServletResponse.sendError(statusCode)
+    httpServletResponse.sendError(statusCode, responseBody)
   }
 
   override def destroy(): Unit = {

--- a/repose-aggregator/components/filters/derp/src/test/scala/org/openrepose/filters/derp/DerpFilterTest.scala
+++ b/repose-aggregator/components/filters/derp/src/test/scala/org/openrepose/filters/derp/DerpFilterTest.scala
@@ -57,8 +57,7 @@ class DerpFilterTest extends FunSpec {
 
       derpFilter.doFilter(req, resp, null)
 
-      verify(resp).sendError(404)
-      verify(respWriter).write("not found")
+      verify(resp).sendError(404, "not found")
     }
 
     it("should send an error response corresponding to the delegation value with the highest quality") {
@@ -70,8 +69,7 @@ class DerpFilterTest extends FunSpec {
 
       derpFilter.doFilter(req, resp, null)
 
-      verify(resp).sendError(500)
-      verify(respWriter).write("bar")
+      verify(resp).sendError(500, "bar")
     }
 
     it("should send an error response corresponding to the delegation value with the highest quality, reverse order") {
@@ -83,8 +81,7 @@ class DerpFilterTest extends FunSpec {
 
       derpFilter.doFilter(req, resp, null)
 
-      verify(resp).sendError(500)
-      verify(respWriter).write("bar")
+      verify(resp).sendError(500, "bar")
     }
 
     it("should reject the request if no delegation value could be parsed") {
@@ -98,8 +95,10 @@ class DerpFilterTest extends FunSpec {
       derpFilter.doFilter(req, resp, fc)
 
       verify(fc, never()).doFilter(any(classOf[ServletRequest]), any(classOf[ServletResponse]))
-      verify(resp).sendError(500)
-      verify(respWriter).write(anyString())
+      //verify(resp).sendError(eq(500), anyString())                    // Won't compile; says to use type ascription
+      //verify(resp).sendError(eq(500:java.lang.Integer), anyString())  // Won't compile; type mismatch; found: Boolean; required: Int
+      //verify(resp).sendError(eq(500:Int), anyString())                // Won't compile; type mismatch; found: Int; required: AnyRef
+      verify(resp).sendError(500, anyString())                          // Runtime failure: Invalid use of argument matchers!
     }
 
     it("should treat a delegation value without an explicit quality as having a quality of 1") {
@@ -111,8 +110,7 @@ class DerpFilterTest extends FunSpec {
 
       derpFilter.doFilter(req, resp, null)
 
-      verify(resp).sendError(500)
-      verify(respWriter).write("bar")
+      verify(resp).sendError(500, "bar")
     }
   }
 

--- a/repose-aggregator/components/filters/derp/src/test/scala/org/openrepose/filters/derp/DerpFilterTest.scala
+++ b/repose-aggregator/components/filters/derp/src/test/scala/org/openrepose/filters/derp/DerpFilterTest.scala
@@ -59,6 +59,7 @@ class DerpFilterTest extends FunSpec {
       derpFilter.doFilter(req, resp, null)
 
       verify(resp).sendError(404, "not found")
+      verify(respWriter).write("not found")
     }
 
     it("should send an error response corresponding to the delegation value with the highest quality") {
@@ -71,6 +72,7 @@ class DerpFilterTest extends FunSpec {
       derpFilter.doFilter(req, resp, null)
 
       verify(resp).sendError(500, "bar")
+      verify(respWriter).write("bar")
     }
 
     it("should send an error response corresponding to the delegation value with the highest quality, reverse order") {
@@ -83,6 +85,7 @@ class DerpFilterTest extends FunSpec {
       derpFilter.doFilter(req, resp, null)
 
       verify(resp).sendError(500, "bar")
+      verify(respWriter).write("bar")
     }
 
     it("should reject the request if no delegation value could be parsed") {
@@ -97,6 +100,7 @@ class DerpFilterTest extends FunSpec {
 
       verify(fc, never()).doFilter(any(classOf[ServletRequest]), any(classOf[ServletResponse]))
       verify(resp).sendError(Matchers.eq(500), anyString())
+      verify(respWriter).write(anyString())
     }
 
     it("should treat a delegation value without an explicit quality as having a quality of 1") {
@@ -109,6 +113,7 @@ class DerpFilterTest extends FunSpec {
       derpFilter.doFilter(req, resp, null)
 
       verify(resp).sendError(500, "bar")
+      verify(respWriter).write("bar")
     }
   }
 
@@ -132,7 +137,7 @@ class DerpFilterTest extends FunSpec {
         "status_code=5a0`component=foo2`message=baz`q=0.7"
       ))
 
-      assert(parsedValues.size == 0)
+      assert(parsedValues.isEmpty)
     }
   }
 

--- a/repose-aggregator/components/filters/derp/src/test/scala/org/openrepose/filters/derp/DerpFilterTest.scala
+++ b/repose-aggregator/components/filters/derp/src/test/scala/org/openrepose/filters/derp/DerpFilterTest.scala
@@ -25,6 +25,7 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.servlet.{FilterChain, ServletRequest, ServletResponse}
 
 import org.junit.runner.RunWith
+import org.mockito.Matchers
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
@@ -95,10 +96,7 @@ class DerpFilterTest extends FunSpec {
       derpFilter.doFilter(req, resp, fc)
 
       verify(fc, never()).doFilter(any(classOf[ServletRequest]), any(classOf[ServletResponse]))
-      //verify(resp).sendError(eq(500), anyString())                    // Won't compile; says to use type ascription
-      //verify(resp).sendError(eq(500:java.lang.Integer), anyString())  // Won't compile; type mismatch; found: Boolean; required: Int
-      //verify(resp).sendError(eq(500:Int), anyString())                // Won't compile; type mismatch; found: Int; required: AnyRef
-      verify(resp).sendError(500, anyString())                          // Runtime failure: Invalid use of argument matchers!
+      verify(resp).sendError(Matchers.eq(500), anyString())
     }
 
     it("should treat a delegation value without an explicit quality as having a quality of 1") {

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
@@ -307,14 +307,14 @@ public class PowerFilterChain implements FilterChain {
             FilterContext filter = currentFilters.get(position++);
             long start = tracer.traceEnter();
             setStartTimeForHttpLogger(start, mutableHttpRequest);
-            doReposeFilter(mutableHttpRequest, servletResponse, filter);
+            doReposeFilter(mutableHttpRequest, mutableHttpResponse, filter);
             long delay = tracer.traceExit(mutableHttpResponse, filter.getFilterConfig().getName());
             if (filterTimer != null) {
                 filterTimer.update(filter.getFilterConfig().getName(), delay, TimeUnit.MILLISECONDS);
             }
         } else {
             tracer.traceEnter();
-            doRouting(mutableHttpRequest, servletResponse);
+            doRouting(mutableHttpRequest, mutableHttpResponse);
             long delay = tracer.traceExit(mutableHttpResponse, "route");
             if (filterTimer != null) {
                 filterTimer.update("route", delay, TimeUnit.MILLISECONDS);

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
@@ -300,22 +300,20 @@ public class PowerFilterChain implements FilterChain {
             throws IOException, ServletException {
         final MutableHttpServletRequest mutableHttpRequest =
                 MutableHttpServletRequest.wrap((HttpServletRequest) servletRequest);
-        final MutableHttpServletResponse mutableHttpResponse =
-                MutableHttpServletResponse.wrap(mutableHttpRequest, (HttpServletResponse) servletResponse);
 
         if (filterChainAvailable && position < currentFilters.size()) {
             FilterContext filter = currentFilters.get(position++);
             long start = tracer.traceEnter();
             setStartTimeForHttpLogger(start, mutableHttpRequest);
-            doReposeFilter(mutableHttpRequest, mutableHttpResponse, filter);
-            long delay = tracer.traceExit(mutableHttpResponse, filter.getFilterConfig().getName());
+            doReposeFilter(mutableHttpRequest, servletResponse, filter);
+            long delay = tracer.traceExit((HttpServletResponse) servletResponse, filter.getFilterConfig().getName());
             if (filterTimer != null) {
                 filterTimer.update(filter.getFilterConfig().getName(), delay, TimeUnit.MILLISECONDS);
             }
         } else {
             tracer.traceEnter();
-            doRouting(mutableHttpRequest, mutableHttpResponse);
-            long delay = tracer.traceExit(mutableHttpResponse, "route");
+            doRouting(mutableHttpRequest, servletResponse);
+            long delay = tracer.traceExit((HttpServletResponse) servletResponse, "route");
             if (filterTimer != null) {
                 filterTimer.update("route", delay, TimeUnit.MILLISECONDS);
             }

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/RequestTracer.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/RequestTracer.java
@@ -19,7 +19,7 @@
  */
 package org.openrepose.powerfilter;
 
-import org.openrepose.commons.utils.servlet.http.MutableHttpServletResponse;
+import javax.servlet.http.HttpServletResponse;
 
 public class RequestTracer {
 
@@ -41,7 +41,7 @@ public class RequestTracer {
         return startTime;
     }
 
-    public long traceExit(MutableHttpServletResponse response, String filterName) {
+    public long traceExit(HttpServletResponse response, String filterName) {
         if (!trace) {
             return 0;
         }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/apivalidatormultimatch/response-messaging.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/apivalidatormultimatch/response-messaging.cfg.xml
@@ -1,53 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <response-messaging xmlns="http://docs.rackspacecloud.com/repose/response-messaging/v1.0">
-    <status-code id="403" code-regex="403" overwrite="ALWAYS">
+    <status-code id="401" code-regex="401" overwrite="ALWAYS">
         <message media-type="*/*" content-type="application/json">
             {
-            "code" : 403,
-            "message" : "Forbidden",
-            "details" : "Error (403)"
+            "code" : %s,
+            "message" : "%M",
+            "details" : "Error (%s)"
             }
         </message>
         <message media-type="application/xml" content-type="application/xml"><![CDATA[
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<forbidden code="403">
-  <message>Forbidden</message>
-  <details>Error (403)</details>
+<forbidden code="%s">
+  <message>%M</message>
+  <details>Error (%s)</details>
 </forbidden >
 ]]></message>
     </status-code>
-    <status-code id="404" code-regex="404" overwrite="ALWAYS">
-        <message media-type="*/*" content-type="application/json">
-            {
-            "code" : 404,
-            "message" : "Resource not found",
-            "details" : "Error (404)"
-            }
-        </message>
-        <message media-type="application/xml" content-type="application/xml"><![CDATA[
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<notFound code="404">
-  <message>Resource not found</message>
-  <details>Error (404)</details>
-</notFound>
-]]></message>
-    </status-code>
-    <status-code id="405" code-regex="405" overwrite="ALWAYS">
-        <message media-type="*/*" content-type="application/json">
-            {
-            "code" : 405,
-            "message" : "Method not allowed",
-            "details" : "Error (405)"
-            }
-        </message>
-        <message media-type="application/xml" content-type="application/xml"><![CDATA[
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<notFound code="405">
-  <message>Method not allowed</message>
-  <details>Error (405)</details>
-</notFound>
-]]></message>
-    </status-code>
 </response-messaging>
-
-

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/wderpandrms/response-messaging.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/wderpandrms/response-messaging.cfg.xml
@@ -1,53 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <response-messaging xmlns="http://docs.rackspacecloud.com/repose/response-messaging/v1.0">
-    <status-code id="403" code-regex="403" overwrite="ALWAYS">
+    <status-code id="401" code-regex="401" overwrite="ALWAYS">
         <message media-type="*/*" content-type="application/json">
             {
-            "code" : 403,
-            "message" : "Forbidden",
-            "details" : "Error (403)"
+            "code" : %s,
+            "message" : "%M",
+            "details" : "Error (%s)"
             }
         </message>
         <message media-type="application/xml" content-type="application/xml"><![CDATA[
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<forbidden code="403">
-  <message>Forbidden</message>
-  <details>Error (403)</details>
+<forbidden code="%s">
+  <message>%M</message>
+  <details>Error (%s)</details>
 </forbidden >
 ]]></message>
     </status-code>
-    <status-code id="404" code-regex="404" overwrite="ALWAYS">
+    <status-code id="500" code-regex="500" overwrite="ALWAYS">
         <message media-type="*/*" content-type="application/json">
             {
-            "code" : 404,
-            "message" : "Resource not found",
-            "details" : "Error (404)"
+            "code" : %s,
+            "message" : "%M",
+            "details" : "Error (%s)"
             }
         </message>
         <message media-type="application/xml" content-type="application/xml"><![CDATA[
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<notFound code="404">
-  <message>Resource not found</message>
-  <details>Error (404)</details>
-</notFound>
-]]></message>
-    </status-code>
-    <status-code id="405" code-regex="405" overwrite="ALWAYS">
-        <message media-type="*/*" content-type="application/json">
-            {
-            "code" : 405,
-            "message" : "Method not allowed",
-            "details" : "Error (405)"
-            }
-        </message>
-        <message media-type="application/xml" content-type="application/xml"><![CDATA[
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<notFound code="405">
-  <message>Method not allowed</message>
-  <details>Error (405)</details>
-</notFound>
+<forbidden code="%s">
+  <message>%M</message>
+  <details>Error (%s)</details>
+</forbidden >
 ]]></message>
     </status-code>
 </response-messaging>
-
-

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/wderpandrms/response-messaging.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/wderpandrms/response-messaging.cfg.xml
@@ -16,6 +16,54 @@
 </forbidden >
 ]]></message>
     </status-code>
+    <status-code id="403" code-regex="403" overwrite="ALWAYS">
+        <message media-type="*/*" content-type="application/json">
+            {
+            "code" : 403,
+            "message" : "Forbidden",
+            "details" : "Error (403)"
+            }
+        </message>
+        <message media-type="application/xml" content-type="application/xml"><![CDATA[
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<forbidden code="403">
+  <message>Forbidden</message>
+  <details>Error (403)</details>
+</forbidden >
+]]></message>
+    </status-code>
+    <status-code id="404" code-regex="404" overwrite="ALWAYS">
+        <message media-type="*/*" content-type="application/json">
+            {
+            "code" : 404,
+            "message" : "Resource not found",
+            "details" : "Error (404)"
+            }
+        </message>
+        <message media-type="application/xml" content-type="application/xml"><![CDATA[
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<notFound code="404">
+  <message>Resource not found</message>
+  <details>Error (404)</details>
+</notFound>
+]]></message>
+    </status-code>
+    <status-code id="405" code-regex="405" overwrite="ALWAYS">
+        <message media-type="*/*" content-type="application/json">
+            {
+            "code" : 405,
+            "message" : "Method not allowed",
+            "details" : "Error (405)"
+            }
+        </message>
+        <message media-type="application/xml" content-type="application/xml"><![CDATA[
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<notFound code="405">
+  <message>Method not allowed</message>
+  <details>Error (405)</details>
+</notFound>
+]]></message>
+    </status-code>
     <status-code id="500" code-regex="500" overwrite="ALWAYS">
         <message media-type="*/*" content-type="application/json">
             {


### PR DESCRIPTION
# tl;dr

If the initial `MutableHttpServletResponse` wrapper was re-wrapped by another type (e.g. `CheckerServletResponse`), then the delegation message set in the `DerpFilter` was never propagated to the `ResponseMessageHandler`.

# full
The `ResponseMessageHandler` is expecting to retrieve the message from `MutableHttpServletResponse.getMessage()`.

* https://github.com/rackerlabs/repose/blob/master/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/ResponseMessageHandler.java#L40

This message is set using the `HttpServletResponse.sendError(int, String)` on a `MutableHttpServletResponse`. The delegation message was originally only being set in the `DerpFilter` using `HttpServletResponse.getWriter.write(String)`.

* https://github.com/rackerlabs/repose/blob/master/repose-aggregator/components/filters/derp/src/main/scala/org/openrepose/filters/derp/DerpFilter.scala#L81

This could not be picked up by the `ResponseMessageHandler` since it was not being set as expected. The delegation message is now also being set in the `DerpFilter` using this overloaded `HttpServletResponse.sendError()`:

* https://github.com/rackerlabs/repose/blob/REP-2494_CloudFeedsIssue/repose-aggregator/components/filters/derp/src/main/scala/org/openrepose/filters/derp/DerpFilter.scala#L84

When *API-Checker* is in the `FilterChain` (e.g. `api-validator`, `simple-rbac`), the `ServletResponse` passed into `PowerFilterChain.doFilter()` at the following is a `CheckerServletResponse`:

* https://github.com/rackerlabs/api-checker/blob/master/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/DelegationHandler.scala#L45

This is immediately wrapped in a `MutableHttpServletResponse` and sent on down the `FilterChain`:

* https://github.com/rackerlabs/repose/blob/master/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java#L184-L185

The `HttpServletResponse` provides no mechanism to retrieve the message that was set using `sendError()`. The `HttpServletResponseWrapper`, is the base implementation of `HttpServletResponse`, and it's direct descendant `CheckerServletResponse` doesn't either.

So even though the second layer `MutableHttpServletResponse` had the delegation message set directly in the `DerpFilter` using the overloaded `HttpServletResponse.sendError()`,
that particular message was never passed on to the intermediary `CheckerServletResponse` or in turn the inner original  `MutableHttpServletResponse` for later retrieval by `ResponseMessageHandler`.