### PR TITLE
Rep 2517 session info in tracing header

### DIFF
--- a/repose-aggregator/commons/utilities/pom.xml
+++ b/repose-aggregator/commons/utilities/pom.xml
@@ -64,6 +64,38 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.10</artifactId>
         </dependency>
+
+        <!-- super handy lazy logging! -->
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging-slf4j_2.10</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
     </dependencies>
 </project>
 

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/TracingKey.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/TracingKey.java
@@ -1,0 +1,25 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.commons.utils.logging;
+
+public class TracingKey {
+    public static String TRACING_KEY = "traceGuid";
+}

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatter.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatter.java
@@ -126,7 +126,7 @@ public class HttpLogFormatter {
                 formatter.setLogic(new ResponseMessageHandler(httpLogFormatterState));
                 break;
             case TRACE_GUID:
-                formatter.setLogic(new RequestHeaderHandler(CommonHttpHeader.TRACE_GUID.toString(), extractor.getArguments()));
+                formatter.setLogic(new TraceGuidHandler());
                 break;
         }
     }

--- a/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TraceGuidHandler.java
+++ b/repose-aggregator/commons/utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TraceGuidHandler.java
@@ -1,0 +1,41 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.commons.utils.logging.apache.format.stock;
+
+import org.openrepose.commons.utils.http.CommonHttpHeader;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
+import org.openrepose.commons.utils.logging.apache.format.FormatterLogic;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+
+public class TraceGuidHandler extends HeaderHandler implements FormatterLogic {
+
+    public TraceGuidHandler() {
+        super(CommonHttpHeader.TRACE_GUID.toString(), Collections.<String>emptyList());
+    }
+
+    @Override
+    public String handle(HttpServletRequest request, HttpServletResponse response) {
+        return TracingHeaderHelper.getTraceGuid(getValues(request.getHeaders(getHeaderName())));
+    }
+}

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/logging/TracingHeaderHelper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/logging/TracingHeaderHelper.scala
@@ -41,6 +41,7 @@ object TracingHeaderHelper extends LazyLogging {
   // JSON contents
   private val TraceGuidKey = "requestId"
   private val OriginKey = "origin"
+  private val UserKey = "user"
 
   def getTraceGuid(tracingHeader: String): String = {
     (Option(MDC.get(TracingKey.TRACING_KEY)), Option(tracingHeader)) match {
@@ -58,9 +59,17 @@ object TracingHeaderHelper extends LazyLogging {
   }
 
   def createTracingHeader(requestId: String, origin: String): String = {
+    createTracingHeader(requestId, origin, None)
+  }
+
+  def createTracingHeader(requestId: String, origin: String, user: String): String = {
+    createTracingHeader(requestId, origin, Option(user))
+  }
+
+  def createTracingHeader(requestId: String, origin: String, user: Option[String]): String = {
     Base64.encodeBase64String(
       ObjectMapper.writeValueAsBytes(
-        Map(TraceGuidKey -> requestId, OriginKey -> origin).asJava))
+        (Map(TraceGuidKey -> requestId, OriginKey -> origin) ++ user.map(UserKey -> _)).asJava))
   }
 
   def decode(tracingHeader: String): String = {

--- a/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/logging/TracingHeaderHelper.scala
+++ b/repose-aggregator/commons/utilities/src/main/scala/org/openrepose/commons/utils/logging/TracingHeaderHelper.scala
@@ -1,0 +1,69 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.commons.utils.logging
+
+import java.io.IOException
+import java.util
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.apache.commons.codec.binary.Base64
+import org.slf4j.MDC
+
+import scala.collection.JavaConverters._
+
+object TracingHeaderHelper extends LazyLogging {
+
+  // JSON parsing
+  private val ObjectMapper = new ObjectMapper(new JsonFactory)
+  private val TypeRef = new TypeReference[util.HashMap[String, String]] {}
+
+  // JSON contents
+  private val TraceGuidKey = "requestId"
+  private val OriginKey = "origin"
+
+  def getTraceGuid(tracingHeader: String): String = {
+    (Option(MDC.get(TracingKey.TRACING_KEY)), Option(tracingHeader)) match {
+      case (Some(tracingGuid), _) if tracingGuid.trim.nonEmpty => tracingGuid
+      case (_, None) => null
+      case (_, Some(header)) =>
+        try {
+          ObjectMapper.readValue[util.HashMap[String, String]](decode(tracingHeader), TypeRef).get(TraceGuidKey)
+        } catch {
+          case e: IOException =>
+            logger.debug("Unable to Base64 decode/JSON parse tracing header: {}", header, e)
+            header
+        }
+    }
+  }
+
+  def createTracingHeader(requestId: String, origin: String): String = {
+    Base64.encodeBase64String(
+      ObjectMapper.writeValueAsBytes(
+        Map(TraceGuidKey -> requestId, OriginKey -> origin).asJava))
+  }
+
+  def decode(tracingHeader: String): String = {
+    if (Base64.isBase64(tracingHeader)) new String(Base64.decodeBase64(tracingHeader)) else tracingHeader
+  }
+}

--- a/repose-aggregator/commons/utilities/src/test/groovy/org/openrepose/commons/utils/logging/TracingHeaderHelperTest.groovy
+++ b/repose-aggregator/commons/utilities/src/test/groovy/org/openrepose/commons/utils/logging/TracingHeaderHelperTest.groovy
@@ -1,0 +1,142 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.commons.utils.logging
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import org.apache.commons.codec.binary.Base64
+import org.junit.Before
+import org.slf4j.MDC
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Created by Mario on 8/17/15.
+ */
+class TracingHeaderHelperTest extends Specification {
+
+    @Before
+    def setup() {
+        MDC.clear();
+    }
+
+    @Unroll
+    def 'get Request ID from Base64 encoded JSON string: #jsonContents'() {
+        given:
+        def tracingHeader = Base64.encodeBase64String(JsonOutput.toJson(jsonContents).bytes)
+
+        when:
+        def requestId = TracingHeaderHelper.getTraceGuid(tracingHeader)
+
+        then:
+        requestId == jsonContents.requestId
+
+        where:
+        jsonContents << [
+                [requestId:'5c65235b-06a4-4461-ad09-c1db3dae81b7'],
+                [requestId:'4ceac78d-bf1e-4b18-b788-87da5f05388b', sessionId:'a54b0120-4352-4d53-b89b-a5c328122616'],
+                [requestId:'36a15d3c-b485-4350-84b3-b60327f659fc', sessionId:'bac9ff48-a944-4ee9-816c-a57d0fdb2e3e', user:'bob', domain:'rackspace'],
+                [requestId:'b3082092-ef75-44aa-9597-f7e830304a8b', favoriteFood:'french fries', favoriteSeason:'summer'],
+                [edgeCase:'Request ID Missing']
+        ]
+    }
+
+    @Unroll
+    def 'get Request ID from logging context when it is available despite tracing header contents of #tracingHeader'() {
+        given:
+        MDC.put('traceGuid', uuid)
+
+        when:
+        def requestId = TracingHeaderHelper.getTraceGuid(tracingHeader)
+
+        then:
+        requestId == uuid
+
+        where:
+        uuid                                   | tracingHeader
+        '57d81803-3d80-4fce-a07a-a6b569441dc7' | null
+        'c59d9ea2-4994-4927-a7d2-3234d15062df' | ''
+        '8d0c84fe-9862-4c57-8d88-047338b97a50' | 'potato'
+        'cce4a344-ec37-46f6-a41a-79202d31de07' | 'SV9MSUtFX0hBTQ=='
+        '2f410bd5-686c-43b1-bb23-7068751c3c7c' | '{"requestId":"7fbf1c74-7ba8-44b1-8914-8bb01466af9b"}'
+        '54476536-bb80-45d0-9331-596fe5e98889' | Base64.encodeBase64String(JsonOutput.toJson([requestId:'683229c1-929c-4414-87d4-24693edb7446']).bytes)
+    }
+
+    @Unroll
+    def 'get Request ID from entire string when header is not properly encoded: #tracingHeader'() {
+        when:
+        def requestId = TracingHeaderHelper.getTraceGuid(tracingHeader)
+
+        then:
+        notThrown(Exception)
+        requestId == tracingHeader
+
+        where:
+        tracingHeader << [null, '', 'potato', 'SV9MSUtFX0hBTQ==']
+    }
+
+    def 'get Request ID from entire string when header is a UUID (legacy)'() {
+        given:
+        def uuid = '88c51bb3-2897-47ea-8403-fa1fd5fc17ca'
+
+        when:
+        def requestId = TracingHeaderHelper.getTraceGuid(uuid)
+
+        then:
+        requestId == uuid
+    }
+
+    def 'create Tracing Header from specified Request ID and Origin'() {
+        given:
+        def requestId = '67564a55-1fd0-43f9-ab9c-7055c9334f30'
+        def origin = 'some_via'
+
+        when:
+        def tracingHeader = TracingHeaderHelper.createTracingHeader(requestId, origin)
+
+        then:
+        new JsonSlurper().parseText(new String(Base64.decodeBase64(tracingHeader))).requestId == requestId
+        new JsonSlurper().parseText(new String(Base64.decodeBase64(tracingHeader))).origin == origin
+    }
+
+    def 'decode Tracing Header to printable string'() {
+        given:
+        def jsonString = JsonOutput.toJson([requestId:'4ceac78d-bf1e-4b18-b788-87da5f05388b', sessionId:'a54b0120-4352-4d53-b89b-a5c328122616'])
+        def tracingHeader = Base64.encodeBase64String(jsonString.bytes)
+
+        when:
+        def decodedTracingHeader = TracingHeaderHelper.decode(tracingHeader)
+
+        then:
+        decodedTracingHeader == jsonString
+    }
+
+    def 'decode is skipped and the same string is returned if string is not properly Base64 encoded'() {
+        given:
+        def tracingHeader = '{"requestId":"04721d61-7420-4472-a5a6-ebfa0ac485bd"}'
+
+        when:
+        def decodedTracingHeader = TracingHeaderHelper.decode(tracingHeader)
+
+        then:
+        decodedTracingHeader == tracingHeader
+    }
+}

--- a/repose-aggregator/commons/utilities/src/test/groovy/org/openrepose/commons/utils/logging/TracingHeaderHelperTest.groovy
+++ b/repose-aggregator/commons/utilities/src/test/groovy/org/openrepose/commons/utils/logging/TracingHeaderHelperTest.groovy
@@ -115,6 +115,22 @@ class TracingHeaderHelperTest extends Specification {
         then:
         new JsonSlurper().parseText(new String(Base64.decodeBase64(tracingHeader))).requestId == requestId
         new JsonSlurper().parseText(new String(Base64.decodeBase64(tracingHeader))).origin == origin
+        !new JsonSlurper().parseText(new String(Base64.decodeBase64(tracingHeader))).user
+    }
+
+    def 'create Tracing Header from specified Request ID, Origin, and Username'() {
+        given:
+        def requestId = '67564a55-1fd0-43f9-ab9c-7055c9334f30'
+        def origin = 'some_via'
+        def username = 'Sam'
+
+        when:
+        def tracingHeader = TracingHeaderHelper.createTracingHeader(requestId, origin, username)
+
+        then:
+        new JsonSlurper().parseText(new String(Base64.decodeBase64(tracingHeader))).requestId == requestId
+        new JsonSlurper().parseText(new String(Base64.decodeBase64(tracingHeader))).origin == origin
+        new JsonSlurper().parseText(new String(Base64.decodeBase64(tracingHeader))).user == username
     }
 
     def 'decode Tracing Header to printable string'() {

--- a/repose-aggregator/commons/utilities/src/test/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatterTest.java
+++ b/repose-aggregator/commons/utilities/src/test/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatterTest.java
@@ -368,7 +368,7 @@ public class HttpLogFormatterTest {
 
             httpLogFormatter.setLogic(extractor, formatter);
 
-            assertTrue(formatter.getLogic() instanceof RequestHeaderHandler);
+            assertTrue(formatter.getLogic() instanceof TraceGuidHandler);
         }
     }
 

--- a/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/logging/apache/format/stock/TraceGuidHandlerTest.scala
+++ b/repose-aggregator/commons/utilities/src/test/scala/org/openrepose/commons/utils/logging/apache/format/stock/TraceGuidHandlerTest.scala
@@ -1,0 +1,57 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.commons.utils.logging.apache.format.stock
+
+import java.util.StringTokenizer
+import javax.servlet.http.HttpServletRequest
+
+import org.openrepose.commons.utils.http.CommonHttpHeader
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, BeforeAndAfter, FunSpec}
+
+class TraceGuidHandlerTest extends FunSpec with BeforeAndAfter with Matchers with MockitoSugar {
+  import org.mockito.Mockito.when
+
+  var mockRequest: HttpServletRequest = _
+  var traceGuidHandler: TraceGuidHandler = _
+
+  before {
+    mockRequest = mock[HttpServletRequest]
+    traceGuidHandler = new TraceGuidHandler
+  }
+
+  describe("the trace GUID handler") {
+    List(
+      ("panda", "panda"),
+      ("f229a177-8bd4-4842-889f-1ff8aa70e8da", "f229a177-8bd4-4842-889f-1ff8aa70e8da"),
+      ("eyJyZXF1ZXN0SWQiOiI1Zjg1NDE4OC02OGEyLTQ2N2YtODc0ZS02ZTA4OTM1OTI4MTgifQ==", "5f854188-68a2-467f-874e-6e0893592818")
+    ).foreach { case (tracingHeader, expectedMessage) =>
+        it(s"should convert header $tracingHeader to $expectedMessage") {
+          when(mockRequest.getHeaders(CommonHttpHeader.TRACE_GUID.toString))
+            .thenReturn(new StringTokenizer(tracingHeader).asInstanceOf[java.util.Enumeration[String]])
+
+          val actualMessage = traceGuidHandler.handle(mockRequest, null)
+
+          actualMessage shouldEqual expectedMessage
+        }
+    }
+  }
+}

--- a/repose-aggregator/components/filters/client-auth/pom.xml
+++ b/repose-aggregator/components/filters/client-auth/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.openrepose</groupId>
             <artifactId>auth</artifactId>
             <version>${project.version}</version>

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationHandlerFactory.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationHandlerFactory.java
@@ -26,9 +26,12 @@ import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.http.ServiceClient;
 import org.openrepose.commons.utils.regex.KeyedRegexExtractor;
 import org.openrepose.core.filter.logic.AbstractConfiguredFilterHandlerFactory;
+import org.openrepose.core.services.config.ConfigurationService;
 import org.openrepose.core.services.datastore.Datastore;
+import org.openrepose.core.services.healthcheck.HealthCheckService;
 import org.openrepose.core.services.httpclient.HttpClientService;
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
+import org.openrepose.core.spring.ReposeSpringProperties;
 import org.openrepose.filters.clientauth.atomfeed.AuthFeedReader;
 import org.openrepose.filters.clientauth.atomfeed.FeedListenerManager;
 import org.openrepose.filters.clientauth.atomfeed.sax.SaxAuthFeedReader;
@@ -41,7 +44,9 @@ import org.openrepose.filters.clientauth.config.WhiteList;
 import org.openrepose.filters.clientauth.openstack.OpenStackAuthenticationHandlerFactory;
 import org.openrepose.filters.clientauth.openstack.config.ClientMapping;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,6 +67,7 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
     private static final Long MINIMUM_INTERVAL = new Long("10000");
     private final Datastore datastore;
     private final HttpClientService httpClientService;
+    private final String reposeVersion;
     private AuthenticationHandler authenticationModule;
     private KeyedRegexExtractor<String> accountRegexExtractor = new KeyedRegexExtractor<String>();
     private UriMatcher uriMatcher;
@@ -70,10 +76,11 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
     private boolean isOutboundTracing;
 
 
-    public ClientAuthenticationHandlerFactory(Datastore datastore, HttpClientService httpClientService, AkkaServiceClient akkaServiceClient) {
+    public ClientAuthenticationHandlerFactory(Datastore datastore, HttpClientService httpClientService, AkkaServiceClient akkaServiceClient, String reposeVersion) {
         this.datastore = datastore;
         this.httpClientService = httpClientService;
         this.akkaServiceClient = akkaServiceClient;
+        this.reposeVersion = reposeVersion;
     }
 
     @Override
@@ -174,6 +181,7 @@ public class ClientAuthenticationHandlerFactory extends AbstractConfiguredFilter
                 SaxAuthFeedReader rdr = new SaxAuthFeedReader(
                         new ServiceClient(modifiedConfig.getOpenstackAuth().getConnectionPoolId(), httpClientService),
                         akkaServiceClient,
+                        reposeVersion,
                         feed.getUri(),
                         feed.getId(),
                         isOutboundTracing);

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/FeedCacheInvalidator.java
@@ -19,7 +19,7 @@
  */
 package org.openrepose.filters.clientauth.atomfeed;
 
-import org.openrepose.core.logging.TracingKey;
+import org.openrepose.commons.utils.logging.TracingKey;
 import org.openrepose.core.services.datastore.Datastore;
 import org.openrepose.filters.clientauth.common.AuthGroupCache;
 import org.openrepose.filters.clientauth.common.AuthTokenCache;

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReader.java
@@ -24,6 +24,7 @@ import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.http.ServiceClient;
 import org.openrepose.commons.utils.http.ServiceClientResponse;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
 import org.openrepose.filters.clientauth.atomfeed.*;
 import org.slf4j.LoggerFactory;
@@ -122,7 +123,8 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
         final Map<String, String> headers = new HashMap<>();
 
         if (isOutboundTracing) {
-            headers.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
+            headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
+                    traceID, headers.get(CommonHttpHeader.VIA.toString())));
         }
 
         if (isAuthed) {
@@ -141,7 +143,8 @@ public class SaxAuthFeedReader extends DefaultHandler implements AuthFeedReader 
                         throw new FeedException("Failed to obtain credentials.", e);
                     }
                     if (isOutboundTracing) {
-                        headers.put(CommonHttpHeader.TRACE_GUID.toString(), traceID);
+                        headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
+                                traceID, headers.get(CommonHttpHeader.VIA.toString())));
                     }
                     headers.put(CommonHttpHeader.AUTH_TOKEN.toString(), adminToken);
                     resp = client.get(targetFeed, headers);

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/common/AuthenticationHandler.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/common/AuthenticationHandler.java
@@ -96,11 +96,11 @@ public abstract class AuthenticationHandler extends AbstractFilterLogicHandler {
         this.sendTenantIdQuality = configurables.sendTenantIdQuality();
     }
 
