### PR TITLE
Rep 2521 tenant id case sensitive

### DIFF
--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHandler.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHandler.java
@@ -93,12 +93,12 @@ public class OpenStackAuthenticationHandler extends AuthenticationHandler {
             authToken = new OpenStackToken(resp);
         }
 
-        if (authToken != null && !roleIsServiceAdmin(authToken) && !authToken.getTenantId().equalsIgnoreCase(tenantID)) {
+        if (authToken != null && !roleIsServiceAdmin(authToken) && !authToken.getTenantId().equals(tenantID)) {
             // tenant ID from token did not match URI.
 
             if (resp.getUser() != null && resp.getUser().getRoles() != null) {
                 for (Role role : resp.getUser().getRoles().getRole()) {
-                    if (tenantID.equalsIgnoreCase(role.getTenantId())) {
+                    if (tenantID.equals(role.getTenantId())) {
                         //we have the real tenantID
                         return authToken;
                     }


### PR DESCRIPTION
I updated Client Auth to be case sensitive when testing for Tenant ID equality.

Jenny added a functional test to verify that Client Auth is case sensitive when testing for Tenant ID equality.  Before my update, the functional test failed as expected.  After the update, the test passed.  Unit tests also correctly failed before the update and passed after the update.

Keystone v3 doesn't need to be updated:
https://github.com/rackerlabs/repose/blob/master/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Handler.scala#L325