### PR TITLE
Rep 2387

### DIFF
--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/intrafilterLogging/RequestLog.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/intrafilterLogging/RequestLog.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -66,7 +66,13 @@ public class RequestLog {
         List<String> headerNames = Collections.list(mutableHttpServletRequest.getHeaderNames());
 
         for (String headerName : headerNames) {
-            headerMap.put(headerName, mutableHttpServletRequest.getHeader(headerName));
+            StringBuilder allHeaderValues = new StringBuilder();
+            for (String value : Collections.list(mutableHttpServletRequest.getHeaders(headerName))) {
+                allHeaderValues.append(value).append(",");
+            }
+            //Clobber the last character
+            allHeaderValues.deleteCharAt(allHeaderValues.length() - 1);
+            headerMap.put(headerName, allHeaderValues.toString());
         }
 
         return headerMap;

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/intrafilterLogging/ResponseLog.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/intrafilterLogging/ResponseLog.java
@@ -63,7 +63,13 @@ public class ResponseLog {
         List<String> headerNames = (List<String>) mutableHttpServletResponse.getHeaderNames();
 
         for (String headerName : headerNames) {
-            headerMap.put(headerName, mutableHttpServletResponse.getHeader(headerName));
+            StringBuilder allHeaderValues = new StringBuilder();
+            for (String value : mutableHttpServletResponse.getHeaders(headerName)) {
+                allHeaderValues.append(value).append(",");
+            }
+            //Clobber the last character
+            allHeaderValues.deleteCharAt(allHeaderValues.length() - 1);
+            headerMap.put(headerName, allHeaderValues.toString());
         }
 
         return headerMap;

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/tracingmultigroups/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/tracingmultigroups/header-translation.cfg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<header-translation xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
+    <header original-name="x-roles" new-name="x-pp-groups" remove-original="false"/>
+    <header original-name="Accept-encoding" new-name="something" remove-original="false"/>
+</header-translation>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/tracingmultigroups/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/tracingmultigroups/keystone-v2.cfg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<keystone-v2 xmlns="http://docs.openrepose.org/repose/keystone-v2/v1.0">
+    <identity-service
+            username="admin_username"
+            password="password"
+            uri="http://localhost:${identityPort}"
+            set-groups-in-header="true"
+            set-catalog-in-header="false"
+            />
+    <white-list>
+        <uri-regex>^$</uri-regex>
+        <uri-regex>/buildinfo</uri-regex>
+        <uri-regex>/get</uri-regex>
+    </white-list>
+</keystone-v2>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/tracingmultigroups/log4j2-test.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/tracingmultigroups/log4j2-test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="org.apache.logging.log4j.flume.appender">
+    <Appenders>
+        <RollingFile name="RollingFile" fileName="${repose.log.name}"
+                     filePattern="${repose.log.pattern}" immediateFlush="true">
+            <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="2"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="RollingFile"/>
+        </Root>
+        <Logger name="com.sun.jersey" level="off"/>
+        <Logger name="net.sf.ehcache" level="error"/>
+        <Logger name="org.apache" level="warn"/>
+        <Logger name="org.eclipse.jetty" level="off"/>
+        <Logger name="org.openrepose" level="debug"/>
+        <Logger name="org.rackspace.deproxy" level="info"/>
+        <Logger name="org.springframework" level="warn"/>
+        <Logger name="intrafilter-logging" level="trace"/>
+
+        <!-- I need debug info from JMX! -->
+        <!-- useful: http://docs.oracle.com/javase/1.5.0/docs/guide/jmx/logging.html -->
+        <!-- also useful: http://logging.apache.org/log4j/2.x/log4j-jul/index.html -->
+        <!-- set these to FINEST to get log analysis of when mbeans were started and where -->
+        <Logger name="javax.management" level="debug"/>
+        <Logger name="javax.management.remote" level="debug"/>
+
+        <!-- because adding the JUL bridge, I need to silence a bunch of internal sun stuff -->
+        <Logger name="com.sun.xml.internal" level="warn"/>
+
+    </Loggers>
+</Configuration>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/tracingmultigroups/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/tracingmultigroups/system-model.cfg.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+
+        <nodes>
+            <node id="simple-node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+
+        <filters>
+            <filter name="keystone-v2"/>
+            <filter name="header-translation"/>
+        </filters>
+
+        <destinations>
+            <endpoint id="target" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
+                      default="true"/>
+        </destinations>
+
+    </repose-cluster>
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/intrafilterlogging/IntraFilterLoggingMultipleGroupsTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/intrafilterlogging/IntraFilterLoggingMultipleGroupsTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.core.intrafilterlogging
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import groovy.json.JsonSlurper
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+/**
+ * Created by jennyvo on 10/5/15.
+ *  Previously intrafilter logging at trace level only log the first group
+ *      from the list and ignore the rest of groups
+ *  Fix log all groups (x-pp-groups)
+ */
+class IntraFilterLoggingMultipleGroupsTest extends ReposeValveTest {
+
+    def static originEndpoint
+    def static identityEndpoint
+
+    def static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+
+        deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/core/intrafilterlogging/tracingmultigroups", params)
+
+        originEndpoint = deproxy.addEndpoint(params.targetPort, 'origin service')
+        fakeIdentityV2Service = new MockIdentityV2Service(params.identityPort, params.targetPort)
+        identityEndpoint = deproxy.addEndpoint(params.identityPort,
+                'identity service', null, fakeIdentityV2Service.handler)
+
+        repose.start()
+        repose.waitForNon500FromUrl(reposeEndpoint)
+    }
+
+    def cleanupSpec() {
+        deproxy.shutdown()
+
+        repose.stop()
+    }
+
+    def setup() {
+        fakeIdentityV2Service.resetDefaultParameters()
+    }
+
+    def "Verify log all groups to x-pp-groups and more"() {
+        given:
+        fakeIdentityV2Service.with {
+            client_token = UUID.randomUUID().toString()
+            client_tenantid = "mytenant"
+            client_tenantname = "mytenantname"
+        }
+
+        def headers = [
+                'content-type': 'application/json',
+                'X-Auth-Token': fakeIdentityV2Service.client_token,
+                'x-roles'     : 'test',
+                'X-Roles'     : 'user',
+                "x-pp-groups" : 'Repose_test_group'
+        ]
+
+        when: "User passes a request through repose with valid token"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/servers/test", method: 'GET',
+                headers: headers)
+
+        String tracelogLine = reposeLogSearch.searchByString('TRACE intrafilter-logging - ."preamble":"Intrafilter Request Log","timestamp":(.*),"currentFilter":"header-translation')
+        String jsonpart = tracelogLine.substring(tracelogLine.indexOf("{"))
+        println(jsonpart)
+        def slurper = new JsonSlurper()
+        def logresult = slurper.parseText(jsonpart)
+
+        then: "They should pass"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-tenant-id") == "mytenant"
+        mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-tenant-name") == "mytenantname"
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-pp-groups").contains("Repose_test_group")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-pp-groups").contains("test")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-pp-groups").contains("user")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-pp-groups").contains("0")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-pp-groups").toString().contains("compute:admin")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-pp-groups").toString().contains("object-store:admin")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-pp-groups").toString().contains("service:admin-role1")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-roles").contains("test")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-roles").contains("user")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-roles").toString().contains("compute:admin")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-roles").toString().contains("object-store:admin")
+        mc.getHandlings().get(0).getRequest().getHeaders().findAll("x-roles").toString().contains("service:admin-role1")
+
+        //intrafilterlogging check after headers translation
+        logresult.headers["x-roles"].toString().contains("test")
+        logresult.headers["x-roles"].toString().contains("user")
+        logresult.headers["x-roles"].toString().contains("compute:admin")
+        logresult.headers["x-roles"].toString().contains("object-store:admin")
+        logresult.headers["x-roles"].toString().contains("service:admin-role1")
+        logresult.headers["x-pp-groups"].toString().contains("Repose_test_group")
+        logresult.headers["x-pp-groups"].toString().contains("0")
+        logresult.headers["x-pp-groups"].toString().contains("compute:admin")
+        logresult.headers["x-pp-groups"].toString().contains("object-store:admin")
+        logresult.headers["x-pp-groups"].toString().contains("service:admin-role1")
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/IntrafilterLoggingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/IntrafilterLoggingTest.groovy
@@ -182,6 +182,9 @@ class IntrafilterLoggingTest extends ReposeValveTest {
         xPPUsers.length == 4
 
         and: "Need to verify the response while we're at it"
+        JSONObject responseLine1 = convertToJson("Intrafilter Response Log", 1)
+        def responseUsers = responseLine1.get("headers").get("x-pp-user").split(",")
+        responseUsers.length == 3
     }
 
     private JSONObject convertToJson(String searchString, int entryNumber) {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/IntrafilterLoggingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/powerfilter/IntrafilterLoggingTest.groovy
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -145,6 +145,43 @@ class IntrafilterLoggingTest extends ReposeValveTest {
         sendtoken                  | respcode | respmsg         | type               | respbody
         "this-is-a-token"          | "200"    | "OK"            | "application/json" | "{\"response\": \"amazing\""
         "this-is-an-invalid-token" | "401"    | "Invalid Token" | "plain/text"       | "{\"response\": \"Unauthorized\""
+    }
+
+    def "ensure that intrafilter logging isn't munching the x-pp-user headers"() {
+        given:
+        fakeIdentityService.client_token = "this-is-a-token"
+
+        when: "User passes a request through repose with multiple x-pp-groups headers"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/servers/server123", method: 'GET',
+                headers: ['X-Auth-Token': fakeIdentityService.client_token,
+                          'x-pp-user'   : "Developers;q=1.0 , Secure Developers;q=0.9 , service:admin-role1 , member"],
+                defaultHandler: { request ->
+                    return new Response(200, "OK", [
+                            "Content-Type": "application/json",
+                            "x-pp-user"   : "one,two,three"
+                    ], """{"response": "amazing"}""")
+                })
+
+        then: "Making sure it was logged, and that it went through repose correctly"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+        reposeLogSearch.searchByString("TRACE intrafilter-logging").size() == 4
+        reposeLogSearch.searchByString("Intrafilter Request Log").size() == 2
+        reposeLogSearch.searchByString("Intrafilter Response Log").size() == 2
+
+        // This part of test what will be in the TRACE log to expect
+        and: "Checking to make sure that we didn't clobber the x-pp-user header entries in the log output"
+
+        JSONObject authreqline1 = convertToJson("Intrafilter Request Log", 0)
+
+        //Need to assert that the splittable headers are logged properly, not just the first one (or the last one)
+        //get the headers object out
+        def xPPUsers = authreqline1.get("headers").get("x-pp-user").split(",")
+
+        //We expect that THERE ARE FOUR LIGHTS.... er entries in the xPPUser header
+        xPPUsers.length == 4
+
+        and: "Need to verify the response while we're at it"
     }
 
     private JSONObject convertToJson(String searchString, int entryNumber) {


### PR DESCRIPTION
Update the intrafilter logging to not be naieve about the header values and properly concatenate *all* headers. Tests are written using `x-pp-user` since it's known that repose splits that header.