### PR TITLE
REP-2670 Remove Reliance on Default Tenant ID

### DIFF
--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/common/AuthenticationHandler.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/common/AuthenticationHandler.java
@@ -108,7 +108,7 @@ public abstract class AuthenticationHandler extends AbstractFilterLogicHandler {
                                                     double delegableQuality, String delegationMessage,
                                                     FilterDirector filterDirector, String extractedResult,
                                                     List<AuthGroup> groups, String endpointsBase64, String contactId,
-                                                    boolean tenanted, boolean sendAllTenantIds, boolean sendTenantIdQuality);
+                                                    boolean sendAllTenantIds, boolean sendTenantIdQuality);
 
     @Override
     public FilterDirector handleRequest(HttpServletRequest request, ReadableHttpServletResponse response) {
@@ -200,7 +200,7 @@ public abstract class AuthenticationHandler extends AbstractFilterLogicHandler {
         }
 
         setFilterDirectorValues(authToken, token, delegable, delegableQuality, delegationMessage.get(), filterDirector,
-                account == null ? "" : account.getResult(), groups, endpointsInBase64, contactId, tenanted, sendAllTenantIds,
+                account == null ? null : account.getResult(), groups, endpointsInBase64, contactId, sendAllTenantIds,
                 sendTenantIdQuality);
 
         delegationMessage.remove();

--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/common/Configurables.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/common/Configurables.java
@@ -21,7 +21,9 @@ package org.openrepose.filters.clientauth.common;
 
 import org.openrepose.commons.utils.regex.KeyedRegexExtractor;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author fran
@@ -41,8 +43,7 @@ public class Configurables {
     private final int cacheOffset;
     private final boolean requestGroups;
     private final EndpointsConfiguration endpointsConfiguration;
-    private final List<String> serviceAdminRoles;
-    private final List<String> ignoreTenantRoles;
+    private final Set<String> ignoreTenantRoles;
     private final boolean sendAllTenantIds;
     private final boolean sendTenantIdQuality;
 
@@ -50,6 +51,9 @@ public class Configurables {
                          boolean tenanted, long groupCacheTtl, long tokenCacheTtl, long usrCacheTtl, int cacheOffset, boolean requestGroups,
                          EndpointsConfiguration endpointsConfiguration, List<String> serviceAdminRoles, List<String> ignoreTenantRoles,
                          boolean sendAllTenantIds, boolean sendTenantIdQuality) {
+        HashSet<String> noTenantRoles = new HashSet<>(serviceAdminRoles);
+        noTenantRoles.addAll(ignoreTenantRoles);
+
         this.delegable = delegable;
         this.delegableQuality = delegableQuality;
         this.authServiceUri = authServiceUri;
@@ -61,8 +65,7 @@ public class Configurables {
         this.cacheOffset = cacheOffset;
         this.requestGroups = requestGroups;
         this.endpointsConfiguration = endpointsConfiguration;
-        this.serviceAdminRoles = serviceAdminRoles;
-        this.ignoreTenantRoles = ignoreTenantRoles;
+        this.ignoreTenantRoles = noTenantRoles;
         this.sendAllTenantIds = sendAllTenantIds;
         this.sendTenantIdQuality = sendTenantIdQuality;
     }
@@ -111,11 +114,7 @@ public class Configurables {
         return cacheOffset;
     }
 
-    public List<String> getServiceAdminRoles() {
-        return serviceAdminRoles;
-    }
-
-    public List<String> getIgnoreTenantRoles() {
+    public Set<String> getIgnoreTenantRoles() {
         return ignoreTenantRoles;
     }
 

--- a/repose-aggregator/components/filters/client-auth/src/main/resources/META-INF/schema/config/openstack-ids-auth/openstack-ids-auth.xsd
+++ b/repose-aggregator/components/filters/client-auth/src/main/resources/META-INF/schema/config/openstack-ids-auth/openstack-ids-auth.xsd
@@ -274,8 +274,10 @@
     <xs:complexType name="IgnoreTenantRoles">
         <xs:annotation>
             <xs:documentation>
-                <html:p>A list of roles to bypass the tenant requirement check.
-                    Users with the any of the roles specified will not have the requirement for a tenant.
+                <html:p>
+                    A list of roles to bypass the tenant check.
+                    Users with the any of the roles specified will not have the requirement for the existence or
+                    equality of a tenant.
                 </html:p>
             </xs:documentation>
         </xs:annotation>

--- a/repose-aggregator/components/filters/client-auth/src/test/groovy/org/openrepose/filters/clientauth/common/AuthenticationHandlerTest.groovy
+++ b/repose-aggregator/components/filters/client-auth/src/test/groovy/org/openrepose/filters/clientauth/common/AuthenticationHandlerTest.groovy
@@ -95,7 +95,7 @@ class AuthenticationHandlerTest extends Specification {
                                                double delegableQuality, String delegationMessage,
                                                FilterDirector filterDirector, String extractedResult,
                                                List<AuthGroup> groups, String endpointsBase64, String contactId,
-                                               boolean tenanted, boolean sendAllTenantIds, boolean sendTenantIdQuality) {
+                                               boolean sendAllTenantIds, boolean sendTenantIdQuality) {
         }
 
         protected String checkEndpointsCache(String token) {

--- a/repose-aggregator/components/filters/client-auth/src/test/groovy/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHeaderManagerGroovyTest.groovy
+++ b/repose-aggregator/components/filters/client-auth/src/test/groovy/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHeaderManagerGroovyTest.groovy
@@ -51,10 +51,11 @@ class OpenStackAuthenticationHeaderManagerGroovyTest extends Specification {
         endpointsBase64 = "endpointsBase64";
         authToken = Mock()
         authToken.getImpersonatorRoles() >> new HashSet<String>()
+        authToken.getTenantIds() >> new HashSet<String>()
         authToken.getTokenId() >> "tokenId"
         openStackAuthenticationHeaderManager =
                 new OpenStackAuthenticationHeaderManager(authTokenString, authToken, isDelegatable, 0.7, "some message", filterDirector,
-                        tenantId, authGroupList, wwwAuthHeaderContents, endpointsBase64, null, true, false, false);
+                        tenantId, authGroupList, wwwAuthHeaderContents, endpointsBase64, null, false, false);
 
         when:
         openStackAuthenticationHeaderManager.setFilterDirectorValues()

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHeaderManagerTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHeaderManagerTest.java
@@ -76,7 +76,7 @@ public class OpenStackAuthenticationHeaderManagerTest {
             openStackAuthenticationHeaderManager =
                     new OpenStackAuthenticationHeaderManager(authTokenString, authToken, isDelegatable, 0.7, "test",
                             filterDirector, tenantId, authGroupList, wwwAuthHeaderContents, endpointsBase64, null,
-                            true, false, false);
+                            false, false);
 
         }
 
@@ -156,7 +156,7 @@ public class OpenStackAuthenticationHeaderManagerTest {
             openStackAuthenticationHeaderManager =
                     new OpenStackAuthenticationHeaderManager(authTokenString, authToken, isDelegatable, 0.7, "test",
                             filterDirector, tenantId, authGroupList, wwwAuthHeaderContents, endpointsBase64, null,
-                            true, false, false);
+                            false, false);
             openStackAuthenticationHeaderManager.setFilterDirectorValues();
 
         }
@@ -189,7 +189,7 @@ public class OpenStackAuthenticationHeaderManagerTest {
         public void shouldAddDelegationHeader() {
             OpenStackAuthenticationHeaderManager headerManager =
                     new OpenStackAuthenticationHeaderManager(null, null, true, 0.7, "test", filterDirector, tenantId,
-                            authGroupList, wwwAuthHeaderContents, endpointsBase64, null, true, false, false);
+                            authGroupList, wwwAuthHeaderContents, endpointsBase64, null, false, false);
             headerManager.setFilterDirectorValues();
 
             assertTrue(filterDirector.requestHeaderManager().headersToAdd().containsKey(HeaderName.wrap(HttpDelegationHeaderNames.Delegated())));
@@ -266,7 +266,7 @@ public class OpenStackAuthenticationHeaderManagerTest {
 
             OpenStackAuthenticationHeaderManager headerManager =
                     new OpenStackAuthenticationHeaderManager(null, aToken, true, 0.7, "test", filterDirector, tenantId,
-                            authGroupList, wwwAuthHeaderContents, endpointsBase64, null, true, false, false);
+                            authGroupList, wwwAuthHeaderContents, endpointsBase64, null, false, false);
             headerManager.setFilterDirectorValues();
 
             assertTrue(filterDirector.requestHeaderManager().headersToAdd().containsKey(HeaderName.wrap(OpenStackServiceHeader.IMPERSONATOR_ROLES.toString())));
@@ -277,7 +277,7 @@ public class OpenStackAuthenticationHeaderManagerTest {
             OpenStackAuthenticationHeaderManager headerManager =
                     new OpenStackAuthenticationHeaderManager(null, authToken, true, 0.7, "test",
                             filterDirector, tenantId, authGroupList, wwwAuthHeaderContents, endpointsBase64, "butts",
-                            true, false, false);
+                            false, false);
             headerManager.setFilterDirectorValues();
 
 

--- a/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHeaderManagerTest.java
+++ b/repose-aggregator/components/filters/client-auth/src/test/java/org/openrepose/filters/clientauth/openstack/OpenStackAuthenticationHeaderManagerTest.java
@@ -227,7 +227,7 @@ public class OpenStackAuthenticationHeaderManagerTest {
 
             OpenStackAuthenticationHeaderManager headerManager =
                     new OpenStackAuthenticationHeaderManager(null, aToken, true, 0.7, "test", filterDirector, tenantId,
-                            authGroupList, wwwAuthHeaderContents, endpointsBase64, null, true, false, false);
+                            authGroupList, wwwAuthHeaderContents, endpointsBase64, null, false, false);
             headerManager.setFilterDirectorValues();
 
             HashSet<String> expectedValues = new HashSet<>();

--- a/repose-aggregator/components/filters/keystone-v2/src/test/scala/org/openrepose/filters/keystonev2/KeystoneV2FilterTest.scala
+++ b/repose-aggregator/components/filters/keystone-v2/src/test/scala/org/openrepose/filters/keystonev2/KeystoneV2FilterTest.scala
@@ -1421,6 +1421,22 @@ with HttpDelegationManager {
     filter.KeystoneV2ConfigListener.configurationUpdated(configuration)
     filter.SystemModelConfigListener.configurationUpdated(mockSystemModel)
 
+    it("will not require a default tenant ID") {
+      val request = new MockHttpServletRequest()
+      request.setRequestURL("http://www.sample.com/tenant/test")
+      request.setRequestURI("/tenant/test")
+      request.addHeader(CommonHttpHeader.AUTH_TOKEN.toString, VALID_TOKEN)
+
+      when(mockDatastore.get(s"$TOKEN_KEY_PREFIX$VALID_TOKEN")).thenReturn(TestValidToken(tenantIds = Seq("tenant")), Nil: _*)
+
+      val response = new MockHttpServletResponse
+      val filterChain = new MockFilterChain()
+      filter.doFilter(request, response, filterChain)
+
+      filterChain.getLastRequest shouldNot be(null)
+      filterChain.getLastResponse shouldNot be(null)
+    }
+
     it("will extract the tenant from the URI and validate that the user has that tenant in their list") {
       val request = new MockHttpServletRequest()
       request.setRequestURL("http://www.sample.com/tenant/test")

--- a/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/AuthToken.java
+++ b/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/AuthToken.java
@@ -30,6 +30,10 @@ public abstract class AuthToken implements Serializable {
 
     public abstract String getTenantId();
 
+    public abstract void setMatchingTenantId(String tenantId);
+
+    public abstract String getMatchingTenantId();
+
     public abstract String getUserId();
 
     public abstract String getTokenId();

--- a/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/openstack/OpenStackToken.java
+++ b/repose-aggregator/external/service-clients/auth/src/main/java/org/openrepose/common/auth/openstack/OpenStackToken.java
@@ -54,6 +54,7 @@ public class OpenStackToken extends AuthToken implements Serializable {
     private final String defaultRegion;
     private final Set<String> tenantIds;
     private final String contactId;
+    private String matchingTenantId;
 
     public OpenStackToken(AuthenticateResponse response) {
 
@@ -118,6 +119,11 @@ public class OpenStackToken extends AuthToken implements Serializable {
         }
     }
 
+    @Override
+    public void setMatchingTenantId(String tenantId) {
+        this.matchingTenantId = tenantId;
+    }
+
     private String getDefaultRegion(AuthenticateResponse response) {
         return StringUtilities.getNonBlankValue(response.getUser().getOtherAttributes().get(REGION_QNAME), "");
     }
@@ -125,6 +131,11 @@ public class OpenStackToken extends AuthToken implements Serializable {
     @Override
     public String getTenantId() {
         return tenantId;
+    }
+
+    @Override
+    public String getMatchingTenantId() {
+        return matchingTenantId;
     }
 
     @Override

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/clientauthn/removetenant/tenantednondelegable/client-auth-n.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/clientauthn/removetenant/tenantednondelegable/client-auth-n.cfg.xml
@@ -8,7 +8,7 @@
         <identity-service username="admin_username"
                           password="admin_password"
                           uri="http://localhost:${identityPort}"/>
-        <client-mapping id-regex=".*/servers/([-|\w]+)/?.*"/>
+        <client-mapping id-regex=".*/servers/([:|-|\w]+)/?.*"/>
         <service-admin-roles>
             <role>service:admin-role1</role>
             <role>service:admin-role2</role>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/clientauthn/removetenant/tenantednondelegable/client-auth-n.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/clientauthn/removetenant/tenantednondelegable/client-auth-n.cfg.xml
@@ -8,7 +8,7 @@
         <identity-service username="admin_username"
                           password="admin_password"
                           uri="http://localhost:${identityPort}"/>
-        <client-mapping id-regex=".*/servers/([:|-|\w]+)/?.*"/>
+        <client-mapping id-regex=".*/servers/([-|:|\w]+)/?.*"/>
         <service-admin-roles>
             <role>service:admin-role1</role>
             <role>service:admin-role2</role>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/removetenant/tenantednondelegable/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/removetenant/tenantednondelegable/keystone-v2.cfg.xml
@@ -8,7 +8,7 @@
     </cache>
     <tenant-handling>
         <validate-tenant>
-            <uri-extraction-regex>.*/servers/([-|\w]+)/?.*</uri-extraction-regex>
+            <uri-extraction-regex>.*/servers/([:|-|\w]+)/?.*</uri-extraction-regex>
         </validate-tenant>
     </tenant-handling>
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/client-auth-n.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/client-auth-n.cfg.xml
@@ -2,7 +2,8 @@
 <client-auth xmlns="http://docs.openrepose.org/repose/client-auth/v1.0">
     <openstack-auth tenanted="false"
                     request-groups="true"
-                    token-cache-timeout="0"
+                    token-cache-timeout="1000"
+                    user-cache-timeout="1000"
                     group-cache-timeout="600000"
                     xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
         <identity-service username="admin_username"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/client-auth-n.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/client-auth-n.cfg.xml
@@ -8,6 +8,6 @@
         <identity-service username="admin_username"
                           password="admin_password"
                           uri="http://localhost:${identityPort}" />
-        <client-mapping id-regex=".*/servers/([-|\w]+)/?.*"/>
+        <client-mapping id-regex=".*/servers/([:|-|\w]+)/?.*"/>
     </openstack-auth>
 </client-auth>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/tenantvalidation/TenantedNonDelegableTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/tenantvalidation/TenantedNonDelegableTest.groovy
@@ -214,5 +214,81 @@ class TenantedNonDelegableTest extends ReposeValveTest {
         mc.receivedResponse.headers.findAll("via").size() == 1
     }
 
+    // REP-2670: Ded Auth Changes
+    def "Always add x-tenant to request for origin service use"() {
+        fakeIdentityService.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_userid = "456"
+            client_tenant = "456"
+        }
 
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/servers/456", method: 'GET',
+                headers: ['content-type': 'application/json', 'X-Auth-Token': fakeIdentityService.client_token])
+
+        then: "Things are forward to the origin, because we're not validating existence of tenant"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        mc.getHandlings().get(0).getRequest().getHeaders().contains("x-tenant-id")
+        mc.getHandlings().get(0).getRequest().getHeaders().contains("x-tenant-name")
+    }
+
+    // REP-2670: Ded Auth Changes
+    @Unroll("Request Tenant: #requestTenant")
+    def "URI tenant will not get added to x-tenant"() {
+        given: "identity info"
+        fakeIdentityService.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_userid = 123
+            client_tenant = 12345
+            client_tenant_file = "nast-id"
+        }
+
+        when: "pass request with request tenant"
+        def mc =
+                deproxy.makeRequest(
+                        url: reposeEndpoint + "/servers/" + requestTenant,
+                        method: 'GET',
+                        headers: ['content-type': 'application/json', 'X-Auth-Token': fakeIdentityService.client_token]
+                )
+
+        then: "should satisfy the following"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-tenant-id").get(0).split(",").size() == 1
+        mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-tenant-id") == "12345" // Default tenant
+
+        where:
+        requestTenant << ["12345", "nast-it"]
+    }
+
+    // REP-2670: Ded Auth Changes
+    // Currently, without a default tenantID, we do not make the Valkyrie call.
+    // We will remove the requirement for a default tenantID so that when we don’t have a default URI,
+    // we will rely on a tenantID from the validate token call
+    // apply for this case dedicated user
+    def "Remove reliance on default tenant check" () {
+        given: "keystone v2v2 with dedicated user access"
+        fakeIdentityService.with {
+            client_token = "dedicatedUser"
+            client_tenant = "hybrid:12345"
+        }
+        when:
+        "User passes a request through repose with request tenant"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/hybrid:12345",
+                method: 'GET',
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token
+                ]
+        )
+        then: "Things are forward to the origin, because we're not validating existence of tenant"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        mc.getHandlings().get(0).getRequest().getHeaders().contains("x-tenant-id")
+        mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-tenant-id") == "hybrid:12345"
+    }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/tenantvalidation/TenantedNonDelegableTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/tenantvalidation/TenantedNonDelegableTest.groovy
@@ -269,7 +269,7 @@ class TenantedNonDelegableTest extends ReposeValveTest {
     // We will remove the requirement for a default tenantID so that when we don’t have a default URI,
     // we will rely on a tenantID from the validate token call
     // apply for this case dedicated user
-    def "Remove reliance on default tenant check" () {
+    def "Remove reliance on default tenant check"() {
         given: "keystone v2v2 with dedicated user access"
         fakeIdentityService.with {
             client_token = "dedicatedUser"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/KeystoneV2BasicTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/KeystoneV2BasicTest.groovy
@@ -153,7 +153,7 @@ class KeystoneV2BasicTest extends ReposeValveTest {
     }
 
     def "If no impersonator then no impersonator headers" () {
-        given: "keystone v2v2 with impersonate access"
+        given: "keystone v2v2 without impersonate access"
         fakeIdentityV2Service.with {
             client_token = UUID.randomUUID().toString()
         }
@@ -168,5 +168,33 @@ class KeystoneV2BasicTest extends ReposeValveTest {
         !mc.handlings[0].request.headers.contains("x-impersonator-id")
         !mc.handlings[0].request.headers.contains("x-impersonator-name")
         !mc.handlings[0].request.headers.contains("x-impersonator-roles")
+    }
+
+    // REP-2670: Ded Auth Changes
+    // Currently, without a default tenantID, we do not make the Valkyrie call.
+    // We will remove the requirement for a default tenantID so that when we don’t have a default URI,
+    // we will rely on a tenantID from the validate token call
+    // apply for this case dedicated user
+    def "Remove reliance on default tenant check" () {
+        given: "keystone v2v2 with dedicated user access"
+        fakeIdentityV2Service.with {
+            client_token = "dedicatedUser"
+            client_tenantid = "hybrid:12345"
+        }
+        when:
+        "User passes a request through repose with request tenant"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/hybrid:12345",
+                method: 'GET',
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityV2Service.client_token
+                ]
+        )
+        then: "Things are forward to the origin, because we're not validating existence of tenant"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        mc.getHandlings().get(0).getRequest().getHeaders().contains("x-tenant-id")
+        mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-tenant-id") == "hybrid:12345"
     }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/nogroups/TenantedNonDelegableNoGroupsTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/nogroups/TenantedNonDelegableNoGroupsTest.groovy
@@ -161,11 +161,11 @@ class TenantedNonDelegableNoGroupsTest extends ReposeValveTest {
         def request2 = mc.handlings[0].request
         request2.headers.getFirstValue("X-Default-Region") == "the-default-region"
         request2.headers.getFirstValue("x-forwarded-for") == "127.0.0.1"
-        request2.headers.getFirstValue("x-tenant-id") == requestTenant.toString()
+        request2.headers.getFirstValue("x-tenant-id") == responseTenant.toString()
         request2.headers.contains("x-token-expires")
         request2.headers.getFirstValue("x-pp-user") == "username;q=1.0"
         request2.headers.contains("x-roles")
-        request2.headers.getFirstValue("x-authorization") == "Proxy $requestTenant"
+        request2.headers.getFirstValue("x-authorization") == "Proxy $responseTenant"
         request2.headers.getFirstValue("x-user-name") == "username"
 
         !mc.receivedResponse.headers.contains("www-authenticate")

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/BypassTenantRolesWQualityTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/BypassTenantRolesWQualityTest.groovy
@@ -95,14 +95,14 @@ class BypassTenantRolesWQualityTest extends ReposeValveTest {
         request2.headers.getFirstValue("X-Default-Region") == "DFW"
         request2.headers.contains("x-auth-token")
         request2.headers.contains("x-authorization")
-        request2.headers.getFirstValue("x-tenant-id") == requestTenant + ";" + quality
-        request2.headers.getFirstValue("x-authorization") == "Proxy " + requestTenant
+        request2.headers.getFirstValue("x-tenant-id") == responseTenant + ";" + quality
+        request2.headers.getFirstValue("x-authorization") == "Proxy " + responseTenant
 
         where:
         requestTenant | responseTenant | serviceAdminRole      | responseCode | quality
         206           | 206            | "not-admin"           | "200"        | "q=0.9"
         207           | 207            | "not-admin"           | "200"        | "q=0.9"
         208           | 208            | "service:admin-role1" | "200"        | "q=0.9"
-        208           | 209            | "service:admin-role1" | "200"        | "q=0.7"
+        208           | 209            | "service:admin-role1" | "200"        | "q=0.9"
     }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/ClientAuthNRemoveTenantTenantedDelegableTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/ClientAuthNRemoveTenantTenantedDelegableTest.groovy
@@ -144,9 +144,9 @@ class ClientAuthNRemoveTenantTenantedDelegableTest extends ReposeValveTest {
         request2.headers.contains("x-auth-token")
         request2.headers.contains("x-identity-status")
         request2.headers.contains("x-authorization")
-        request2.headers.getFirstValue("x-tenant-id") == requestTenant.toString()
+        request2.headers.getFirstValue("x-tenant-id") == responseTenant.toString()
         request2.headers.getFirstValue("x-identity-status") == "Confirmed"
-        request2.headers.getFirstValue("x-authorization") == "Proxy " + requestTenant
+        request2.headers.getFirstValue("x-authorization") == "Proxy " + responseTenant
 
         where:
         requestTenant | responseTenant | serviceAdminRole      | responseCode

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/TenantedNonDelegableTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/TenantedNonDelegableTest.groovy
@@ -299,7 +299,7 @@ class TenantedNonDelegableTest extends ReposeValveTest {
     }
 
     // REP-2670: Ded Auth Changes -Zerotenant
-    def "Non-tenant(racker) with tenanted mode and bypass service admin role" () {
+    def "Non-tenant(racker) with tenanted mode and bypass service admin role"() {
         fakeIdentityV2Service.with {
             client_token = "rackerSSO"
             tokenExpiresAt = DateTime.now().plusDays(1)
@@ -358,9 +358,9 @@ class TenantedNonDelegableTest extends ReposeValveTest {
         mc.receivedResponse.headers.contains("www-authenticate") == false
 
         where:
-        requestTenant | responseTenant | serviceAdminRole      | responseCode
-        717           | 717            | "not-admin"           | "200"
-        718           | 719            | "not-admin"           | "200"
+        requestTenant | responseTenant | serviceAdminRole | responseCode
+        717           | 717            | "not-admin"      | "200"
+        718           | 719            | "not-admin"      | "200"
     }
 
     // REP-2670: Ded Auth Changes
@@ -368,7 +368,7 @@ class TenantedNonDelegableTest extends ReposeValveTest {
     // We will remove the requirement for a default tenantID so that when we don’t have a default URI,
     // we will rely on a tenantID from the validate token call
     // apply for this case dedicated user
-    def "Remove reliance on default tenant check" () {
+    def "Remove reliance on default tenant check"() {
         given: "keystone v2v2 with dedicated user access"
         def hybridtenant = "hybrid:12345"
         fakeIdentityV2Service.with {
@@ -378,7 +378,7 @@ class TenantedNonDelegableTest extends ReposeValveTest {
         when:
         "User passes a request through repose with request tenant"
         MessageChain mc = deproxy.makeRequest(
-                url: "$reposeEndpoint/servers/"+hybridtenant,
+                url: "$reposeEndpoint/servers/" + hybridtenant,
                 method: 'GET',
                 headers: [
                         'content-type': 'application/json',

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/TenantedNonDelegableTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/TenantedNonDelegableTest.groovy
@@ -298,24 +298,23 @@ class TenantedNonDelegableTest extends ReposeValveTest {
         requestTenant << ["12345", "nast-it"]
     }
 
-    // REP-2670: Ded Auth Changes
-    def "Non-tenant(racker) with tenanted mode" () {
+    // REP-2670: Ded Auth Changes -Zerotenant
+    def "Non-tenant(racker) with tenanted mode and bypass service admin role" () {
         fakeIdentityV2Service.with {
             client_token = "rackerSSO"
             tokenExpiresAt = DateTime.now().plusDays(1)
             client_userid = "456"
-            client_tenantid = "456"
+            service_admin_role = "service:admin-role1"
         }
 
         when: "User passes a request through repose"
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/servers/456", method: 'GET',
-                headers: ['content-type': 'application/json', 'X-Auth-Token': fakeIdentityV2Service.client_token])
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/servers/456/", method: 'GET',
+                headers: ['content-type': 'application/json',
+                          'X-Auth-Token': fakeIdentityV2Service.client_token])
 
-        then: "Things are forward to the origin, because we're not validating existence of tenant"
+        then: "Things are forward to the origin, because we're not validating tenant from uri"
         mc.receivedResponse.code == "200"
         mc.handlings.size() == 1
-        mc.getHandlings().get(0).getRequest().getHeaders().contains("x-tenant-id")
-        mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-tenant-id") == "456"
     }
 
     // REP-2670: Ded Auth Changes

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
@@ -58,6 +58,7 @@ class BasicValkyrieTest extends ReposeValveTest {
 
     def setup() {
         fakeIdentityService.resetHandlers()
+        fakeIdentityService.resetDefaultParameters()
         fakeValkyrie.resetHandlers()
     }
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
@@ -18,6 +18,7 @@
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.filters.valkyrie
+
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import framework.mocks.MockValkyrie

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
@@ -292,8 +292,8 @@ class BasicValkyrieTest extends ReposeValveTest {
     // We will remove the requirement for a default tenantID so that when we don’t have a default URI,
     // we will rely on a tenantID from the validate token call
     // apply for this case dedicated user
-    @Unroll("Dedecated User test permission: #permission for #method with tenant: #tenantID and deviceID: #deviceID should return a #responseCode")
-    def "Test with dedecatedUser make sure make call to valkyrie"() {
+    @Unroll("Dedicated User test permission: #permission for #method with tenant: #tenantID and deviceID: #deviceID should return a #responseCode")
+    def "Test with dedicatedUser make sure make call to valkyrie"() {
         given: "A device ID with a particular permission level defined in Valkyrie"
 
         fakeIdentityService.with {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
@@ -18,13 +18,11 @@
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.filters.valkyrie
-
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import framework.mocks.MockValkyrie
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 class BasicValkyrieTest extends ReposeValveTest {
@@ -72,7 +70,7 @@ class BasicValkyrieTest extends ReposeValveTest {
         }
     }
 
-    @Ignore
+
     @Unroll("permission: #permission for #method with tenant: #tenantID and deviceID: #deviceID should return a #responseCode")
     def "Test fine grain access of resources based on Valkyrie permissions (no rbac)"() {
         given: "A device ID with a particular permission level defined in Valkyrie"
@@ -142,7 +140,7 @@ class BasicValkyrieTest extends ReposeValveTest {
         "DELETE" | randomTenant()             | "520707" | "blah"          | "403"
 
     }
-    @Ignore
+
     @Unroll("tenant missing prefix 'hybrid': #tenantID, permission: #permission for #method and deviceID: #deviceID should return a #responseCode")
     def "Repose return 403 if tenant coming from identity prefix 'hybrid' is missing"() {
         given: "A device ID with a particular permission level defined in Valkyrie"
@@ -199,7 +197,7 @@ class BasicValkyrieTest extends ReposeValveTest {
         "PATCH"  | "dedicated:" + random.nextInt() | "520707" | "edit_product"  | "403"
         "DELETE" | "dedicated:" + random.nextInt() | "520707" | "edit_product"  | "403"
     }
-    @Ignore
+
     @Unroll("Without tenantId - permission: #permission for #method and deviceID: #deviceID should return a #responseCode")
     def "Repose return 403 if missing tenantId"() {
         given: "A device ID with a particular permission level defined in Valkyrie"
@@ -242,7 +240,7 @@ class BasicValkyrieTest extends ReposeValveTest {
         "PATCH"  | "520707" | "edit_product"  | "401"
         "DELETE" | "520707" | "edit_product"  | "401"
     }
-    @Ignore
+
     @Unroll("ContactId missing: #tenantID, permission: #permission for #method and deviceID: #deviceID should return a #responseCode")
     def "Repose return 403 if contact id missing"() {
         given: "A device ID with a particular permission level defined in Valkyrie"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/BasicValkyrieTest.groovy
@@ -307,6 +307,8 @@ class BasicValkyrieTest extends ReposeValveTest {
             device_perm = permission
         }
 
+        sleep(2000)
+
         when: "a request is made against a device with Valkyrie set permissions"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/" + deviceID, method: method,
                 headers: [

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -356,16 +356,16 @@ class MockIdentityService {
         def request_token = tokenId
 
         def params = [
-                expires      : getExpires(),
-                userid       : client_userid,
-                username     : client_username,
-                tenant       : client_tenant,
-                tenanttwo    : client_tenant_file,
-                token        : request_token,
-                serviceadmin : service_admin_role,
-                contactIdXml : contactIdXml,
-                contactIdJson: contactIdJson,
-                impersonateid: impersonate_id,
+                expires        : getExpires(),
+                userid         : client_userid,
+                username       : client_username,
+                tenant         : client_tenant,
+                tenanttwo      : client_tenant_file,
+                token          : request_token,
+                serviceadmin   : service_admin_role,
+                contactIdXml   : contactIdXml,
+                contactIdJson  : contactIdJson,
+                impersonateid  : impersonate_id,
                 impersonatename: impersonate_name
         ];
         if (contact_id != null && !contact_id.isEmpty()) {
@@ -392,13 +392,13 @@ class MockIdentityService {
                     template = rackerTokenWithoutProperRoleXmlTemplate
                 } else if (tokenId == "dedicatedUser") {
                     template = dedicatedUserSuccessfulRespXmlTemplate
-                } else if (impersonate_id != ""){
+                } else if (impersonate_id != "") {
                     template = impersonateSuccessfulXmlRespTemplate
                 } else {
                     template = identitySuccessXmlTemplate
                 }
             } else {
-                if (impersonate_id != ""){
+                if (impersonate_id != "") {
                     template = impersonateSuccessfulJsonRespTemplate
                 } else if (tokenId == "dedicatedUser") {
                     template = dedicatedUserSuccessfulRespJsonTemplate

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -942,7 +942,7 @@ class MockIdentityService {
             <rax-auth:credential>PASSWORD</rax-auth:credential>
         </rax-auth:authenticatedBy>
     </token>
-    <user id="dedicatedUser" name="dedicated_29502_1099363" rax-auth:defaultRegion="ORD">
+    <user id="dedicatedUser" name="dedicated_29502_1099363" rax-auth:defaultRegion="ORD" \${contactIdXml}>
         <roles>
             <role id="10015582"
                   name="monitoring:admin"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -948,12 +948,12 @@ class MockIdentityService {
                   name="monitoring:admin"
                   description="Monitoring Admin Role for Account User"
                   serviceId="bde1268ebabeeabb70a0e702a4626977c331d5c4"
-                  tenantId="\${tenantid}" rax-auth:propagate="false"/>
+                  tenantId="\${tenant}" rax-auth:propagate="false"/>
             <role id="16"
                   name="dedicated:default"
                   description="a role that allows a user access to dedicated service methods"
                   serviceId="bde1268ebabeeabb70a0e702a4626977c331d5c4"
-                  tenantId="\${tenantid}"
+                  tenantId="\${tenant}"
                   rax-auth:propagate="true"/>
             <role id="2"
                   name="identity:default"
@@ -978,14 +978,14 @@ class MockIdentityService {
       "id": "dedicatedUser",
       "roles": [
         {
-          "tenantId" : "\${tenantid}",
+          "tenantId" : "\${tenant}",
           "id": "10015582",
           "serviceId": "bde1268ebabeeabb70a0e702a4626977c331d5c4",
           "description": "Monitoring Admin Role for Account User",
           "name": "monitoring:admin"
         },
         {
-          "tenantId" : "\${tenantid}",
+          "tenantId" : "\${tenant}",
           "id": "16",
           "serviceId": "bde1268ebabeeabb70a0e702a4626977c331d5c4",
           "description": "a role that allows a user access to dedicated service methods",

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -390,6 +390,8 @@ class MockIdentityService {
                     template = rackerTokenXmlTemplate
                 } else if (tokenId == "failureRacker") {
                     template = rackerTokenWithoutProperRoleXmlTemplate
+                } else if (tokenId == "dedicatedUser") {
+                    template = dedicatedUserSuccessfulRespXmlTemplate
                 } else if (impersonate_id != ""){
                     template = impersonateSuccessfulXmlRespTemplate
                 } else {
@@ -398,6 +400,8 @@ class MockIdentityService {
             } else {
                 if (impersonate_id != ""){
                     template = impersonateSuccessfulJsonRespTemplate
+                } else if (tokenId == "dedicatedUser") {
+                    template = dedicatedUserSuccessfulRespJsonTemplate
                 } else {
                     template = identitySuccessJsonTemplate
                 }
@@ -922,6 +926,83 @@ class MockIdentityService {
         </roles>
     </rax-auth:impersonator>
 </access>
+"""
+    def dedicatedUserSuccessfulRespXmlTemplate =
+            """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<access xmlns:atom="http://www.w3.org/2005/Atom"
+        xmlns:rax-auth="http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1.0"
+        xmlns="http://docs.openstack.org/identity/api/v2.0"
+        xmlns:ns4="http://docs.rackspace.com/identity/api/ext/RAX-KSGRP/v1.0"
+        xmlns:rax-ksqa="http://docs.rackspace.com/identity/api/ext/RAX-KSQA/v1.0"
+        xmlns:os-ksadm="http://docs.openstack.org/identity/api/ext/OS-KSADM/v1.0"
+        xmlns:rax-kskey="http://docs.rackspace.com/identity/api/ext/RAX-KSKEY/v1.0"
+        xmlns:os-ksec2="http://docs.openstack.org/identity/api/ext/OS-KSEC2/v1.0">
+    <token id="\${token}" expires="\${expires}">
+        <rax-auth:authenticatedBy>
+            <rax-auth:credential>PASSWORD</rax-auth:credential>
+        </rax-auth:authenticatedBy>
+    </token>
+    <user id="dedicatedUser" name="dedicated_29502_1099363" rax-auth:defaultRegion="ORD">
+        <roles>
+            <role id="10015582"
+                  name="monitoring:admin"
+                  description="Monitoring Admin Role for Account User"
+                  serviceId="bde1268ebabeeabb70a0e702a4626977c331d5c4"
+                  tenantId="\${tenantid}" rax-auth:propagate="false"/>
+            <role id="16"
+                  name="dedicated:default"
+                  description="a role that allows a user access to dedicated service methods"
+                  serviceId="bde1268ebabeeabb70a0e702a4626977c331d5c4"
+                  tenantId="\${tenantid}"
+                  rax-auth:propagate="true"/>
+            <role id="2"
+                  name="identity:default"
+                  description="Default Role."
+                  serviceId="bde1268ebabeeabb70a0e702a4626977c331d5c4"
+                  rax-auth:propagate="false"/>
+        </roles>
+    </user>
+</access>
+"""
+    def dedicatedUserSuccessfulRespJsonTemplate =
+            """{
+  "access": {
+    "token": {
+        "id": "\${token}",
+        "expires": "\${expires}",
+        "RAX-AUTH:authenticatedBy": [
+            "PASSWORD"
+        ]
+    },
+    "user": {
+      "id": "dedicatedUser",
+      "roles": [
+        {
+          "tenantId" : "\${tenantid}",
+          "id": "10015582",
+          "serviceId": "bde1268ebabeeabb70a0e702a4626977c331d5c4",
+          "description": "Monitoring Admin Role for Account User",
+          "name": "monitoring:admin"
+        },
+        {
+          "tenantId" : "\${tenantid}",
+          "id": "16",
+          "serviceId": "bde1268ebabeeabb70a0e702a4626977c331d5c4",
+          "description": "a role that allows a user access to dedicated service methods",
+          "name": "dedicated:default"
+        },
+        {
+          "id": "2",
+          "serviceId": "bde1268ebabeeabb70a0e702a4626977c331d5c4",
+          "description": "Default Role.",
+          "name": "identity:default"
+        }
+      ],
+      "name": "dedicated_29502_1099363",
+      "RAX-AUTH:defaultRegion": "ORD"
+    }
+  }
+}
 """
     // TODO: Replace this with builder
     def identityEndpointsJsonTemplate =

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -999,7 +999,8 @@ class MockIdentityService {
         }
       ],
       "name": "dedicated_29502_1099363",
-      "RAX-AUTH:defaultRegion": "ORD"
+      "RAX-AUTH:defaultRegion": "ORD",
+      \${contactIdJson}
     }
   }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
@@ -611,6 +611,8 @@ class MockIdentityV2Service {
                     template = rackerTokenXmlTemplate
                 } else if (tokenId == "rackerSSO") {
                     template = rackerSuccessfulValidateRespXmlTemplate
+                } else if (tokenId == "dedicatedUser") {
+                    template = dedicatedUserSuccessfulRespJsonTemplate
                 } else if (tokenId == "failureRacker") {
                     template = rackerTokenWithoutProperRoleXmlTemplate
                 } else if (impersonate_id != "") {
@@ -621,6 +623,8 @@ class MockIdentityV2Service {
             } else {
                 if (tokenId == "rackerSSO"){
                     template = rackerSuccessfulValidateRespJsonTemplate
+                } else if (tokenId == "dedicatedUser") {
+                    template = dedicatedUserSuccessfulRespJsonTemplate
                 } else if (impersonate_id != "") {
                     template = successfulImpersonateValidateTokenJsonTemplate
                 } else {
@@ -1314,7 +1318,7 @@ class MockIdentityV2Service {
             <role id="9" name="Racker"
                 description="Defines a user as being a Racker"
                 serviceId="18e7a7032733486cd32f472d7bd58f709ac0d221"/>
-            <role name="dl_RackUSA"/>
+            <role name="dl_RackUSA" tenantId="\${tenantid}"/>
             <role name="dl_RackGlobal"/>
             <role name="dl_cloudblock"/>
             <role name="dl_US Managers"/>
@@ -1337,7 +1341,8 @@ class MockIdentityV2Service {
           "name": "Racker",
           "description": "Defines a user as being a Racker",
           "id": "9",
-          "serviceId": "18e7a7032733486cd32f472d7bd58f709ac0d221"
+          "serviceId": "18e7a7032733486cd32f472d7bd58f709ac0d221",
+          "tenantId" : "\${tenantid}"
         }
       ],
       "id": "rackerSSOUsername"
@@ -1345,7 +1350,83 @@ class MockIdentityV2Service {
   }
 }
 """
-
+    def dedicatedUserSuccessfulRespXmlTemplate =
+            """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<access xmlns:atom="http://www.w3.org/2005/Atom"
+        xmlns:rax-auth="http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1.0"
+        xmlns="http://docs.openstack.org/identity/api/v2.0"
+        xmlns:ns4="http://docs.rackspace.com/identity/api/ext/RAX-KSGRP/v1.0"
+        xmlns:rax-ksqa="http://docs.rackspace.com/identity/api/ext/RAX-KSQA/v1.0"
+        xmlns:os-ksadm="http://docs.openstack.org/identity/api/ext/OS-KSADM/v1.0"
+        xmlns:rax-kskey="http://docs.rackspace.com/identity/api/ext/RAX-KSKEY/v1.0"
+        xmlns:os-ksec2="http://docs.openstack.org/identity/api/ext/OS-KSEC2/v1.0">
+    <token id="\${token}" expires="\${expires}">
+        <rax-auth:authenticatedBy>
+            <rax-auth:credential>PASSWORD</rax-auth:credential>
+        </rax-auth:authenticatedBy>
+    </token>
+    <user id="dedicatedUser" name="dedicated_29502_1099363" rax-auth:defaultRegion="ORD">
+        <roles>
+            <role id="10015582"
+                  name="monitoring:admin"
+                  description="Monitoring Admin Role for Account User"
+                  serviceId="bde1268ebabeeabb70a0e702a4626977c331d5c4"
+                  tenantId="\${tenantid}" rax-auth:propagate="false"/>
+            <role id="16"
+                  name="dedicated:default"
+                  description="a role that allows a user access to dedicated service methods"
+                  serviceId="bde1268ebabeeabb70a0e702a4626977c331d5c4"
+                  tenantId="\${tenantid}"
+                  rax-auth:propagate="true"/>
+            <role id="2"
+                  name="identity:default"
+                  description="Default Role."
+                  serviceId="bde1268ebabeeabb70a0e702a4626977c331d5c4"
+                  rax-auth:propagate="false"/>
+        </roles>
+    </user>
+</access>
+"""
+    def dedicatedUserSuccessfulRespJsonTemplate =
+            """{
+  "access": {
+    "token": {
+        "id": "\${token}",
+        "expires": "\${expires}",
+        "RAX-AUTH:authenticatedBy": [
+            "PASSWORD"
+        ]
+    },
+    "user": {
+      "id": "dedicatedUser",
+      "roles": [
+        {
+          "tenantId" : "\${tenantid}",
+          "id": "10015582",
+          "serviceId": "bde1268ebabeeabb70a0e702a4626977c331d5c4",
+          "description": "Monitoring Admin Role for Account User",
+          "name": "monitoring:admin"
+        },
+        {
+          "tenantId" : "\${tenantid}",
+          "id": "16",
+          "serviceId": "bde1268ebabeeabb70a0e702a4626977c331d5c4",
+          "description": "a role that allows a user access to dedicated service methods",
+          "name": "dedicated:default"
+        },
+        {
+          "id": "2",
+          "serviceId": "bde1268ebabeeabb70a0e702a4626977c331d5c4",
+          "description": "Default Role.",
+          "name": "identity:default"
+        }
+      ],
+      "name": "dedicated_29502_1099363",
+      "RAX-AUTH:defaultRegion": "ORD"
+    }
+  }
+}
+"""
     def UserGlobalRolesXmlTemplate =
             """<?xml version="1.0" encoding="UTF-8"?>
   <roles

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
@@ -621,7 +621,7 @@ class MockIdentityV2Service {
                     template = successfulValidateTokenXmlTemplate
                 }
             } else {
-                if (tokenId == "rackerSSO"){
+                if (tokenId == "rackerSSO") {
                     template = rackerSuccessfulValidateRespJsonTemplate
                 } else if (tokenId == "dedicatedUser") {
                     template = dedicatedUserSuccessfulRespJsonTemplate

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
@@ -1318,7 +1318,7 @@ class MockIdentityV2Service {
             <role id="9" name="Racker"
                 description="Defines a user as being a Racker"
                 serviceId="18e7a7032733486cd32f472d7bd58f709ac0d221"/>
-            <role name="dl_RackUSA" tenantId="\${tenantid}"/>
+            <role name="dl_RackUSA" />
             <role name="dl_RackGlobal"/>
             <role name="dl_cloudblock"/>
             <role name="dl_US Managers"/>
@@ -1341,8 +1341,7 @@ class MockIdentityV2Service {
           "name": "Racker",
           "description": "Defines a user as being a Racker",
           "id": "9",
-          "serviceId": "18e7a7032733486cd32f472d7bd58f709ac0d221",
-          "tenantId" : "\${tenantid}"
+          "serviceId": "18e7a7032733486cd32f472d7bd58f709ac0d221"
         }
       ],
       "id": "rackerSSOUsername"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
@@ -1315,7 +1315,7 @@ class MockIdentityV2Service {
         expires="\${expires}"/>
     <user id="rackerSSOUsername">
         <roles>
-            <role id="9" name="Racker"
+            <role id="9" name="\${serviceadmin}"
                 description="Defines a user as being a Racker"
                 serviceId="18e7a7032733486cd32f472d7bd58f709ac0d221"/>
             <role name="dl_RackUSA" />
@@ -1338,7 +1338,7 @@ class MockIdentityV2Service {
       "RAX-AUTH:defaultRegion": "",
       "roles": [
         {
-          "name": "Racker",
+          "name": "\${serviceadmin}",
           "description": "Defines a user as being a Racker",
           "id": "9",
           "serviceId": "18e7a7032733486cd32f472d7bd58f709ac0d221"


### PR DESCRIPTION
Note that there are no changes to the Identity v3 filters. That filter already appears to meet the acceptance criteria of the story.