-    protected abstract AuthToken validateToken(ExtractorResult<String> account, String token, String requestGuid) throws AuthServiceException;
+    protected abstract AuthToken validateToken(ExtractorResult<String> account, String token, String tracingHeader) throws AuthServiceException;
 
-    protected abstract AuthGroups getGroups(String group, String requestGuid) throws AuthServiceException;
+    protected abstract AuthGroups getGroups(String group, String tracingHeader) throws AuthServiceException;
 
-    protected abstract String getEndpointsBase64(String token, EndpointsConfiguration endpointsConfiguration, String requestGuid) throws AuthServiceException;
+    protected abstract String getEndpointsBase64(String token, EndpointsConfiguration endpointsConfiguration, String tracingHeader) throws AuthServiceException;
 
     protected abstract FilterDirector processResponse(ReadableHttpServletResponse response);
 

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/common/AuthenticationHandler.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/common/AuthenticationHandler.java
@@ -25,6 +25,7 @@ import org.openrepose.commons.utils.StringUriUtilities;
 import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.http.HttpDate;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
 import org.openrepose.commons.utils.regex.ExtractorResult;
 import org.openrepose.commons.utils.regex.KeyedRegexExtractor;
 import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse;
@@ -139,7 +140,7 @@ public abstract class AuthenticationHandler extends AbstractFilterLogicHandler {
         filterDirector.setFilterAction(FilterAction.RETURN);
         int offset = getCacheOffset();
 
-        final String requestGuid = request.getHeader(CommonHttpHeader.TRACE_GUID.toString());
+        final String requestGuid = TracingHeaderHelper.getTraceGuid(request.getHeader(CommonHttpHeader.TRACE_GUID.toString()));
         final String authToken = request.getHeader(CommonHttpHeader.AUTH_TOKEN.toString());
         ExtractorResult<String> account = null;
         AuthToken token = null;

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHandler.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHandler.java
@@ -116,15 +116,15 @@ public class OpenStackAuthenticationHandler extends AuthenticationHandler {
     }
 
     @Override
-    public AuthToken validateToken(ExtractorResult<String> account, String token, String requestGuid) throws AuthServiceException {
+    public AuthToken validateToken(ExtractorResult<String> account, String token, String tracingHeader) throws AuthServiceException {
         AuthToken authToken = null;
 
         if (account != null) {
-            AuthenticateResponse authResponse = authenticationService.validateToken(account.getResult(), token, requestGuid);
+            AuthenticateResponse authResponse = authenticationService.validateToken(account.getResult(), token, tracingHeader);
             delegationMessage.set(AuthenticationServiceClient.getDelegationMessage()); // Must be set before validateTenant call in case that call overwrites this value
             authToken = validateTenant(authResponse, account.getResult());
         } else {
-            AuthenticateResponse authResp = authenticationService.validateToken(null, token, requestGuid);
+            AuthenticateResponse authResp = authenticationService.validateToken(null, token, tracingHeader);
             delegationMessage.set(AuthenticationServiceClient.getDelegationMessage());
             if (authResp != null) {
                 authToken = new OpenStackToken(authResp);
@@ -136,8 +136,8 @@ public class OpenStackAuthenticationHandler extends AuthenticationHandler {
     }
 
     @Override
-    public AuthGroups getGroups(String group, String requestGuid) throws AuthServiceException {
-        return authenticationService.getGroups(group, requestGuid);
+    public AuthGroups getGroups(String group, String tracingHeader) throws AuthServiceException {
+        return authenticationService.getGroups(group, tracingHeader);
     }
 
     @Override
@@ -187,8 +187,8 @@ public class OpenStackAuthenticationHandler extends AuthenticationHandler {
     }
 
     @Override
-    protected String getEndpointsBase64(String token, EndpointsConfiguration endpointsConfiguration, String requestGuid) throws AuthServiceException {
-        return authenticationService.getBase64EndpointsStringForHeaders(token, endpointsConfiguration.getFormat(), requestGuid);
+    protected String getEndpointsBase64(String token, EndpointsConfiguration endpointsConfiguration, String tracingHeader) throws AuthServiceException {
+        return authenticationService.getBase64EndpointsStringForHeaders(token, endpointsConfiguration.getFormat(), tracingHeader);
     }
 
     @Override

--- a/repose-aggregator/components/filters/client-auth/src/test/groovy/org/openrepose/filters/clientauth/AuthNFilterDeprecationTest.groovy
+++ b/repose-aggregator/components/filters/client-auth/src/test/groovy/org/openrepose/filters/clientauth/AuthNFilterDeprecationTest.groovy
@@ -20,7 +20,7 @@ class AuthNFilterDeprecationTest extends Specification {
 
     def 'logs a deprecation warning upon init'() {
         given:
-        def filter = new ClientAuthenticationFilter(mock(DatastoreService.class), mock(ConfigurationService.class), null, null)
+        def filter = new ClientAuthenticationFilter(mock(DatastoreService.class), mock(ConfigurationService.class), null, null, "0.0.0.0")
 
         when:
         filter.init(new MockFilterConfig())

--- a/repose-aggregator/components/filters/client-auth/src/test/groovy/org/openrepose/filters/clientauth/common/AuthenticationHandlerTest.groovy
+++ b/repose-aggregator/components/filters/client-auth/src/test/groovy/org/openrepose/filters/clientauth/common/AuthenticationHandlerTest.groovy
@@ -71,17 +71,17 @@ class AuthenticationHandlerTest extends Specification {
         }
 
         @Override
-        protected AuthToken validateToken(ExtractorResult<String> account, String token, String requestGuid) {
+        protected AuthToken validateToken(ExtractorResult<String> account, String token, String tracingHeader) {
             return null
         }
 
         @Override
-        protected AuthGroups getGroups(String group, String requestGuid) {
+        protected AuthGroups getGroups(String group, String tracingHeader) {
             return null
         }
 
         @Override
-        protected String getEndpointsBase64(String token, EndpointsConfiguration endpointsConfiguration, String requestGuid) {
+        protected String getEndpointsBase64(String token, EndpointsConfiguration endpointsConfiguration, String tracingHeader) {
             return null
         }
 

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/atomfeed/sax/SaxAuthFeedReaderTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class SaxAuthFeedReaderTest {
+    private static final String REPOSE_VERSION = "0.0.0.0";
     private ServiceClient client;
     private AkkaServiceClient akkaClient;
     private ServiceClientResponse resp1, resp2, resp3;
@@ -73,7 +74,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", false);
+        reader = new SaxAuthFeedReader(client, akkaClient, REPOSE_VERSION, "http://some.junit.test.feed/at/somepath", "atomId", false);
         CacheKeys keys = reader.getCacheKeys("key");
 
         String[] users = {"224277258", //User from atom feed
@@ -89,7 +90,7 @@ public class SaxAuthFeedReaderTest {
 
         resp3 = new ServiceClientResponse(401, null);
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp3);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", false);
+        reader = new SaxAuthFeedReader(client, akkaClient, REPOSE_VERSION, "http://some.junit.test.feed/at/somepath", "atomId", false);
         CacheKeys keys = reader.getCacheKeys("key");
 
         assertThat("Should log 401 with atom feed configured without auth",
@@ -101,7 +102,7 @@ public class SaxAuthFeedReaderTest {
 
         resp3 = new ServiceClientResponse(503, null);
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp3);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", false);
+        reader = new SaxAuthFeedReader(client, akkaClient, REPOSE_VERSION, "http://some.junit.test.feed/at/somepath", "atomId", false);
 
         CacheKeys keys = reader.getCacheKeys("key");
 
@@ -114,7 +115,7 @@ public class SaxAuthFeedReaderTest {
         when(client.get(eq("http://some.junit.test.feed/at/somepath"), anyMap())).thenReturn(resp1);
         when(client.get(eq("https://test.feed.atomhopper.rackspace.com/some/identity/feed/?marker=urn:uuid:b23a9c7f-5489-4fd8-bf10-3292032d805f&limit=25&search=&direction=forward"),
                 anyMap())).thenReturn(resp2);
-        reader = new SaxAuthFeedReader(client, akkaClient, "http://some.junit.test.feed/at/somepath", "atomId", false);
+        reader = new SaxAuthFeedReader(client, akkaClient, REPOSE_VERSION, "http://some.junit.test.feed/at/somepath", "atomId", false);
         CacheKeys keys = reader.getCacheKeys("key");
 
         String[] users = {"224277258", //User from atom feed

--- a/repose-aggregator/components/filters/client-authorization/src/main/java/org/openrepose/filters/authz/RequestAuthorizationHandler.java
+++ b/repose-aggregator/components/filters/client-authorization/src/main/java/org/openrepose/filters/authz/RequestAuthorizationHandler.java
@@ -30,7 +30,6 @@ import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.http.HttpDate;
 import org.openrepose.commons.utils.http.OpenStackServiceHeader;
-import org.openrepose.commons.utils.logging.TracingHeaderHelper;
 import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse;
 import org.openrepose.components.authz.rackspace.config.DelegatingType;
 import org.openrepose.components.authz.rackspace.config.IgnoreTenantRoles;
@@ -88,7 +87,7 @@ public class RequestAuthorizationHandler extends AbstractFilterLogicHandler {
         myDirector.setResponseStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         String message = "Failure in authorization component";
 
-        final String requestGuid = TracingHeaderHelper.getTraceGuid(request.getHeader(CommonHttpHeader.TRACE_GUID.toString()));
+        final String tracingHeader = request.getHeader(CommonHttpHeader.TRACE_GUID.toString());
         final String authenticationToken = request.getHeader(CommonHttpHeader.AUTH_TOKEN.toString());
 
         try {
@@ -98,7 +97,7 @@ public class RequestAuthorizationHandler extends AbstractFilterLogicHandler {
                 LOG.debug(message);
                 myDirector.setResponseStatusCode(HttpServletResponse.SC_UNAUTHORIZED);
             } else if (adminRoleMatchIgnoringCase(request.getHeaders(OpenStackServiceHeader.ROLES.toString())) ||
-                    isEndpointAuthorizedForToken(authenticationToken, requestGuid)) {
+                    isEndpointAuthorizedForToken(authenticationToken, tracingHeader)) {
                 myDirector.setFilterAction(FilterAction.PASS);
             } else {
                 message = "User token: " + authenticationToken +
@@ -157,8 +156,8 @@ public class RequestAuthorizationHandler extends AbstractFilterLogicHandler {
         return false;
     }
 
-    private boolean isEndpointAuthorizedForToken(String userToken, String requestGuid) throws AuthServiceException {
-        List<CachedEndpoint> cachedEndpoints = requestEndpointsForToken(userToken, requestGuid);
+    private boolean isEndpointAuthorizedForToken(String userToken, String tracingHeader) throws AuthServiceException {
+        List<CachedEndpoint> cachedEndpoints = requestEndpointsForToken(userToken, tracingHeader);
         if (cachedEndpoints != null) {
             return !Collections2.filter(cachedEndpoints, forMatchingEndpoint()).isEmpty();
         }
@@ -197,11 +196,11 @@ public class RequestAuthorizationHandler extends AbstractFilterLogicHandler {
         };
     }
 
-    private List<CachedEndpoint> requestEndpointsForToken(String userToken, String requestGuid) throws AuthServiceException {
+    private List<CachedEndpoint> requestEndpointsForToken(String userToken, String tracingHeader) throws AuthServiceException {
         List<CachedEndpoint> cachedEndpoints = endpointListCache.getCachedEndpointsForToken(userToken);
 
         if (cachedEndpoints == null || cachedEndpoints.isEmpty()) {
-            List<Endpoint> authorizedEndpoints = authenticationService.getEndpointsForToken(userToken, requestGuid);
+            List<Endpoint> authorizedEndpoints = authenticationService.getEndpointsForToken(userToken, tracingHeader);
             if (authorizedEndpoints != null) {
                 cachedEndpoints = new LinkedList<>();
                 for (Endpoint ep : authorizedEndpoints) {

--- a/repose-aggregator/components/filters/client-authorization/src/main/java/org/openrepose/filters/authz/RequestAuthorizationHandler.java
+++ b/repose-aggregator/components/filters/client-authorization/src/main/java/org/openrepose/filters/authz/RequestAuthorizationHandler.java
@@ -30,6 +30,7 @@ import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.http.HttpDate;
 import org.openrepose.commons.utils.http.OpenStackServiceHeader;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
 import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse;
 import org.openrepose.components.authz.rackspace.config.DelegatingType;
 import org.openrepose.components.authz.rackspace.config.IgnoreTenantRoles;
@@ -87,7 +88,7 @@ public class RequestAuthorizationHandler extends AbstractFilterLogicHandler {
         myDirector.setResponseStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         String message = "Failure in authorization component";
 
-        final String requestGuid = request.getHeader(CommonHttpHeader.TRACE_GUID.toString());
+        final String requestGuid = TracingHeaderHelper.getTraceGuid(request.getHeader(CommonHttpHeader.TRACE_GUID.toString()));
         final String authenticationToken = request.getHeader(CommonHttpHeader.AUTH_TOKEN.toString());
 
         try {

--- a/repose-aggregator/components/filters/herp/src/main/scala/org/openrepose/filters/herp/HerpFilter.scala
+++ b/repose-aggregator/components/filters/herp/src/main/scala/org/openrepose/filters/herp/HerpFilter.scala
@@ -33,6 +33,7 @@ import com.rackspace.httpdelegation._
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.{CommonHttpHeader, OpenStackServiceHeader}
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.openrepose.core.filter.FilterConfigHelper
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.core.spring.ReposeSpringProperties
@@ -143,7 +144,7 @@ class HerpFilter @Inject()(configurationService: ConfigurationService,
       "timestamp" -> System.currentTimeMillis,
       "responseCode" -> httpServletResponse.getStatus,
       "responseMessage" -> Try(HttpStatus.valueOf(httpServletResponse.getStatus).name).getOrElse("UNKNOWN"),
-      "guid" -> Option(stripHeaderParams(httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString)))
+      "guid" -> Option(stripHeaderParams(TracingHeaderHelper.getTraceGuid(httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString))))
         .getOrElse(java.util.UUID.randomUUID.toString),
       "serviceCode" -> serviceCode,
       "region" -> region,

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Handler.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Handler.scala
@@ -26,7 +26,6 @@ import com.rackspace.httpdelegation.HttpDelegationManager
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.apache.commons.codec.binary.Base64
 import org.openrepose.commons.utils.http._
-import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse
 import org.openrepose.core.filter.logic.common.AbstractFilterLogicHandler
 import org.openrepose.core.filter.logic.impl.FilterDirectorImpl
@@ -101,10 +100,10 @@ class OpenStackIdentityV3Handler(identityConfig: OpenstackIdentityV3Config, iden
       var failureInValidation = false
 
       // Extract the tracing GUID from the request
-      val requestGuid = Option(TracingHeaderHelper.getTraceGuid(request.getHeader(CommonHttpHeader.TRACE_GUID.toString)))
+      val tracingHeader = Option(request.getHeader(CommonHttpHeader.TRACE_GUID.toString))
 
       // Attempt to validate the request token with the Identity service
-      val token = authenticate(request, requestGuid) match {
+      val token = authenticate(request, tracingHeader) match {
         case Success(tokenObject) =>
           Some(tokenObject)
         case Failure(e: InvalidSubjectTokenException) =>
@@ -149,7 +148,7 @@ class OpenStackIdentityV3Handler(identityConfig: OpenstackIdentityV3Config, iden
       // Attempt to fetch groups if configured to do so
       val userGroups = if (!failureInValidation && forwardGroups) {
         token.get.user.id map { userId =>
-          identityAPI.getGroups(userId, requestGuid) match {
+          identityAPI.getGroups(userId, tracingHeader) match {
             case Success(groupsList) =>
               groupsList.map(_.name)
             case Failure(e: IdentityServiceOverLimitException) =>
@@ -239,10 +238,10 @@ class OpenStackIdentityV3Handler(identityConfig: OpenstackIdentityV3Config, iden
     filterDirector
   }
 
-  private def authenticate(request: HttpServletRequest, requestGuid: Option[String] = None): Try[AuthenticateResponse] = {
+  private def authenticate(request: HttpServletRequest, tracingHeader: Option[String] = None): Try[AuthenticateResponse] = {
     Option(request.getHeader(OpenStackIdentityV3Headers.X_SUBJECT_TOKEN)) match {
       case Some(subjectToken) =>
-        identityAPI.validateToken(subjectToken, requestGuid)
+        identityAPI.validateToken(subjectToken, tracingHeader)
       case None =>
         logger.error("No X-Subject-Token present -- a subject token was not provided to validate")
         Failure(new InvalidSubjectTokenException("A subject token was not provided to validate"))

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Handler.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Handler.scala
@@ -26,6 +26,7 @@ import com.rackspace.httpdelegation.HttpDelegationManager
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.apache.commons.codec.binary.Base64
 import org.openrepose.commons.utils.http._
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse
 import org.openrepose.core.filter.logic.common.AbstractFilterLogicHandler
 import org.openrepose.core.filter.logic.impl.FilterDirectorImpl
@@ -100,7 +101,7 @@ class OpenStackIdentityV3Handler(identityConfig: OpenstackIdentityV3Config, iden
       var failureInValidation = false
 
       // Extract the tracing GUID from the request
-      val requestGuid = Option(request.getHeader(CommonHttpHeader.TRACE_GUID.toString))
+      val requestGuid = Option(TracingHeaderHelper.getTraceGuid(request.getHeader(CommonHttpHeader.TRACE_GUID.toString)))
 
       // Attempt to validate the request token with the Identity service
       val token = authenticate(request, requestGuid) match {

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3API.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3API.scala
@@ -94,9 +94,9 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
       case Some(adminToken) if checkCache =>
         Success(adminToken)
       case _ =>
-        val requestGuidHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
+        val requestTracingHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
           .getOrElse(Map())
-        val headerMap = Map(CommonHttpHeader.ACCEPT.toString -> MediaType.APPLICATION_JSON) ++ requestGuidHeader
+        val headerMap = Map(CommonHttpHeader.ACCEPT.toString -> MediaType.APPLICATION_JSON) ++ requestTracingHeader
         val authTokenResponse = Option(akkaServiceClient.post(
           ADMIN_TOKEN_KEY,
           identityServiceUri + TOKEN_ENDPOINT,
@@ -144,13 +144,13 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
       case None =>
         getAdminToken(tracingHeader, checkCache) match {
           case Success(adminToken) =>
-            val requestGuidHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
+            val requestTracingHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
               .getOrElse(Map())
             val headerMap = Map(
               OpenStackIdentityV3Headers.X_AUTH_TOKEN -> adminToken,
               OpenStackIdentityV3Headers.X_SUBJECT_TOKEN -> subjectToken,
               HttpHeaders.ACCEPT -> MediaType.APPLICATION_JSON
-            ) ++ requestGuidHeader
+            ) ++ requestTracingHeader
             val validateTokenResponse = Option(akkaServiceClient.get(
               TOKEN_KEY_PREFIX + subjectToken,
               identityServiceUri + TOKEN_ENDPOINT,
@@ -203,12 +203,12 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
       case None =>
         getAdminToken(tracingHeader, checkCache) match {
           case Success(adminToken) =>
-            val requestGuidHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
+            val requestTracingHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
               .getOrElse(Map())
             val headerMap = Map(
               OpenStackIdentityV3Headers.X_AUTH_TOKEN -> adminToken,
               HttpHeaders.ACCEPT -> MediaType.APPLICATION_JSON
-            ) ++ requestGuidHeader
+            ) ++ requestTracingHeader
             val groupsResponse = Option(akkaServiceClient.get(
               GROUPS_KEY_PREFIX + userId,
               identityServiceUri + GROUPS_ENDPOINT(userId),

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3API.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3API.scala
@@ -58,7 +58,7 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
   private val tokenCacheTtl = config.getTokenCacheTimeout
   private val groupsCacheTtl = config.getGroupsCacheTimeout
 
-  def getAdminToken(requestGuid: Option[String] = None, checkCache: Boolean = true): Try[String] = {
+  def getAdminToken(tracingHeader: Option[String] = None, checkCache: Boolean = true): Try[String] = {
     def createAdminAuthRequest() = {
       val username = config.getOpenstackIdentityService.getUsername
       val password = config.getOpenstackIdentityService.getPassword
@@ -94,7 +94,7 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
       case Some(adminToken) if checkCache =>
         Success(adminToken)
       case _ =>
-        val requestGuidHeader = requestGuid.map(guid => Map(CommonHttpHeader.TRACE_GUID.toString -> guid))
+        val requestGuidHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
           .getOrElse(Map())
         val headerMap = Map(CommonHttpHeader.ACCEPT.toString -> MediaType.APPLICATION_JSON) ++ requestGuidHeader
         val authTokenResponse = Option(akkaServiceClient.post(
@@ -137,14 +137,14 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
     }
   }
 
-  def validateToken(subjectToken: String, requestGuid: Option[String] = None, checkCache: Boolean = true): Try[AuthenticateResponse] = {
+  def validateToken(subjectToken: String, tracingHeader: Option[String] = None, checkCache: Boolean = true): Try[AuthenticateResponse] = {
     getFromCache[AuthenticateResponse](TOKEN_KEY_PREFIX + subjectToken) match {
       case Some(cachedSubjectTokenObject) =>
         Success(cachedSubjectTokenObject)
       case None =>
-        getAdminToken(requestGuid, checkCache) match {
+        getAdminToken(tracingHeader, checkCache) match {
           case Success(adminToken) =>
-            val requestGuidHeader = requestGuid.map(guid => Map(CommonHttpHeader.TRACE_GUID.toString -> guid))
+            val requestGuidHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
               .getOrElse(Map())
             val headerMap = Map(
               OpenStackIdentityV3Headers.X_AUTH_TOKEN -> adminToken,
@@ -177,7 +177,7 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
                 Failure(new InvalidSubjectTokenException("Failed to validate subject token"))
               case Some(statusCode) if statusCode == HttpServletResponse.SC_UNAUTHORIZED && checkCache =>
                 logger.error("Request made with an expired admin token. Fetching a fresh admin token and retrying token validation. Response Code: 401")
-                validateToken(subjectToken, requestGuid, checkCache = false)
+                validateToken(subjectToken, tracingHeader, checkCache = false)
               case Some(statusCode) if statusCode == HttpServletResponse.SC_UNAUTHORIZED && !checkCache =>
                 logger.error(s"Retry after fetching a new admin token failed. Aborting subject token validation for: '${subjectToken}'")
                 Failure(new IdentityServiceException("Valid admin token could not be fetched"))
@@ -196,14 +196,14 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
     }
   }
 
-  def getGroups(userId: String, requestGuid: Option[String] = None, checkCache: Boolean = true): Try[List[Group]] = {
+  def getGroups(userId: String, tracingHeader: Option[String] = None, checkCache: Boolean = true): Try[List[Group]] = {
     getFromCache[mutable.ArrayBuffer[Group]](GROUPS_KEY_PREFIX + userId) match {
       case Some(cachedGroups) =>
         Success(cachedGroups.toList)
       case None =>
-        getAdminToken(requestGuid, checkCache) match {
+        getAdminToken(tracingHeader, checkCache) match {
           case Success(adminToken) =>
-            val requestGuidHeader = requestGuid.map(guid => Map(CommonHttpHeader.TRACE_GUID.toString -> guid))
+            val requestGuidHeader = tracingHeader.map(headerValue => Map(CommonHttpHeader.TRACE_GUID.toString -> headerValue))
               .getOrElse(Map())
             val headerMap = Map(
               OpenStackIdentityV3Headers.X_AUTH_TOKEN -> adminToken,
@@ -238,7 +238,7 @@ class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datas
                 Failure(new InvalidUserForGroupsException("Failed to fetch groups"))
               case Some(statusCode) if statusCode == HttpServletResponse.SC_UNAUTHORIZED && checkCache =>
                 logger.error("Request made with an expired admin token. Fetching a fresh admin token and retrying groups retrieval. Response Code: 401")
-                getGroups(userId, requestGuid, checkCache = false)
+                getGroups(userId, tracingHeader, checkCache = false)
               case Some(statusCode) if statusCode == HttpServletResponse.SC_UNAUTHORIZED && !checkCache =>
                 logger.error(s"Retry after fetching a new admin token failed. Aborting groups retrieval for: '${userId}'")
                 Failure(new IdentityServiceException("Valid admin token could not be fetched"))

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauth/RackspaceIdentityBasicAuthFilter.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauth/RackspaceIdentityBasicAuthFilter.scala
@@ -153,11 +153,11 @@ class RackspaceIdentityBasicAuthFilter @Inject()(configurationService: Configura
         TokenCreationInfo(HttpServletResponse.SC_UNAUTHORIZED, None, userName, "0")
       } else {
         // Request a User Token based on the extracted User Name/API Key.
-        val requestGuidHeader = Option(httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString))
+        val requestTracingHeader = Option(httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString))
           .map(guid => Map(CommonHttpHeader.TRACE_GUID.toString -> guid)).getOrElse(Map())
         val authTokenResponse = Option(akkaServiceClient.post(authValue,
           identityServiceUri,
-          Map[String, String]().++(requestGuidHeader).asJava,
+          Map[String, String]().++(requestTracingHeader).asJava,
           createAuthRequest(authValue).toString(),
           MediaType.APPLICATION_XML_TYPE))
 

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauth/RackspaceIdentityBasicAuthFilter.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauth/RackspaceIdentityBasicAuthFilter.scala
@@ -32,7 +32,6 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.apache.commons.lang3.StringUtils
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.{CommonHttpHeader, HttpDate}
-import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse
 import org.openrepose.core.filter.FilterConfigHelper
 import org.openrepose.core.filter.logic.common.AbstractFilterLogicHandler
@@ -154,8 +153,7 @@ class RackspaceIdentityBasicAuthFilter @Inject()(configurationService: Configura
         TokenCreationInfo(HttpServletResponse.SC_UNAUTHORIZED, None, userName, "0")
       } else {
         // Request a User Token based on the extracted User Name/API Key.
-        val requestGuidHeader = Option(TracingHeaderHelper.getTraceGuid(
-          httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString)))
+        val requestGuidHeader = Option(httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString))
           .map(guid => Map(CommonHttpHeader.TRACE_GUID.toString -> guid)).getOrElse(Map())
         val authTokenResponse = Option(akkaServiceClient.post(authValue,
           identityServiceUri,

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauth/RackspaceIdentityBasicAuthFilter.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauth/RackspaceIdentityBasicAuthFilter.scala
@@ -32,6 +32,7 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.apache.commons.lang3.StringUtils
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.{CommonHttpHeader, HttpDate}
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse
 import org.openrepose.core.filter.FilterConfigHelper
 import org.openrepose.core.filter.logic.common.AbstractFilterLogicHandler
@@ -153,7 +154,8 @@ class RackspaceIdentityBasicAuthFilter @Inject()(configurationService: Configura
         TokenCreationInfo(HttpServletResponse.SC_UNAUTHORIZED, None, userName, "0")
       } else {
         // Request a User Token based on the extracted User Name/API Key.
-        val requestGuidHeader = Option(httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString))
+        val requestGuidHeader = Option(TracingHeaderHelper.getTraceGuid(
+          httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString)))
           .map(guid => Map(CommonHttpHeader.TRACE_GUID.toString -> guid)).getOrElse(Map())
         val authTokenResponse = Option(akkaServiceClient.post(authValue,
           identityServiceUri,

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/nodeservice/httpcomponent/RequestProxyServiceImpl.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/nodeservice/httpcomponent/RequestProxyServiceImpl.java
@@ -205,8 +205,9 @@ public class RequestProxyServiceImpl implements RequestProxyService {
         String traceGUID = MDC.get(TracingKey.TRACING_KEY);
         if (!StringUtils.isEmpty(traceGUID)) {
             Header viaHeader = base.getFirstHeader(CommonHttpHeader.VIA.toString());
-            base.addHeader(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
-                    traceGUID, viaHeader != null ? viaHeader.getValue() : null));
+            base.addHeader(CommonHttpHeader.TRACE_GUID.toString(),
+                    TracingHeaderHelper.createTracingHeader(traceGUID, viaHeader != null ? viaHeader.getValue() : null)
+            );
         }
     }
 

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/nodeservice/httpcomponent/RequestProxyServiceImpl.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/nodeservice/httpcomponent/RequestProxyServiceImpl.java
@@ -22,6 +22,7 @@ package org.openrepose.nodeservice.httpcomponent;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -36,9 +37,10 @@ import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.http.ServiceClientResponse;
 import org.openrepose.commons.utils.io.RawInputStreamReader;
 import org.openrepose.commons.utils.io.stream.ReadLimitReachedException;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
+import org.openrepose.commons.utils.logging.TracingKey;
 import org.openrepose.commons.utils.proxy.ProxyRequestException;
 import org.openrepose.core.filter.SystemModelInterrogator;
-import org.openrepose.core.logging.TracingKey;
 import org.openrepose.core.proxy.HttpException;
 import org.openrepose.core.services.RequestProxyService;
 import org.openrepose.core.services.config.ConfigurationService;
@@ -202,7 +204,9 @@ public class RequestProxyServiceImpl implements RequestProxyService {
         //Tack on the tracing ID for requests via the dist datastore
         String traceGUID = MDC.get(TracingKey.TRACING_KEY);
         if (!StringUtils.isEmpty(traceGUID)) {
-            base.addHeader(CommonHttpHeader.TRACE_GUID.toString(), traceGUID);
+            Header viaHeader = base.getFirstHeader(CommonHttpHeader.VIA.toString());
+            base.addHeader(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
+                    traceGUID, viaHeader != null ? viaHeader.getValue() : null));
         }
     }
 

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilter.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilter.java
@@ -23,11 +23,12 @@ import com.google.common.base.Optional;
 import org.openrepose.commons.config.manager.UpdateListener;
 import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.http.CommonHttpHeader;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
+import org.openrepose.commons.utils.logging.TracingKey;
 import org.openrepose.commons.utils.servlet.http.MutableHttpServletRequest;
 import org.openrepose.commons.utils.servlet.http.MutableHttpServletResponse;
 import org.openrepose.core.ResponseCode;
 import org.openrepose.core.filter.SystemModelInterrogator;
-import org.openrepose.core.logging.TracingKey;
 import org.openrepose.core.proxy.ServletContextWrapper;
 import org.openrepose.core.services.RequestProxyService;
 import org.openrepose.core.services.config.ConfigurationService;
@@ -361,7 +362,8 @@ public class PowerFilter extends DelegatingFilterProxy {
         if (StringUtilities.isBlank(mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString()))) {
             traceGUID = UUID.randomUUID().toString();
         } else {
-            traceGUID = mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString());
+            traceGUID = TracingHeaderHelper.getTraceGuid(
+                    mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString()));
         }
 
         MDC.put(TracingKey.TRACING_KEY, traceGUID);
@@ -379,10 +381,12 @@ public class PowerFilter extends DelegatingFilterProxy {
                 if (currentSystemModel.get().isTracingHeader()) {
                     if (StringUtilities.isBlank(mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString()))) {
                         mutableHttpRequest.addHeader(CommonHttpHeader.TRACE_GUID.toString(),
-                                traceGUID);
+                                TracingHeaderHelper.createTracingHeader(
+                                        traceGUID, mutableHttpRequest.getHeader(CommonHttpHeader.VIA.toString())));
                     }
-                    mutableHttpResponse.addHeader(CommonHttpHeader.TRACE_GUID.toString(),
-                            mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString()));
+                    String tracingHeader = mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString());
+                    LOG.info("Tracing header: {}", TracingHeaderHelper.decode(tracingHeader));
+                    mutableHttpResponse.addHeader(CommonHttpHeader.TRACE_GUID.toString(), tracingHeader);
                 }
                 requestFilterChain.startFilterChain(mutableHttpRequest, mutableHttpResponse);
             }

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilter.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilter.java
@@ -381,8 +381,7 @@ public class PowerFilter extends DelegatingFilterProxy {
                 if (currentSystemModel.get().isTracingHeader()) {
                     if (StringUtilities.isBlank(mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString()))) {
                         mutableHttpRequest.addHeader(CommonHttpHeader.TRACE_GUID.toString(),
-                                TracingHeaderHelper.createTracingHeader(
-                                        traceGUID, mutableHttpRequest.getHeader(CommonHttpHeader.VIA.toString())));
+                                TracingHeaderHelper.createTracingHeader(traceGUID, mutableHttpRequest.getHeader(CommonHttpHeader.VIA.toString())));
                     }
                     String tracingHeader = mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString());
                     LOG.info("Tracing header: {}", TracingHeaderHelper.decode(tracingHeader));

--- a/repose-aggregator/core/core-lib/src/test/groovy/org/openrepose/nodeservice/httpcomponent/RequestProxyServiceImplTest.groovy
+++ b/repose-aggregator/core/core-lib/src/test/groovy/org/openrepose/nodeservice/httpcomponent/RequestProxyServiceImplTest.groovy
@@ -27,7 +27,8 @@ import org.apache.http.client.methods.HttpPatch
 import org.apache.logging.log4j.ThreadContext
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
-import org.openrepose.core.logging.TracingKey
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
+import org.openrepose.commons.utils.logging.TracingKey
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.core.services.healthcheck.HealthCheckService
 import org.openrepose.core.services.httpclient.HttpClientResponse
@@ -113,7 +114,7 @@ class RequestProxyServiceImplTest extends Specification {
         request.getMethod() == "PATCH"
         request.getURI().toString() == "http://www.google.com/key"
         request.getHeaders("thing").first().value == "other thing"
-        request.getHeaders("X-Trans-Id").first().value == "LOLOL"
+        TracingHeaderHelper.getTraceGuid(request.getHeaders("X-Trans-Id").first().value) == "LOLOL"
         readBytes == sentBytes
 
         response.status == 418

--- a/repose-aggregator/core/core-service-api/src/main/java/org/openrepose/core/logging/TracingKey.java
+++ b/repose-aggregator/core/core-service-api/src/main/java/org/openrepose/core/logging/TracingKey.java
@@ -1,5 +1,0 @@
-package org.openrepose.core.logging;
-
-public class TracingKey {
-    public static String TRACING_KEY = "traceGuid";
-}

--- a/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/openstack/AuthenticationService.java
+++ b/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/openstack/AuthenticationService.java
@@ -28,11 +28,11 @@ import java.util.List;
 
 public interface AuthenticationService {
 
-    AuthenticateResponse validateToken(String tenant, String userToken, String requestGuid) throws AuthServiceException;
+    AuthenticateResponse validateToken(String tenant, String userToken, String tracingHeader) throws AuthServiceException;
 
-    List<Endpoint> getEndpointsForToken(String userToken, String requestGuid) throws AuthServiceException;
+    List<Endpoint> getEndpointsForToken(String userToken, String tracingHeader) throws AuthServiceException;
 
-    AuthGroups getGroups(String userId, String requestGuid) throws AuthServiceException;
+    AuthGroups getGroups(String userId, String tracingHeader) throws AuthServiceException;
 
-    String getBase64EndpointsStringForHeaders(String userToken, String format, String requestGuid) throws AuthServiceException;
+    String getBase64EndpointsStringForHeaders(String userToken, String format, String tracingHeader) throws AuthServiceException;
 }

--- a/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/openstack/AuthenticationServiceClient.java
+++ b/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/openstack/AuthenticationServiceClient.java
@@ -31,6 +31,7 @@ import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.http.HttpDate;
 import org.openrepose.commons.utils.http.ServiceClientResponse;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
 import org.openrepose.commons.utils.transform.jaxb.JaxbEntityToXml;
 import org.openrepose.core.filter.logic.FilterDirector;
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
@@ -160,7 +161,8 @@ public class AuthenticationServiceClient implements AuthenticationService {
         headers.put(ACCEPT_HEADER, MediaType.APPLICATION_XML);
         headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, force));
         if (requestGuid != null) {
-            headers.put(CommonHttpHeader.TRACE_GUID.toString(), requestGuid);
+            headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
+                    requestGuid, headers.get(CommonHttpHeader.VIA.toString())));
         }
         try {
             return akkaServiceClient.get(TOKEN_PREFIX + userToken, targetHostUri + TOKENS + userToken, headers);
@@ -179,7 +181,8 @@ public class AuthenticationServiceClient implements AuthenticationService {
             headers.put(ACCEPT_HEADER, MediaType.APPLICATION_XML);
             headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, false));
             if (requestGuid != null) {
-                headers.put(CommonHttpHeader.TRACE_GUID.toString(), requestGuid);
+                headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
+                        requestGuid, headers.get(CommonHttpHeader.VIA.toString())));
             }
 
             ServiceClientResponse endpointListResponse = akkaServiceClient.get(ENDPOINTS_PREFIX + userToken, targetHostUri + TOKENS + userToken + ENDPOINTS, headers);
@@ -237,7 +240,8 @@ public class AuthenticationServiceClient implements AuthenticationService {
             headers.put(ACCEPT_HEADER, format);
             headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, false));
             if (requestGuid != null) {
-                headers.put(CommonHttpHeader.TRACE_GUID.toString(), requestGuid);
+                headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
+                        requestGuid, headers.get(CommonHttpHeader.VIA.toString())));
             }
 
             ServiceClientResponse serviceClientResponse = akkaServiceClient.get(ENDPOINTS_PREFIX + userToken,
@@ -311,7 +315,8 @@ public class AuthenticationServiceClient implements AuthenticationService {
             headers.put(ACCEPT_HEADER, MediaType.APPLICATION_XML);
             headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, false));
             if (requestGuid != null) {
-                headers.put(CommonHttpHeader.TRACE_GUID.toString(), requestGuid);
+                headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
+                        requestGuid, headers.get(CommonHttpHeader.VIA.toString())));
             }
 
             ServiceClientResponse serviceResponse = akkaServiceClient.get(GROUPS_PREFIX + userId, targetHostUri + "/users/" + userId + "/RAX-KSGRP", headers);
@@ -377,7 +382,8 @@ public class AuthenticationServiceClient implements AuthenticationService {
             if (adminToken == null) {
                 Map<String, String> headerMap = new HashMap<>();
                 if (!StringUtilities.isEmpty(requestGuid)) {
-                    headerMap.put(CommonHttpHeader.TRACE_GUID.toString(), requestGuid);
+                    headerMap.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
+                            requestGuid, headerMap.get(CommonHttpHeader.VIA.toString())));
                 }
                 final ServiceClientResponse serviceResponse = akkaServiceClient.post(AdminToken.CACHE_KEY,
                         targetHostUri + "/tokens",

--- a/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/openstack/AuthenticationServiceClient.java
+++ b/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/openstack/AuthenticationServiceClient.java
@@ -31,7 +31,6 @@ import org.openrepose.commons.utils.StringUtilities;
 import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.http.HttpDate;
 import org.openrepose.commons.utils.http.ServiceClientResponse;
-import org.openrepose.commons.utils.logging.TracingHeaderHelper;
 import org.openrepose.commons.utils.transform.jaxb.JaxbEntityToXml;
 import org.openrepose.core.filter.logic.FilterDirector;
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
@@ -112,9 +111,9 @@ public class AuthenticationServiceClient implements AuthenticationService {
     }
 
     @Override
-    public AuthenticateResponse validateToken(String tenant, String userToken, String requestGuid) throws AuthServiceException {
+    public AuthenticateResponse validateToken(String tenant, String userToken, String tracingHeader) throws AuthServiceException {
         AuthenticateResponse authenticateResponse = null;
-        ServiceClientResponse serviceResponse = validateUser(userToken, tenant, false, requestGuid);
+        ServiceClientResponse serviceResponse = validateUser(userToken, tenant, false, tracingHeader);
 
         switch (serviceResponse.getStatus()) {
             case HttpServletResponse.SC_OK:
@@ -130,7 +129,7 @@ public class AuthenticationServiceClient implements AuthenticationService {
             case HttpServletResponse.SC_UNAUTHORIZED:
                 LOG.error("Unable to validate token: " + userToken + " due to status code: " + serviceResponse.getStatus() + " :admin token expired. Retrieving new admin token and retrying token validation...");
 
-                serviceResponse = validateUser(userToken, tenant, true, requestGuid);
+                serviceResponse = validateUser(userToken, tenant, true, tracingHeader);
 
                 if (serviceResponse.getStatus() == HttpServletResponse.SC_OK) {
                     authenticateResponse = openStackCoreResponseUnmarshaller.unmarshall(serviceResponse.getData(), AuthenticateResponse.class);
@@ -156,13 +155,12 @@ public class AuthenticationServiceClient implements AuthenticationService {
         return authenticateResponse;
     }
 
-    private ServiceClientResponse validateUser(String userToken, String tenant, boolean force, String requestGuid) throws AuthServiceException {
+    private ServiceClientResponse validateUser(String userToken, String tenant, boolean force, String tracingHeader) throws AuthServiceException {
         final Map<String, String> headers = new HashMap<>();
         headers.put(ACCEPT_HEADER, MediaType.APPLICATION_XML);
-        headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, force));
-        if (requestGuid != null) {
-            headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
-                    requestGuid, headers.get(CommonHttpHeader.VIA.toString())));
+        headers.put(AUTH_TOKEN_HEADER, getAdminToken(tracingHeader, force));
+        if (tracingHeader != null) {
+            headers.put(CommonHttpHeader.TRACE_GUID.toString(), tracingHeader);
         }
         try {
             return akkaServiceClient.get(TOKEN_PREFIX + userToken, targetHostUri + TOKENS + userToken, headers);
@@ -172,17 +170,16 @@ public class AuthenticationServiceClient implements AuthenticationService {
     }
 
     @Override
-    public List<Endpoint> getEndpointsForToken(String userToken, String requestGuid) throws AuthServiceException {
+    public List<Endpoint> getEndpointsForToken(String userToken, String tracingHeader) throws AuthServiceException {
         final Map<String, String> headers = new HashMap<>();
 
         List<Endpoint> endpointList;
 
         try {
             headers.put(ACCEPT_HEADER, MediaType.APPLICATION_XML);
-            headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, false));
-            if (requestGuid != null) {
-                headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
-                        requestGuid, headers.get(CommonHttpHeader.VIA.toString())));
+            headers.put(AUTH_TOKEN_HEADER, getAdminToken(tracingHeader, false));
+            if (tracingHeader != null) {
+                headers.put(CommonHttpHeader.TRACE_GUID.toString(), tracingHeader);
             }
 
             ServiceClientResponse endpointListResponse = akkaServiceClient.get(ENDPOINTS_PREFIX + userToken, targetHostUri + TOKENS + userToken + ENDPOINTS, headers);
@@ -195,7 +192,7 @@ public class AuthenticationServiceClient implements AuthenticationService {
                     LOG.error("Unable to get endpoints for user: " + endpointListResponse.getStatus() + " :admin token expired. " +
                             "Retrieving new admin token and retrying endpoints retrieval...");
 
-                    headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, true));
+                    headers.put(AUTH_TOKEN_HEADER, getAdminToken(tracingHeader, true));
                     endpointListResponse = akkaServiceClient.get(ENDPOINTS_PREFIX + userToken, targetHostUri + TOKENS + userToken + ENDPOINTS, headers);
 
                     if (endpointListResponse.getStatus() == HttpServletResponse.SC_OK) {
@@ -224,7 +221,7 @@ public class AuthenticationServiceClient implements AuthenticationService {
 
     // Method to take in the format and token, then use that info to get the endpoints catalog from auth, and return it encoded.
     @Override
-    public String getBase64EndpointsStringForHeaders(String userToken, String format, String requestGuid) throws AuthServiceException {
+    public String getBase64EndpointsStringForHeaders(String userToken, String format, String tracingHeader) throws AuthServiceException {
         final Map<String, String> headers = new HashMap<>();
 
         //defaulting to json format
@@ -238,10 +235,9 @@ public class AuthenticationServiceClient implements AuthenticationService {
         try {
             //telling the service what format to send the endpoints to us in
             headers.put(ACCEPT_HEADER, format);
-            headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, false));
-            if (requestGuid != null) {
-                headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
-                        requestGuid, headers.get(CommonHttpHeader.VIA.toString())));
+            headers.put(AUTH_TOKEN_HEADER, getAdminToken(tracingHeader, false));
+            if (tracingHeader != null) {
+                headers.put(CommonHttpHeader.TRACE_GUID.toString(), tracingHeader);
             }
 
             ServiceClientResponse serviceClientResponse = akkaServiceClient.get(ENDPOINTS_PREFIX + userToken,
@@ -254,7 +250,7 @@ public class AuthenticationServiceClient implements AuthenticationService {
                 case HttpServletResponse.SC_UNAUTHORIZED:
                     LOG.error("Unable to get endpoints for user: " + serviceClientResponse.getStatus() + " :admin token expired. Retrieving new admin token and retrying endpoints retrieval...");
 
-                    headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, true));
+                    headers.put(AUTH_TOKEN_HEADER, getAdminToken(tracingHeader, true));
                     serviceClientResponse = akkaServiceClient.get(ENDPOINTS_PREFIX + userToken, targetHostUri + TOKENS + userToken + ENDPOINTS, headers);
 
                     if (serviceClientResponse.getStatus() == HttpServletResponse.SC_ACCEPTED) {
@@ -306,17 +302,16 @@ public class AuthenticationServiceClient implements AuthenticationService {
     }
 
     @Override
-    public AuthGroups getGroups(String userId, String requestGuid) throws AuthServiceException {
+    public AuthGroups getGroups(String userId, String tracingHeader) throws AuthServiceException {
         final Map<String, String> headers = new HashMap<>();
 
         AuthGroups authGroups;
 
         try {
             headers.put(ACCEPT_HEADER, MediaType.APPLICATION_XML);
-            headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, false));
-            if (requestGuid != null) {
-                headers.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
-                        requestGuid, headers.get(CommonHttpHeader.VIA.toString())));
+            headers.put(AUTH_TOKEN_HEADER, getAdminToken(tracingHeader, false));
+            if (tracingHeader != null) {
+                headers.put(CommonHttpHeader.TRACE_GUID.toString(), tracingHeader);
             }
 
             ServiceClientResponse serviceResponse = akkaServiceClient.get(GROUPS_PREFIX + userId, targetHostUri + "/users/" + userId + "/RAX-KSGRP", headers);
@@ -328,7 +323,7 @@ public class AuthenticationServiceClient implements AuthenticationService {
                 case HttpServletResponse.SC_UNAUTHORIZED:
                     LOG.error("Unable to get groups for user: " + serviceResponse.getStatus() + " :admin token expired. Retrieving new admin token and retrying groups retrieval...");
 
-                    headers.put(AUTH_TOKEN_HEADER, getAdminToken(requestGuid, true));
+                    headers.put(AUTH_TOKEN_HEADER, getAdminToken(tracingHeader, true));
 
                     serviceResponse = akkaServiceClient.get(GROUPS_PREFIX + userId, targetHostUri + "/users/" + userId + "/RAX-KSGRP", headers);
 
@@ -374,16 +369,15 @@ public class AuthenticationServiceClient implements AuthenticationService {
         }
     }
 
-    private String getAdminToken(String requestGuid, boolean force) throws AuthServiceException {
+    private String getAdminToken(String tracingHeader, boolean force) throws AuthServiceException {
 
         String adminToken = !force && currentAdminToken != null && currentAdminToken.isValid() ? currentAdminToken.getToken() : null;
 
         try {
             if (adminToken == null) {
                 Map<String, String> headerMap = new HashMap<>();
-                if (!StringUtilities.isEmpty(requestGuid)) {
-                    headerMap.put(CommonHttpHeader.TRACE_GUID.toString(), TracingHeaderHelper.createTracingHeader(
-                            requestGuid, headerMap.get(CommonHttpHeader.VIA.toString())));
+                if (!StringUtilities.isEmpty(tracingHeader)) {
+                    headerMap.put(CommonHttpHeader.TRACE_GUID.toString(), tracingHeader);
                 }
                 final ServiceClientResponse serviceResponse = akkaServiceClient.post(AdminToken.CACHE_KEY,
                         targetHostUri + "/tokens",

--- a/repose-aggregator/external/service-clients/auth/src/test/groovy/org/openrepose/common/auth/openstack/AuthenticationServiceClientTest.groovy
+++ b/repose-aggregator/external/service-clients/auth/src/test/groovy/org/openrepose/common/auth/openstack/AuthenticationServiceClientTest.groovy
@@ -32,7 +32,6 @@ import org.openrepose.common.auth.AuthServiceOverLimitException
 import org.openrepose.common.auth.ResponseUnmarshaller
 import org.openrepose.commons.utils.http.CommonHttpHeader
 import org.openrepose.commons.utils.http.ServiceClientResponse
-import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.openrepose.commons.utils.transform.jaxb.JaxbEntityToXml
 import org.openrepose.core.filter.logic.FilterDirector
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient
@@ -187,8 +186,7 @@ class AuthenticationServiceClientTest extends Specification {
 
         def akkaServiceClient = mock(AkkaServiceClient)
         mockAdminTokenRequest(akkaServiceClient, admin)
-        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": admin.token,
-                           (CommonHttpHeader.TRACE_GUID.toString()): TracingHeaderHelper.createTracingHeader("", null)]
+        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": admin.token, (CommonHttpHeader.TRACE_GUID.toString()): ""]
         when(akkaServiceClient.get("TOKEN:${userToValidate.token}", "http://some/uri/tokens/${userToValidate.token}", authHeaders))
                 .thenAnswer(new Answer() {
             def increment = 0
@@ -223,8 +221,7 @@ class AuthenticationServiceClientTest extends Specification {
 
         def akkaServiceClient = mock(AkkaServiceClient)
         mockAdminTokenRequest(akkaServiceClient, admin, 200)
-        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": admin.token,
-                           (CommonHttpHeader.TRACE_GUID.toString()): TracingHeaderHelper.createTracingHeader("", null)]
+        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": admin.token, (CommonHttpHeader.TRACE_GUID.toString()): ""]
         when(akkaServiceClient.get("TOKEN:${userToValidate.token}", "http://some/uri/tokens/${userToValidate.token}", authHeaders))
                 .thenAnswer(new Answer() {
             def increment = 0
@@ -347,8 +344,7 @@ class AuthenticationServiceClientTest extends Specification {
     }
 
     private void mockUserEndpointRequest(AkkaServiceClient akkaServiceClient, String adminToken, LinkedHashMap<String, String> userToValidate, int responseCode = 200, int timesCalled = 1) {
-        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": adminToken,
-                           (CommonHttpHeader.TRACE_GUID.toString()): TracingHeaderHelper.createTracingHeader("", null)]
+        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": adminToken, (CommonHttpHeader.TRACE_GUID.toString()): ""]
         when(akkaServiceClient.get("ENDPOINTS${userToValidate.token}", "http://some/uri/tokens/${userToValidate.token}/endpoints", authHeaders))
                 .thenReturn(new ServiceClientResponse(responseCode, new ByteArrayInputStream(createEndpointResponse().getBytes())))
     }
@@ -406,7 +402,7 @@ class AuthenticationServiceClientTest extends Specification {
     LinkedHashMap<String, String> headersForUserAuthentication(String adminToken) {
         ["Accept": MediaType.APPLICATION_XML,
          "X-Auth-Token": adminToken,
-         (CommonHttpHeader.TRACE_GUID.toString()): TracingHeaderHelper.createTracingHeader("", null)]
+         (CommonHttpHeader.TRACE_GUID.toString()): ""]
     }
 
     def createAuthenticationServiceClient(def adminUser, def adminPassword, def adminTenant, def akkaServiceClient) {

--- a/repose-aggregator/external/service-clients/auth/src/test/groovy/org/openrepose/common/auth/openstack/AuthenticationServiceClientTest.groovy
+++ b/repose-aggregator/external/service-clients/auth/src/test/groovy/org/openrepose/common/auth/openstack/AuthenticationServiceClientTest.groovy
@@ -32,6 +32,7 @@ import org.openrepose.common.auth.AuthServiceOverLimitException
 import org.openrepose.common.auth.ResponseUnmarshaller
 import org.openrepose.commons.utils.http.CommonHttpHeader
 import org.openrepose.commons.utils.http.ServiceClientResponse
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.openrepose.commons.utils.transform.jaxb.JaxbEntityToXml
 import org.openrepose.core.filter.logic.FilterDirector
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient
@@ -186,7 +187,8 @@ class AuthenticationServiceClientTest extends Specification {
 
         def akkaServiceClient = mock(AkkaServiceClient)
         mockAdminTokenRequest(akkaServiceClient, admin)
-        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": admin.token, (CommonHttpHeader.TRACE_GUID.toString()): ""]
+        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": admin.token,
+                           (CommonHttpHeader.TRACE_GUID.toString()): TracingHeaderHelper.createTracingHeader("", null)]
         when(akkaServiceClient.get("TOKEN:${userToValidate.token}", "http://some/uri/tokens/${userToValidate.token}", authHeaders))
                 .thenAnswer(new Answer() {
             def increment = 0
@@ -221,7 +223,8 @@ class AuthenticationServiceClientTest extends Specification {
 
         def akkaServiceClient = mock(AkkaServiceClient)
         mockAdminTokenRequest(akkaServiceClient, admin, 200)
-        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": admin.token, (CommonHttpHeader.TRACE_GUID.toString()): ""]
+        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": admin.token,
+                           (CommonHttpHeader.TRACE_GUID.toString()): TracingHeaderHelper.createTracingHeader("", null)]
         when(akkaServiceClient.get("TOKEN:${userToValidate.token}", "http://some/uri/tokens/${userToValidate.token}", authHeaders))
                 .thenAnswer(new Answer() {
             def increment = 0
@@ -344,7 +347,8 @@ class AuthenticationServiceClientTest extends Specification {
     }
 
     private void mockUserEndpointRequest(AkkaServiceClient akkaServiceClient, String adminToken, LinkedHashMap<String, String> userToValidate, int responseCode = 200, int timesCalled = 1) {
-        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": adminToken, (CommonHttpHeader.TRACE_GUID.toString()): ""]
+        def authHeaders = ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": adminToken,
+                           (CommonHttpHeader.TRACE_GUID.toString()): TracingHeaderHelper.createTracingHeader("", null)]
         when(akkaServiceClient.get("ENDPOINTS${userToValidate.token}", "http://some/uri/tokens/${userToValidate.token}/endpoints", authHeaders))
                 .thenReturn(new ServiceClientResponse(responseCode, new ByteArrayInputStream(createEndpointResponse().getBytes())))
     }
@@ -400,7 +404,9 @@ class AuthenticationServiceClientTest extends Specification {
     }
 
     LinkedHashMap<String, String> headersForUserAuthentication(String adminToken) {
-        ["Accept": MediaType.APPLICATION_XML, "X-Auth-Token": adminToken, (CommonHttpHeader.TRACE_GUID.toString()): ""]
+        ["Accept": MediaType.APPLICATION_XML,
+         "X-Auth-Token": adminToken,
+         (CommonHttpHeader.TRACE_GUID.toString()): TracingHeaderHelper.createTracingHeader("", null)]
     }
 
     def createAuthenticationServiceClient(def adminUser, def adminPassword, def adminTenant, def akkaServiceClient) {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/tracing/log4j2-test.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/tracing/log4j2-test.xml
@@ -3,7 +3,7 @@
     <Appenders>
         <RollingFile name="RollingFile" fileName="${repose.log.name}"
                      filePattern="${repose.log.pattern}" immediateFlush="true">
-            <PatternLayout pattern="GUID:%X{traceGuid} - %d %-4r [%t] %-5p %c - %m%n "/>
+            <PatternLayout pattern="Trans-Id:%X{traceGuid} - %d %-4r [%t] %-5p %c - %m%n "/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="200 MB"/>
             </Policies>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/TracingHeaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/TracingHeaderTest.groovy
@@ -20,6 +20,7 @@
 package features.core.powerfilter
 
 import framework.ReposeValveTest
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 
@@ -49,7 +50,7 @@ class TracingHeaderTest extends ReposeValveTest {
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, headers: [:])
 
         then:
-        mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-trans-id").matches(".+-.+-.+-.+-.+")
+        TracingHeaderHelper.getTraceGuid(mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-trans-id")).matches(".+-.+-.+-.+-.+")
     }
 
     def "should return a tracing header if one was provided"() {
@@ -63,7 +64,7 @@ class TracingHeaderTest extends ReposeValveTest {
     def "should return a tracing header if one was not provided"() {
         when:
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, headers: [:])
-        def requestid = mc.getReceivedResponse().getHeaders().getFirstValue("x-trans-id")
+        def requestid = TracingHeaderHelper.getTraceGuid(mc.getReceivedResponse().getHeaders().getFirstValue("x-trans-id"))
         println(requestid)
 
         then:

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingDistDatastoreTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingDistDatastoreTest.groovy
@@ -96,8 +96,8 @@ class TracingDistDatastoreTest extends ReposeValveTest {
         //That header is used in the log output
         //Don't actually care about the result of the failure
 
-        //Find the GUID out of :  GUID:e6a7f92b-1d22-4f97-8367-7787ccb5f100 - 2015-05-20 12:07:14,045 68669 [qtp172333204-48] DEBUG org.openrepose.filters.clientauth.common.AuthenticationHandler - Uri is /servers/1111/
-        List<String> lines = reposeLogSearch.searchByString("GUID:LOLOL - .*SERVICING DISTDATASTORE REQUEST\$")
+        //Find the GUID out of :  Trans-Id:e6a7f92b-1d22-4f97-8367-7787ccb5f100 - 2015-05-20 12:07:14,045 68669 [qtp172333204-48] DEBUG org.openrepose.filters.clientauth.common.AuthenticationHandler - Uri is /servers/1111/
+        List<String> lines = reposeLogSearch.searchByString("Trans-Id:LOLOL - .*SERVICING DISTDATASTORE REQUEST\$")
         lines.size() == 1
     }
 
@@ -117,7 +117,7 @@ class TracingDistDatastoreTest extends ReposeValveTest {
                           'X-Trans-Id'   : 'test12345'],
                 requestBody: body
         )
-        List<String> lines = reposeLogSearch.searchByString("GUID:test12345 - .*SERVICING DISTDATASTORE REQUEST\$")
+        List<String> lines = reposeLogSearch.searchByString("Trans-Id:test12345 - .*SERVICING DISTDATASTORE REQUEST\$")
 
         then: "should report success"
         mc.receivedResponse.code == "202"
@@ -133,7 +133,7 @@ class TracingDistDatastoreTest extends ReposeValveTest {
                           'X-TTL'        : '10',
                           'X-Trans-Id'   : 'test22345'],
         )
-        lines = reposeLogSearch.searchByString("GUID:test22345 - .*SERVICING DISTDATASTORE REQUEST\$")
+        lines = reposeLogSearch.searchByString("Trans-Id:test22345 - .*SERVICING DISTDATASTORE REQUEST\$")
 
         then: "should report that it is"
         mc.receivedResponse.code == "200"
@@ -150,14 +150,14 @@ class TracingDistDatastoreTest extends ReposeValveTest {
                           'X-TTL'        : '10',
                           'X-Trans-Id'   : 'test32345'],
         )
-        lines = reposeLogSearch.searchByString("GUID:test22345 - .*SERVICING DISTDATASTORE REQUEST\$")
+        lines = reposeLogSearch.searchByString("Trans-Id:test22345 - .*SERVICING DISTDATASTORE REQUEST\$")
 
         then: "should report that it was successfully deleted"
         mc.receivedResponse.code == "204"
         mc.receivedResponse.body == ""
         //mc.sentRequest.headers.contains("x-trans-id")
 
-        //Find the GUID out of :  GUID:e6a7f92b-1d22-4f97-8367-7787ccb5f100 - 2015-05-20 12:07:14,045 68669 [qtp172333204-48] DEBUG org.openrepose.filters.clientauth.common.AuthenticationHandler - Uri is /servers/1111/
+        //Find the GUID out of :  Trans-Id:e6a7f92b-1d22-4f97-8367-7787ccb5f100 - 2015-05-20 12:07:14,045 68669 [qtp172333204-48] DEBUG org.openrepose.filters.clientauth.common.AuthenticationHandler - Uri is /servers/1111/
         lines.size() == 1
     }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
@@ -18,14 +18,12 @@
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.core.tracing
-
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import org.joda.time.DateTime
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import spock.lang.Unroll
-
 /**
  * Created by jennyvo on 8/10/15.
  * Verify Tracing header x-trans-id also include sessionid and requestid
@@ -96,11 +94,15 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
         println transid
         def sesid = getSessionId(sessionid)
         println sesid
+        def username = mc.handlings[0].request.headers.getFirstValue("x-pp-user")
+        def requestid = mc.handlings[0].request.headers.getFirstValue("deproxy-request-id")
 
         then: "Make sure there are appropriate log messages with matching GUIDs"
         mc.receivedResponse.code == "200"
 
+        transid.contains(requestid)
         transid.contains(sesid)
+        transid.contains(username)
 
         // should be able to find the same tracing header from log
         reposeLogSearch.searchByString("GUID:$transid -.*AuthTokenFutureActor request!").size() > 0

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
@@ -1,0 +1,123 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.core.tracing
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityService
+import org.joda.time.DateTime
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import spock.lang.Unroll
+
+/**
+ * Created by jennyvo on 8/10/15.
+ * Verify Tracing header x-trans-id also include sessionid and requestid
+ */
+class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
+
+    def static originEndpoint
+    def static identityEndpoint
+
+    def static MockIdentityService fakeIdentityService
+
+    def setupSpec() {
+
+        deproxy = new Deproxy()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/core/tracing", params)
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort,
+                'identity service', null, fakeIdentityService.handler)
+
+        reposeLogSearch.cleanLog()
+    }
+
+    def cleanupSpec() {
+        deproxy.shutdown()
+
+        repose.stop()
+    }
+
+    def setup() {
+        sleep 500
+        fakeIdentityService.resetHandlers()
+    }
+
+    @Unroll ("Checking with session id string: #sessionid")
+    def "Trans id should include session id"() {
+
+        given:
+        fakeIdentityService.with {
+            client_tenant = 1212
+            client_userid = 1212
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+        }
+
+        def url = "$reposeEndpoint/servers/1212"
+        if (sessionid != ""){
+            url = url + ";" + sessionid
+        }
+
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: url,
+                method: 'GET',
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token
+                ]
+        )
+        // get tracing header from request
+        def transid = mc.handlings[0].request.headers.getFirstValue("x-trans-id")
+        println transid
+        def sesid = getSessionId(sessionid)
+        println sesid
+
+        then: "Make sure there are appropriate log messages with matching GUIDs"
+        mc.receivedResponse.code == "200"
+
+        transid.contains(sesid)
+
+        // should be able to find the same tracing header from log
+        reposeLogSearch.searchByString("GUID:$transid -.*AuthTokenFutureActor request!").size() > 0
+
+        where:
+        sessionid  << ["sessionid=abcdedfg1234567","sessionid=1234567890","1234567890","sessionid=",""]
+    }
+
+    def getSessionId (String stringsession){
+        def id = ""
+        if (stringsession.contains("sessionid=")){
+            List session = stringsession.split("=")
+            if (session.size() > 1) {
+                id = session[1]
+            }
+        }
+        return id
+    }
+
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
@@ -90,8 +90,6 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
                 method: 'GET',
                 headers: headers)
 
-        def tracingHeaderRequest = mc.handlings[0].request.headers.getFirstValue(CommonHttpHeader.TRACE_GUID.toString())
-
         then: 'Make sure the request and response contain a new X-Trans-Id header'
         mc.receivedResponse.code == '200'
 
@@ -180,8 +178,8 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
             tokenExpiresAt = DateTime.now().plusDays(1)
         }
 
-        def tracingId = 'd2ff25c3-fa7a-4196-9927-d3dd0eed47d3'
-        def sessionId = '677b358b-9d13-446d-a776-e8c8b9083af6'
+        def tracingId = UUID.randomUUID().toString()
+        def sessionId = UUID.randomUUID().toString()
         def jsonTracingHeader = JsonOutput.toJson([sessionId: sessionId, requestId: tracingId, user: 'a', domain: 'b'])
         def tracingHeader = Base64.encodeBase64String(jsonTracingHeader.bytes)
         def headers = [
@@ -224,8 +222,8 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
             tokenExpiresAt = DateTime.now().plusDays(1)
         }
 
-        def tracingId = 'd2ff25c3-fa7a-4196-9927-d3dd0eed47d3'
-        def sessionId = '677b358b-9d13-446d-a776-e8c8b9083af6'
+        def tracingId = UUID.randomUUID().toString()
+        def sessionId = UUID.randomUUID().toString()
         def jsonTracingHeader = JsonOutput.toJson(
                 [sessionId: sessionId, requestId: tracingId, user: 'bob', domain: 'pluto', favoriteTree: 'cherry'])
         def tracingHeader = Base64.encodeBase64String(jsonTracingHeader.bytes)
@@ -260,7 +258,7 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
             tokenExpiresAt = DateTime.now().plusDays(1)
         }
 
-        def tracingId = '399aee87-061b-4676-b486-cb6ffadb2e8a'
+        def tracingId = UUID.randomUUID().toString()
         def jsonTracingHeader = "{'tracingId': $tracingId, I_LIKE_HAM}".toString()
         def tracingHeader = Base64.encodeBase64String(jsonTracingHeader.bytes)
         def headers = [
@@ -294,7 +292,7 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
             tokenExpiresAt = DateTime.now().plusDays(1)
         }
 
-        def tracingId = '399aee87-061b-4676-b486-cb6ffadb2e8a'
+        def tracingId = UUID.randomUUID().toString()
         def tracingHeader = "{{'tracingId': $tracingId, I_LIKE_HAM}".toString()
         def headers = [
                 'content-type': 'application/json',
@@ -327,7 +325,7 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
             tokenExpiresAt = DateTime.now().plusDays(1)
         }
 
-        def tracingHeader = '399aee87-061b-4676-b486-cb6ffadb2e8a'
+        def tracingHeader = UUID.randomUUID().toString()
         def headers = [
                 'content-type': 'application/json',
                 'X-Auth-Token': fakeIdentityService.client_token,

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
@@ -82,7 +82,7 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
         def headers = [
                 'content-type': 'application/json',
                 'X-Auth-Token': fakeIdentityService.client_token,
-                via: 'some_via']
+                via           : 'some_via']
 
         when: 'User passes a request through repose'
         MessageChain mc = deproxy.makeRequest(
@@ -127,10 +127,10 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
         }
 
         def headers = [
-                'content-type': 'application/json',
-                'X-Auth-Token': fakeIdentityService.client_token,
+                'content-type'                          : 'application/json',
+                'X-Auth-Token'                          : fakeIdentityService.client_token,
                 (CommonHttpHeader.TRACE_GUID.toString()): '',
-                via: 'some_via']
+                via                                     : 'some_via']
 
         when: 'User passes a request through repose'
         MessageChain mc = deproxy.makeRequest(
@@ -183,8 +183,8 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
         def jsonTracingHeader = JsonOutput.toJson([sessionId: sessionId, requestId: tracingId, user: 'a', domain: 'b'])
         def tracingHeader = Base64.encodeBase64String(jsonTracingHeader.bytes)
         def headers = [
-                'content-type': 'application/json',
-                'X-Auth-Token': fakeIdentityService.client_token,
+                'content-type'                          : 'application/json',
+                'X-Auth-Token'                          : fakeIdentityService.client_token,
                 (CommonHttpHeader.TRACE_GUID.toString()): tracingHeader]
 
         when: 'User passes a request through repose'
@@ -228,8 +228,8 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
                 [sessionId: sessionId, requestId: tracingId, user: 'bob', domain: 'pluto', favoriteTree: 'cherry'])
         def tracingHeader = Base64.encodeBase64String(jsonTracingHeader.bytes)
         def headers = [
-                'content-type': 'application/json',
-                'X-Auth-Token': fakeIdentityService.client_token,
+                'content-type'                          : 'application/json',
+                'X-Auth-Token'                          : fakeIdentityService.client_token,
                 (CommonHttpHeader.TRACE_GUID.toString()): tracingHeader]
 
         when: 'User passes a request through repose'
@@ -262,8 +262,8 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
         def jsonTracingHeader = "{'tracingId': $tracingId, I_LIKE_HAM}".toString()
         def tracingHeader = Base64.encodeBase64String(jsonTracingHeader.bytes)
         def headers = [
-                'content-type': 'application/json',
-                'X-Auth-Token': fakeIdentityService.client_token,
+                'content-type'                          : 'application/json',
+                'X-Auth-Token'                          : fakeIdentityService.client_token,
                 (CommonHttpHeader.TRACE_GUID.toString()): tracingHeader]
 
         when: 'User passes a request through repose'
@@ -295,8 +295,8 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
         def tracingId = UUID.randomUUID().toString()
         def tracingHeader = "{{'tracingId': $tracingId, I_LIKE_HAM}".toString()
         def headers = [
-                'content-type': 'application/json',
-                'X-Auth-Token': fakeIdentityService.client_token,
+                'content-type'                          : 'application/json',
+                'X-Auth-Token'                          : fakeIdentityService.client_token,
                 (CommonHttpHeader.TRACE_GUID.toString()): tracingHeader]
 
         when: 'User passes a request through repose'
@@ -327,8 +327,8 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
 
         def tracingHeader = UUID.randomUUID().toString()
         def headers = [
-                'content-type': 'application/json',
-                'X-Auth-Token': fakeIdentityService.client_token,
+                'content-type'                          : 'application/json',
+                'X-Auth-Token'                          : fakeIdentityService.client_token,
                 (CommonHttpHeader.TRACE_GUID.toString()): tracingHeader]
 
         when: 'User passes a request through repose'

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/tracing/TracingHeaderIncludeSessionIdTest.groovy
@@ -18,12 +18,14 @@
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.core.tracing
+
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import org.joda.time.DateTime
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import spock.lang.Unroll
+
 /**
  * Created by jennyvo on 8/10/15.
  * Verify Tracing header x-trans-id also include sessionid and requestid
@@ -108,7 +110,7 @@ class TracingHeaderIncludeSessionIdTest extends ReposeValveTest {
         reposeLogSearch.searchByString("GUID:$transid -.*AuthTokenFutureActor request!").size() > 0
 
         where:
-        sessionid  << ["sessionid=abcdedfg1234567","sessionid=1234567890","1234567890","sessionid=",""]
+        sessionid  << ["sessionid=abcdedfg1234567", "sessionid=1234567890", "1234567890", "sessionid=", ""]
     }
 
     def getSessionId (String stringsession){

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/traceheader/TracingHeaderDisabledTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/traceheader/TracingHeaderDisabledTest.groovy
@@ -78,8 +78,10 @@ class TracingHeaderDisabledTest extends ReposeValveTest {
         mc.receivedResponse.code == "200"
         mc.handlings.size() == 1
         !mc.handlings[0].request.headers.contains("x-trans-id")
-        mc.orphanedHandlings.each {
-            e -> assertTrue(!e.request.headers.contains("x-trans-id"))
+        !mc.handlings[0].request.headers.contains("x-fancy-trans-id")
+        mc.orphanedHandlings.each { e ->
+            assertTrue(!e.request.headers.contains("x-trans-id"))
+            assertTrue(!e.request.headers.contains("x-fancy-trans-id"))
         }
 
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/traceheader/TracingHeaderDisabledTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/traceheader/TracingHeaderDisabledTest.groovy
@@ -78,10 +78,8 @@ class TracingHeaderDisabledTest extends ReposeValveTest {
         mc.receivedResponse.code == "200"
         mc.handlings.size() == 1
         !mc.handlings[0].request.headers.contains("x-trans-id")
-        !mc.handlings[0].request.headers.contains("x-fancy-trans-id")
         mc.orphanedHandlings.each { e ->
             assertTrue(!e.request.headers.contains("x-trans-id"))
-            assertTrue(!e.request.headers.contains("x-fancy-trans-id"))
         }
 
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/HerpCloudfeedCADFdefaultTemplateTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/HerpCloudfeedCADFdefaultTemplateTest.groovy
@@ -20,6 +20,7 @@
 package features.filters.herp
 
 import framework.ReposeValveTest
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.Response
@@ -169,8 +170,8 @@ class HerpCloudfeedCADFdefaultTemplateTest extends ReposeValveTest {
 
         then:
         mc.receivedResponse.code.equals("200")
-        mc.handlings[0].request.headers.getFirstValue("x-trans-id") == event.@requestID.text()
-        mc.receivedResponse.headers.getFirstValue("x-trans-id") == event.@requestID.text()
+        TracingHeaderHelper.getTraceGuid(mc.handlings[0].request.headers.getFirstValue("x-trans-id")) == event.@requestID.text()
+        TracingHeaderHelper.getTraceGuid(mc.receivedResponse.headers.getFirstValue("x-trans-id")) == event.@requestID.text()
 
         where:
         username | request                      | method   | reqBody | respMsg

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/HerpTracingLogTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/HerpTracingLogTest.groovy
@@ -21,6 +21,7 @@ package features.filters.herp
 
 import framework.ReposeValveTest
 import groovy.json.JsonSlurper
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 
@@ -63,7 +64,7 @@ class HerpTracingLogTest extends ReposeValveTest {
         String jsonpart = logLine.substring(logLine.indexOf("{"))
         def slurper = new JsonSlurper()
         def result = slurper.parseText(jsonpart)
-        def requestid = messageChain.receivedResponse.headers.getFirstValue("x-trans-id")
+        def requestid = TracingHeaderHelper.getTraceGuid(messageChain.receivedResponse.headers.getFirstValue("x-trans-id"))
         println requestid
 
         then:

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/HerpUserAccessEventFilterTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/HerpUserAccessEventFilterTest.groovy
@@ -21,6 +21,7 @@ package features.filters.herp
 
 import framework.ReposeValveTest
 import groovy.json.JsonSlurper
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.Response
@@ -301,7 +302,7 @@ class HerpUserAccessEventFilterTest extends ReposeValveTest {
         def pslurper = new JsonSlurper()
         def presult = pslurper.parseText(pjsonpart)
         def pmap = buildParamList(parameters)
-        def requestid = mc.handlings[0].request.headers.getFirstValue("x-trans-id")
+        def requestid = TracingHeaderHelper.getTraceGuid(mc.handlings[0].request.headers.getFirstValue("x-trans-id"))
 
         then:
         "result should be " + responseCode

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingWTracingHeaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingWTracingHeaderTest.groovy
@@ -21,6 +21,7 @@ package features.filters.slf4jlogging
 
 import framework.ReposeLogSearch
 import framework.ReposeValveTest
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.Response
@@ -52,7 +53,7 @@ class Slf4jHttpLoggingWTracingHeaderTest extends ReposeValveTest {
 
         when:
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: method)
-        def requestid = mc.handlings[0].request.headers.getFirstValue("x-trans-id")
+        def requestid = TracingHeaderHelper.getTraceGuid(mc.handlings[0].request.headers.getFirstValue("x-trans-id"))
 
         then: "Request id from request handling should be the same as Request ID logging"
         logSearch.searchByString("Remote IP=127.0.0.1 Local IP=127.0.0.1 Request Method=$method Request ID=$requestid").size() == 1

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/TracingLogWValkyrieTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/TracingLogWValkyrieTest.groovy
@@ -22,6 +22,7 @@ package features.filters.valkyrie
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import framework.mocks.MockValkyrie
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import spock.lang.Unroll
@@ -97,7 +98,7 @@ class TracingLogWValkyrieTest extends ReposeValveTest {
                 ]
         )
 
-        def requestid = mc.receivedResponse.headers.getFirstValue("x-trans-id")
+        def requestid = TracingHeaderHelper.getTraceGuid(mc.receivedResponse.headers.getFirstValue("x-trans-id"))
 
         then: "check response"
         mc.receivedResponse.code == responseCode

--- a/repose-aggregator/installation/configs/core/log4j2.xml
+++ b/repose-aggregator/installation/configs/core/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
         <RollingFile name="RollingFile" fileName="/var/log/repose/current.log"
                      filePattern="/var/log/repose/current-%d{yyyy-MM-dd_HHmmss}.log">
-            <PatternLayout pattern="GUID:%X{traceGuid} - %d %-4r [%t] %-5p %c - %m%n"/>
+            <PatternLayout pattern="Trans-Id:%X{traceGuid} - %d %-4r [%t] %-5p %c - %m%n"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="200 MB"/>
             </Policies>

--- a/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/HashRingDatastoreManager.java
+++ b/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/HashRingDatastoreManager.java
@@ -28,11 +28,12 @@ import org.openrepose.core.services.datastore.impl.distributed.remote.RemoteComm
 public class HashRingDatastoreManager implements DatastoreManager {
 
     private static final String HOST_KEY = "temp-host-key";
+    private static final String TRACING_HEADER = "temp-tracing-header";
     private final HashRingDatastore datastore;
 
     public HashRingDatastoreManager(ClusterConfiguration configuration, Datastore localDatastore) {
         datastore = new HashRingDatastore(
-                new RemoteCommandExecutor(configuration.getProxyService(), HOST_KEY),
+                new RemoteCommandExecutor(configuration.getProxyService(), HOST_KEY, TRACING_HEADER),
                 configuration.getClusterView(),
                 "",
                 localDatastore,

--- a/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/remote/RemoteCommand.java
+++ b/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/remote/RemoteCommand.java
@@ -32,4 +32,6 @@ public interface RemoteCommand {
     Object handleResponse(ServiceClientResponse response) throws IOException;
 
     void setHostKey(String hostKey);
+
+    void setTracingHeader(String tracingHeader);
 }

--- a/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/remote/RemoteCommandExecutor.java
+++ b/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/remote/RemoteCommandExecutor.java
@@ -31,15 +31,18 @@ public class RemoteCommandExecutor {
 
     private final RequestProxyService proxyService;
     private String hostKey;
+    private String tracingHeader;
 
-    public RemoteCommandExecutor(RequestProxyService proxyService, String hostKey) {
+    public RemoteCommandExecutor(RequestProxyService proxyService, String hostKey, String tracingHeader) {
         this.proxyService = proxyService;
         this.hostKey = hostKey;
+        this.tracingHeader = tracingHeader;
     }
 
     public Object execute(final RemoteCommand command, RemoteBehavior behavior) {
         try {
             command.setHostKey(hostKey);
+            command.setTracingHeader(tracingHeader);
             ServiceClientResponse execute = command.execute(proxyService, behavior);
             return command.handleResponse(execute);
         } catch (ProxyRequestException ex) {

--- a/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/remote/command/AbstractRemoteCommand.java
+++ b/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/remote/command/AbstractRemoteCommand.java
@@ -37,6 +37,7 @@ public abstract class AbstractRemoteCommand implements RemoteCommand {
     private final InetSocketAddress remoteEndpoint;
     private final String cacheObjectKey;
     private String hostKey;
+    private String tracingHeader;
 
     public AbstractRemoteCommand(String cacheObjectKey, InetSocketAddress remoteEndpoint) {
         this.cacheObjectKey = cacheObjectKey;
@@ -61,8 +62,7 @@ public abstract class AbstractRemoteCommand implements RemoteCommand {
     protected Map<String, String> getHeaders(RemoteBehavior remoteBehavior) {
         Map<String, String> headers = new HashMap<>();
         headers.put(DatastoreHeader.HOST_KEY.toString(), hostKey);
-        headers.put(CommonHttpHeader.TRACE_GUID.toString(),
-                TracingHeaderHelper.createTracingHeader(TracingHeaderHelper.getTraceGuid(null), null));
+        headers.put(CommonHttpHeader.TRACE_GUID.toString(), tracingHeader);
         headers.put(DatastoreHeader.REMOTE_BEHAVIOR.toString(), remoteBehavior.name());
 
         return headers;
@@ -79,5 +79,10 @@ public abstract class AbstractRemoteCommand implements RemoteCommand {
     @Override
     public void setHostKey(String hostKey) {
         this.hostKey = hostKey;
+    }
+
+    @Override
+    public void setTracingHeader(String tracingHeader) {
+        this.tracingHeader = tracingHeader;
     }
 }

--- a/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/remote/command/AbstractRemoteCommand.java
+++ b/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/core/services/datastore/impl/distributed/remote/command/AbstractRemoteCommand.java
@@ -21,13 +21,12 @@ package org.openrepose.core.services.datastore.impl.distributed.remote.command;
 
 import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.http.ServiceClientResponse;
-import org.openrepose.core.logging.TracingKey;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
 import org.openrepose.core.services.RequestProxyService;
 import org.openrepose.core.services.datastore.distributed.RemoteBehavior;
 import org.openrepose.core.services.datastore.impl.distributed.CacheRequest;
 import org.openrepose.core.services.datastore.impl.distributed.DatastoreHeader;
 import org.openrepose.core.services.datastore.impl.distributed.remote.RemoteCommand;
-import org.slf4j.MDC;
 
 import java.net.InetSocketAddress;
 import java.util.HashMap;
@@ -62,7 +61,8 @@ public abstract class AbstractRemoteCommand implements RemoteCommand {
     protected Map<String, String> getHeaders(RemoteBehavior remoteBehavior) {
         Map<String, String> headers = new HashMap<>();
         headers.put(DatastoreHeader.HOST_KEY.toString(), hostKey);
-        headers.put(CommonHttpHeader.TRACE_GUID.toString(), MDC.get(TracingKey.TRACING_KEY));
+        headers.put(CommonHttpHeader.TRACE_GUID.toString(),
+                TracingHeaderHelper.createTracingHeader(TracingHeaderHelper.getTraceGuid(null), null));
         headers.put(DatastoreHeader.REMOTE_BEHAVIOR.toString(), remoteBehavior.name());
 
         return headers;

--- a/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/nodeservice/distributed/servlet/DistributedDatastoreServlet.java
+++ b/repose-aggregator/services/datastore/impl/src/main/java/org/openrepose/nodeservice/distributed/servlet/DistributedDatastoreServlet.java
@@ -21,7 +21,8 @@ package org.openrepose.nodeservice.distributed.servlet;
 
 import org.openrepose.commons.utils.http.CommonHttpHeader;
 import org.openrepose.commons.utils.io.ObjectSerializer;
-import org.openrepose.core.logging.TracingKey;
+import org.openrepose.commons.utils.logging.TracingHeaderHelper;
+import org.openrepose.commons.utils.logging.TracingKey;
 import org.openrepose.core.services.datastore.*;
 import org.openrepose.core.services.datastore.distributed.ClusterConfiguration;
 import org.openrepose.core.services.datastore.distributed.ClusterView;
@@ -97,7 +98,7 @@ public class DistributedDatastoreServlet extends HttpServlet {
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         if (isRequestValid(request, response)) {
-            String traceGUID = request.getHeader(CommonHttpHeader.TRACE_GUID.toString());
+            String traceGUID = TracingHeaderHelper.getTraceGuid(request.getHeader(CommonHttpHeader.TRACE_GUID.toString()));
             MDC.put(TracingKey.TRACING_KEY, traceGUID);
             LOG.trace("SERVICING DISTDATASTORE REQUEST");
 

--- a/repose-aggregator/services/datastore/impl/src/test/groovy/org/openrepose/core/services/datastore/impl/distributed/remote/command/AbstractRemoteCommandTest.groovy
+++ b/repose-aggregator/services/datastore/impl/src/test/groovy/org/openrepose/core/services/datastore/impl/distributed/remote/command/AbstractRemoteCommandTest.groovy
@@ -23,7 +23,8 @@ import org.junit.Before
 import org.junit.Test
 import org.openrepose.commons.utils.http.CommonHttpHeader
 import org.openrepose.commons.utils.http.ServiceClientResponse
-import org.openrepose.core.logging.TracingKey
+import org.openrepose.commons.utils.logging.TracingHeaderHelper
+import org.openrepose.commons.utils.logging.TracingKey
 import org.openrepose.core.services.RequestProxyService
 import org.openrepose.core.services.datastore.distributed.RemoteBehavior
 import org.openrepose.core.services.datastore.impl.distributed.DatastoreHeader
@@ -55,7 +56,7 @@ class AbstractRemoteCommandTest {
         Map<String, String> headers = arc.getHeaders(RemoteBehavior.ALLOW_FORWARDING)
 
         assert (headers.get(DatastoreHeader.HOST_KEY.toString()).equals("hostKey"));
-        assert (headers.get(CommonHttpHeader.TRACE_GUID.toString()).equals("tracingKey"));
+        assert (TracingHeaderHelper.getTraceGuid(headers.get(CommonHttpHeader.TRACE_GUID.toString())).equals("tracingKey"));
         assert (headers.get(DatastoreHeader.REMOTE_BEHAVIOR.toString()).equals("ALLOW_FORWARDING"));
     }
 }

--- a/repose-aggregator/services/datastore/impl/src/test/java/org/openrepose/core/services/datastore/impl/distributed/remote/RemoteCommandExecutorTest.java
+++ b/repose-aggregator/services/datastore/impl/src/test/java/org/openrepose/core/services/datastore/impl/distributed/remote/RemoteCommandExecutorTest.java
@@ -34,14 +34,15 @@ import static org.mockito.Mockito.mock;
 
 public class RemoteCommandExecutorTest {
 
-    String HOST_KEY = "host_key";
+    private static final String HOST_KEY = "host_key";
+    private static final String TRACING_HEADER = "tracing_header";
     RequestProxyService mockRequestProxyService;
     RemoteCommandExecutor executor;
 
     @Before
     public void setup() throws Exception {
         mockRequestProxyService = mock(RequestProxyService.class);
-        executor = new RemoteCommandExecutor(mockRequestProxyService, HOST_KEY);
+        executor = new RemoteCommandExecutor(mockRequestProxyService, HOST_KEY, TRACING_HEADER);
     }
 
     @Test
@@ -95,6 +96,11 @@ public class RemoteCommandExecutorTest {
         @Override
         public void setHostKey(String hostKey) {
             assertEquals("Host key must be set in the remote command", HOST_KEY, hostKey);
+        }
+
+        @Override
+        public void setTracingHeader(String tracingHeader) {
+            assertEquals("Host key must be set in the remote command", TRACING_HEADER, tracingHeader);
         }
     }
 


### PR DESCRIPTION
The Tracing Header (x-trans-id) now supports containing JSON data that is Base64 encoded.

TracingHeaderHelper.scala was added to provide convenience methods for grabbing the Tracing UUID out of the encoded header (which is what the header used to contain), creating a new encoded header with a given Tracing UUID and VIA header (to signify that Repose created the header), and simply decoding the header but leaving the JSON data intact for logging purposes.  These methods are "safe" in that if the header provided is not properly encoded, they will return the original string so processing can continue.

PowerFilter.java was updated to use the helper and to log the JSON data so that it could be correlated with the Tracing UUID (i.e. Request ID) in other log lines.  Several other classes were updated to use the helper class.  The TracingKey class was moved to be in the same artifact and package as the helper class.  A new TraceGuidHandler was created to use the helper when logging the Trace GUID, and HttpLogFormatter was updated to use it.

PhoneHomeService.scala still needs to be updated to use the helper class.

The Tracing specific functional tests were run and pass, but I'm going to let Jenkins run the full suite of functional tests to see if they all pass.