### PR TITLE
This was found while working on REP-2548 even though it isn't directly related to it.

### DIFF
--- a/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientImpl.java
+++ b/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientImpl.java
@@ -90,34 +90,30 @@ public class AkkaServiceClientImpl implements AkkaServiceClient {
 
     @Override
     public ServiceClientResponse get(String hashKey, String uri, Map<String, String> headers) throws AkkaServiceClientException {
-        ServiceClientResponse serviceClientResponse = null;
         AuthGetRequest authGetRequest = new AuthGetRequest(hashKey, uri, headers);
         try {
             Timeout timeout = new Timeout(serviceClient.getSocketTimeout() + CONNECTION_TIMEOUT_BUFFER_MILLIS, TimeUnit.MILLISECONDS);
             Future<ServiceClientResponse> future = getFuture(authGetRequest, timeout);
-            serviceClientResponse = Await.result(future, timeout.duration());
+            return Await.result(future, timeout.duration());
         } catch (Exception e) {
             LOG.error("Error acquiring value from akka (GET) or the cache. Reason: {}", e.getLocalizedMessage());
             LOG.trace("", e);
             throw new AkkaServiceClientException("Error acquiring value from akka (GET) or the cache.", e);
         }
-        return serviceClientResponse;
     }
 
     @Override
     public ServiceClientResponse post(String hashKey, String uri, Map<String, String> headers, String payload, MediaType contentMediaType) throws AkkaServiceClientException {
-        ServiceClientResponse serviceClientResponse = null;
         AuthPostRequest authPostRequest = new AuthPostRequest(hashKey, uri, headers, payload, contentMediaType);
         try {
             Timeout timeout = new Timeout(serviceClient.getSocketTimeout() + CONNECTION_TIMEOUT_BUFFER_MILLIS, TimeUnit.MILLISECONDS);
             Future<ServiceClientResponse> future = getFuture(authPostRequest, timeout);
-            serviceClientResponse = Await.result(future, timeout.duration());
+            return Await.result(future, timeout.duration());
         } catch (Exception e) {
             LOG.error("Error acquiring value from akka (POST) or the cache. Reason: {}", e.getLocalizedMessage());
             LOG.trace("", e);
             throw new AkkaServiceClientException("Error acquiring value from akka (POST) or the cache.", e);
         }
-        return serviceClientResponse;
     }
 
     private Future getFuture(final ConsistentHashable hashableRequest, final Timeout timeout) throws ExecutionException {


### PR DESCRIPTION
Cleaned up the `AkkaServiceClientImpl` `.get()` and `.post()` methods to more clearly show that a `ServiceClientResponse` is returned or a checked `AkkaServiceClientException` is thrown, but `NULL` is never returned.