### PR TITLE
Rep 2379 logging timestamp formatting

### DIFF
--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatter.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatter.java
@@ -111,7 +111,7 @@ public class HttpLogFormatter {
                 formatter.setLogic(new ResponseBytesHandler());
                 break;
             case TIME_RECEIVED:
-                formatter.setLogic(new TimeReceivedHandler());
+                formatter.setLogic(new TimeReceivedHandler(extractor.getFormat()));
                 break;
             case URL_REQUESTED:
                 formatter.setLogic(new UrlRequestedHandler());

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/LogArgumentGroupExtractor.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/LogArgumentGroupExtractor.java
@@ -19,6 +19,7 @@
  */
 package org.openrepose.commons.utils.logging.apache;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openrepose.commons.utils.StringUtilities;
 
 import java.util.ArrayList;
@@ -34,13 +35,15 @@ public class LogArgumentGroupExtractor {
     private String lifeCycleModifier;
     private String statusCodes;
     private String variable;
+    private String variableArgumentSeparator;
     private String entity;
     private List<String> arguments;
 
-    private LogArgumentGroupExtractor(String lifeCycleModifier, String statusCodes, String variable, String arguments, String entity) {
+    private LogArgumentGroupExtractor(String lifeCycleModifier, String statusCodes, String variable, String variableArgumentSeparator, String arguments, String entity) {
         this.lifeCycleModifier = lifeCycleModifier;
         this.statusCodes = statusCodes;
         this.variable = variable;
+        this.variableArgumentSeparator = variableArgumentSeparator;
         this.arguments = parseArguments(arguments);
         this.entity = entity;
     }
@@ -49,16 +52,17 @@ public class LogArgumentGroupExtractor {
         lifeCycleModifier = getGroupValue(m, LOG_CONSTANTS.LIFECYCLE_GROUP_INDEX);
         statusCodes = getGroupValue(m, LOG_CONSTANTS.STATUS_CODE_INDEX);
         variable = getGroupValue(m, LOG_CONSTANTS.VARIABLE_INDEX);
+        variableArgumentSeparator = getGroupValue(m, LOG_CONSTANTS.VAR_ARG_SEPARATOR_INDEX);
         arguments = parseArguments(getGroupValue(m, LOG_CONSTANTS.ARGUMENTS_INDEX));
         entity = getGroupValue(m, LOG_CONSTANTS.ENTITY_INDEX);
     }
 
     public static LogArgumentGroupExtractor instance(String lifeCycleModifier, String statusCodes, String variable, String arguments, String entity) {
-        return new LogArgumentGroupExtractor(lifeCycleModifier, statusCodes, variable, arguments, entity);
+        return new LogArgumentGroupExtractor(lifeCycleModifier, statusCodes, variable, "", arguments, entity);
     }
 
     public static LogArgumentGroupExtractor stringEntity(String variable) {
-        return new LogArgumentGroupExtractor("", "", variable, "", LogFormatArgument.STRING.name());
+        return new LogArgumentGroupExtractor("", "", variable, "", "", LogFormatArgument.STRING.name());
     }
 
     private List<String> parseArguments(String arguments) {
@@ -97,6 +101,11 @@ public class LogArgumentGroupExtractor {
         return arguments;
     }
 
+    public String getFormat() {
+        // everything that was inside the braces
+        return variable + variableArgumentSeparator + StringUtils.join(arguments, "");
+    }
+
     @Override
     public boolean equals(Object o) {
         boolean result = false;
@@ -109,7 +118,6 @@ public class LogArgumentGroupExtractor {
                     && StringUtilities.nullSafeEquals(other.statusCodes, statusCodes)
                     && other.arguments.equals(arguments)
                     && StringUtilities.nullSafeEquals(other.variable, variable);
-
         }
 
         return result;
@@ -132,15 +140,16 @@ public class LogArgumentGroupExtractor {
         String LIFECYCLE_MODIFIER_EXTRACTOR = "([<>])?";
         // Group 2, 3 (ignore)
         String STATUS_CODE_EXTRACTOR = "([!]?([0-9]{3}[,]?)*)?";
-        // Group 4 (ignore), 5, 6
-        String VARIABLE_EXTRACTOR = "(\\{([\\-a-zA-Z0-9]*)[ ,]?([_\\-a-zA-Z0-9 ,]*)\\})?";
-        // Group 7
+        // Group 4 (ignore), 5, 6, 7
+        String VARIABLE_EXTRACTOR = "(\\{([\\-a-zA-Z0-9:.]*)([ ,]?)([_\\-a-zA-Z0-9 ,:.]*)\\})?";
+        // Group 8
         String ENTITY_EXTRACTOR = "([%a-zA-Z])";
         Pattern PATTERN = Pattern.compile("%" + LIFECYCLE_MODIFIER_EXTRACTOR + STATUS_CODE_EXTRACTOR + VARIABLE_EXTRACTOR + ENTITY_EXTRACTOR);
         int LIFECYCLE_GROUP_INDEX = 1;
         int STATUS_CODE_INDEX = 2;
         int VARIABLE_INDEX = 5;
-        int ARGUMENTS_INDEX = 6;
-        int ENTITY_INDEX = 7;
+        int VAR_ARG_SEPARATOR_INDEX = 6;
+        int ARGUMENTS_INDEX = 7;
+        int ENTITY_INDEX = 8;
     }
 }

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/LogArgumentGroupExtractor.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/LogArgumentGroupExtractor.java
@@ -103,7 +103,7 @@ public class LogArgumentGroupExtractor {
 
     public String getFormat() {
         // everything that was inside the braces
-        return variable + variableArgumentSeparator + StringUtils.join(arguments, "");
+        return variable + variableArgumentSeparator + StringUtils.join(arguments, " ");
     }
 
     @Override

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TimeReceivedHandler.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TimeReceivedHandler.java
@@ -35,6 +35,9 @@ public class TimeReceivedHandler implements FormatterLogic {
 
     public TimeReceivedHandler(final String dateFormat) {
         this.dateFormat = StringUtils.isEmpty(dateFormat) ? DEFAULT_DATE_FORMAT : dateFormat;
+
+        // build it here so an exception will be thrown during application startup if the pattern is invalid
+        new SimpleDateFormat(dateFormat);
     }
 
     @Override

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TimeReceivedHandler.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TimeReceivedHandler.java
@@ -19,6 +19,7 @@
  */
 package org.openrepose.commons.utils.logging.apache.format.stock;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openrepose.commons.utils.logging.apache.format.FormatterLogic;
 
 import javax.servlet.http.HttpServletRequest;
@@ -28,8 +29,20 @@ import java.util.Calendar;
 
 public class TimeReceivedHandler implements FormatterLogic {
 
+    private final static String DEFAULT_DATE_FORMAT = "dd-MM-yyyy-HH:mm:ss.SSS";
+
+    private final String dateFormat;
+
+    public TimeReceivedHandler(final String dateFormat) {
+        this.dateFormat = StringUtils.isEmpty(dateFormat) ? DEFAULT_DATE_FORMAT : dateFormat;
+    }
+
     @Override
     public String handle(HttpServletRequest request, HttpServletResponse response) {
-        return new SimpleDateFormat("dd-MM-yyyy-HH:mm:ss.SSS").format(Calendar.getInstance().getTime());
+        return new SimpleDateFormat(dateFormat).format(Calendar.getInstance().getTime());
+    }
+
+    public String getDateFormat() {
+        return dateFormat;
     }
 }

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TimeReceivedHandler.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TimeReceivedHandler.java
@@ -44,8 +44,4 @@ public class TimeReceivedHandler implements FormatterLogic {
     public String handle(HttpServletRequest request, HttpServletResponse response) {
         return new SimpleDateFormat(dateFormat).format(Calendar.getInstance().getTime());
     }
-
-    public String getDateFormat() {
-        return dateFormat;
-    }
 }

--- a/repose-aggregator/commons/utilities/src/test/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatterTest.java
+++ b/repose-aggregator/commons/utilities/src/test/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatterTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.openrepose.commons.utils.http.CommonHttpHeader;
+import org.openrepose.commons.utils.logging.apache.format.FormatArgumentHandler;
 import org.openrepose.commons.utils.logging.apache.format.LogArgumentFormatter;
 import org.openrepose.commons.utils.logging.apache.format.stock.*;
 import org.openrepose.commons.utils.servlet.http.MutableHttpServletResponse;
@@ -98,6 +99,18 @@ public class HttpLogFormatterTest {
 
             assertEquals(expected, formatter.format(request, response));
         }
+
+        @Test
+        public void shouldParseSimpleTimeFormat() {
+            final String defaultDateFormat = "dd-MM-yyyy-HH:mm:ss.SSS";
+
+            final HttpLogFormatter formatter = new HttpLogFormatter("%t");
+
+            assertEquals(1, formatter.getHandlerList().size());
+
+            assertEquals(defaultDateFormat, ((TimeReceivedHandler) ((LogArgumentFormatter)
+                    formatter.getHandlerList().get(0)).getLogic()).getDateFormat());
+        }
     }
 
     public static class WhenParsingComplexArguments {
@@ -131,6 +144,18 @@ public class HttpLogFormatterTest {
             assertEquals(expected, formatter.format(request, response));
             when(response.getStatus()).thenReturn(401);
             assertEquals("-", formatter.format(request, response));
+        }
+
+        @Test
+        public void shouldParseCustomTimeFormat() {
+            final String customDateFormat = "yyyy-MM-dd HH:mm:ss";
+
+            final HttpLogFormatter formatter = new HttpLogFormatter("%{yyyy-MM-dd HH:mm:ss}t");
+
+            assertEquals(1, formatter.getHandlerList().size());
+
+            assertEquals(customDateFormat, ((TimeReceivedHandler) ((LogArgumentFormatter)
+                    formatter.getHandlerList().get(0)).getLogic()).getDateFormat());
         }
     }
 

--- a/repose-aggregator/commons/utilities/src/test/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatterTest.java
+++ b/repose-aggregator/commons/utilities/src/test/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatterTest.java
@@ -32,6 +32,7 @@ import org.openrepose.commons.utils.servlet.http.MutableHttpServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Vector;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -102,14 +103,12 @@ public class HttpLogFormatterTest {
 
         @Test
         public void shouldParseSimpleTimeFormat() {
-            final String defaultDateFormat = "dd-MM-yyyy-HH:mm:ss.SSS";
+            final String defaultDateFormatRegex = "\\d{2}-\\d{2}-\\d{4}-\\d{2}:\\d{2}:\\d{2}\\.\\d{3}";
 
             final HttpLogFormatter formatter = new HttpLogFormatter("%t");
 
             assertEquals(1, formatter.getHandlerList().size());
-
-            assertEquals(defaultDateFormat, ((TimeReceivedHandler) ((LogArgumentFormatter)
-                    formatter.getHandlerList().get(0)).getLogic()).getDateFormat());
+            assertTrue(Pattern.matches(defaultDateFormatRegex, formatter.format(request, response)));
         }
     }
 
@@ -148,14 +147,12 @@ public class HttpLogFormatterTest {
 
         @Test
         public void shouldParseCustomTimeFormat() {
-            final String customDateFormat = "yyyy-MM-dd HH:mm:ss";
+            final String customDateFormatRegex = "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}";
 
             final HttpLogFormatter formatter = new HttpLogFormatter("%{yyyy-MM-dd HH:mm:ss}t");
 
             assertEquals(1, formatter.getHandlerList().size());
-
-            assertEquals(customDateFormat, ((TimeReceivedHandler) ((LogArgumentFormatter)
-                    formatter.getHandlerList().get(0)).getLogic()).getDateFormat());
+            assertTrue(Pattern.matches(customDateFormatRegex, formatter.format(request, response)));
         }
     }
 

--- a/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
+++ b/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
@@ -115,6 +115,8 @@ class CoreSpringProviderTest extends FunSpec with Matchers with TestFilterBundle
          *
          * - Refactor the 'tracing-header' and 'rewrite-tracing-header' System Model attributes to a new tracing
          * element.
+         *
+         * - Update TimeReceivedHandler.DEFAULT_DATE_FORMAT to "yyyy-MM-dd HH:mm:ss"
          */
       }
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/slf4jhttplogging/customdateformat/slf4j-http-logging.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/slf4jhttplogging/customdateformat/slf4j-http-logging.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<slf4j-http-logging xmlns="http://docs.openrepose.org/repose/slf4j-http-logging/v1.0">
+    <!-- The id attribute is the named target of the log output,
+it can then be used in log4j backend to determine which appender to go to -->
+    <!-- The format includes what will be logged. The arguments with % are a subset of the apache mod_log_config
+found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->
+    <slf4j-http-log
+            id="my-special-log"
+            format="Remote User=%u\tURL Path Requested=%U\tRequest Protocol=%H\tServer Port=%p\tQuery String=%q\tResponse Time=%T seconds\tResponse Time=%D microseconds\tRequest Line=&quot;%r&quot;\tTime Request Received=%{yyyy-MM-dd HH:mm:ss}t\tStatus=%s\n"/>
+    <slf4j-http-log id="my-test-log"
+                    format="Remote IP=%a Local IP=%A Request Method=%m Response Code=%s Response Time=%D "/>
+</slf4j-http-logging>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/slf4jhttplogging/invaliddateformat/slf4j-http-logging.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/slf4jhttplogging/invaliddateformat/slf4j-http-logging.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<slf4j-http-logging xmlns="http://docs.openrepose.org/repose/slf4j-http-logging/v1.0">
+    <!-- The id attribute is the named target of the log output,
+it can then be used in log4j backend to determine which appender to go to -->
+    <!-- The format includes what will be logged. The arguments with % are a subset of the apache mod_log_config
+found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->
+    <slf4j-http-log
+            id="my-special-log"
+            format="Remote User=%u\tURL Path Requested=%U\tRequest Protocol=%H\tServer Port=%p\tQuery String=%q\tResponse Time=%T seconds\tResponse Time=%D microseconds\tRequest Line=&quot;%r&quot;\tTime Request Received=%{yyyy/MM/dd HH:mm:ss}t\tStatus=%s\n"/>
+    <slf4j-http-log id="my-test-log"
+                    format="Remote IP=%a Local IP=%A Request Method=%m Response Code=%s Response Time=%D "/>
+</slf4j-http-logging>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingCustomDateFormatTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingCustomDateFormatTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.slf4jlogging
+
+import framework.ReposeLogSearch
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+
+class Slf4jHttpLoggingCustomDateFormatTest extends ReposeValveTest {
+    def setupSpec() {
+        //remove old log
+        def logSearch = new ReposeLogSearch(properties.logFile)
+        logSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/slf4jhttplogging", params)
+        repose.configurationProvider.applyConfigs("features/filters/slf4jhttplogging/customdateformat", params)
+        repose.start()
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort)
+    }
+
+    def "Check slf4log for our custom date format"() {
+        def logSearch = new ReposeLogSearch(properties.logFile)
+        logSearch.cleanLog()
+
+        when:
+        deproxy.makeRequest(url: reposeEndpoint, method: 'GET')
+
+        then:
+        logSearch.searchByString("Time Request Received=\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}").size() == 1
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingInvalidDateFormatTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingInvalidDateFormatTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.slf4jlogging
+
+import framework.ReposeLogSearch
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+
+/**
+ * Created by jennyvo on 8/7/15.
+ */
+class Slf4jHttpLoggingInvalidDateFormatTest extends ReposeValveTest {
+    def setupSpec() {
+        //remove old log
+        def logSearch = new ReposeLogSearch(properties.logFile)
+        logSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/slf4jhttplogging", params)
+        repose.configurationProvider.applyConfigs("features/filters/slf4jhttplogging/invaliddateformat", params)
+        repose.start()
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort)
+    }
+
+    def "Check slf4log for our custom date format"() {
+        def logSearch = new ReposeLogSearch(properties.logFile)
+        logSearch.cleanLog()
+
+        when:
+        deproxy.makeRequest(url: reposeEndpoint, method: 'GET')
+
+        then:
+        logSearch.searchByString("Time Request Received=\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2}").size() == 0
+    }
+}
+

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingTest.groovy
@@ -41,7 +41,6 @@ class Slf4jHttpLoggingTest extends ReposeValveTest {
         repose.start()
         deproxy = new Deproxy()
         deproxy.addEndpoint(properties.targetPort)
-
     }
 
     @Unroll("Test slf4jlog entry with #method")
@@ -55,6 +54,7 @@ class Slf4jHttpLoggingTest extends ReposeValveTest {
         then:
         logSearch.searchByString("Remote IP=127.0.0.1 Local IP=127.0.0.1 Request Method=$method").size() == 1
         logSearch.searchByString("Remote User=null\tURL Path Requested=http://localhost:${properties.targetPort}//\tRequest Protocol=HTTP/1.1").size() == 1
+        logSearch.searchByString("Time Request Received=\\d{2}-\\d{2}-\\d{4}-\\d{2}:\\d{2}:\\d{2}\\.\\d{3}").size() == 1 // default date format
 
         where:
         method << [


### PR DESCRIPTION
The slf4j http logging string already had support for adding a {} between the %t characters, so I added support for putting a date format in there.  Not specifying a format defaults to the current behavior.  A timebomb was added to change the default format in version 8.  Details about the formatting are documented here (under %{format}t):
https://repose.atlassian.net/wiki/display/REPOSE/SLF4J+HTTP+Logging+filter#SLF4JHTTPLoggingfilter-Whatislogged

Functional tests were added to confirm the existing default behavior and to confirm the custom date format behavior.