### PR TITLE
Update basic auth tests

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/apivalidatormultimatch/wauthnpreference/wbasicauth/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/apivalidatormultimatch/wauthnpreference/wbasicauth/rackspace-identity-basic-auth.cfg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rackspace-identity-basic-auth
+        xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
+        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        token-cache-timeout-millis="0">
+    <delegating quality=".7"/>
+</rackspace-identity-basic-auth>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/apivalidatormultimatch/wauthnpreference/wbasicauth/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/apivalidatormultimatch/wauthnpreference/wbasicauth/system-model.cfg.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+
+        <nodes>
+            <node id="node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+
+        <filters>
+            <filter name="rackspace-identity-basic-auth"/>
+            <filter name="client-auth" />
+            <filter name="api-validator"/>
+            <filter name="herp"/>
+            <filter name="derp"/>
+        </filters>
+
+        <destinations>
+            <endpoint id="target"
+                      protocol="http"
+                      hostname="localhost"
+                      root-path="/"
+                      port="${targetPort}"
+                      default="true"/>
+        </destinations>
+
+    </repose-cluster>
+</system-model>
+

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/atom/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/atom/keystone-v2.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <keystone-v2 xmlns="http://docs.openrepose.org/repose/keystone-v2/v1.0">
-    <cache-settings>
+    <cache>
         <timeouts>
             <token>600000</token>
             <group>600000</group>
@@ -9,7 +9,7 @@
         <eviction-feeds>
             <rs-identity-feed uri="http://localhost:${atomPort}/feed" id="feed-id1"/>
         </eviction-feeds>
-    </cache-settings>
+    </cache>
 
     <identity-service username="admin_username"
                       password="admin_password"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/atomfeedservice/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/atomfeedservice/system-model.cfg.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+
+        <nodes>
+            <node id="config-test" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+
+        <filters>
+        </filters>
+        <destinations>
+            <endpoint id="mock-service" protocol="http" hostname="${targetHostname}" port="${targetPort}" root-path="/"
+                      default="true"/>
+        </destinations>
+
+    </repose-cluster>
+    <!-- Please set the enabled attribute to true to send us usage updates and help us improve Repose! -->
+    <phone-home enabled="false"
+                collection-uri="http://localhost:${phonehomePort}"
+                origin-service-id="repose-test-service"
+                contact-email="repose.core@rackspace.com"/>
+    <atom-feed-service-support enable="true" />
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/BasicAuthHerpDerpRMSMultiMatchAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/BasicAuthHerpDerpRMSMultiMatchAuthTest.groovy
@@ -1,0 +1,121 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+* =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.herp
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityService
+import org.apache.commons.codec.binary.Base64
+import org.apache.commons.lang.RandomStringUtils
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.core.HttpHeaders
+
+/**
+ * Created by jennyvo on 10/7/15.
+ */
+class BasicAuthHerpDerpRMSMultiMatchAuthTest extends ReposeValveTest {
+
+    def static originEndpoint
+    def static identityEndpoint
+
+    def static MockIdentityService fakeIdentityService
+
+    def setupSpec() {
+
+        deproxy = new Deproxy()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/herp", params)
+        repose.configurationProvider.applyConfigs("features/filters/herp/apivalidatormultimatch", params)
+        repose.configurationProvider.applyConfigs("features/filters/herp/apivalidatormultimatch/wauthnpreference", params)
+        repose.configurationProvider.applyConfigs("features/filters/herp/apivalidatormultimatch/wauthnpreference/wbasicauth", params)
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort,
+                'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+
+    }
+
+    def cleanupSpec() {
+        if (deproxy)
+            deproxy.shutdown()
+        if (repose)
+            repose.stop()
+    }
+
+    def setup() {
+        fakeIdentityService.with {
+            // This is required to ensure that one piece of the authentication data is changed
+            // so that the cached version in the Akka Client is not used.
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+        }
+    }
+
+    /*
+    These tests are to verify the delegation of basicauth failures to the derp filter, which then forwards
+    that information back to the client.  The origin service, thus, never gets invoked.
+    */
+
+    def "When the request send with invalid long key or username, then will fail to authenticate"() {
+        given: "the HTTP Basic authentication header containing the User Name and invalid API Key"
+        def key = RandomStringUtils.random(226, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + key).bytes)
+        ]
+
+        when: "the request does have an HTTP Basic authentication header"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "get a token and validate it"
+        mc.receivedResponse.code == HttpServletResponse.SC_UNAUTHORIZED.toString()
+        mc.handlings.size() == 0
+        mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
+    }
+
+    def "When req with invalid key using delegable mode with quality"() {
+        given:
+        def key = RandomStringUtils.random(226, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
+        def headers = [
+                'content-type'             : 'application/json',
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + key).bytes)
+        ]
+
+        when: "User passes a request through repose expire/invalid token"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/1234",
+                method: 'GET',
+                headers: headers)
+
+        then:
+        mc.receivedResponse.code == "401"
+        mc.receivedResponse.headers.contains("content-type")
+        mc.receivedResponse.body.contains("Failed to authenticate user: " + fakeIdentityService.client_username)
+        mc.handlings.size() == 0
+        mc.getOrphanedHandlings().size() == 1
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
@@ -18,7 +18,6 @@
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.filters.identitybasicauth
-
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import org.apache.commons.codec.binary.Base64
@@ -27,6 +26,7 @@ import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.Response
 import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import javax.servlet.http.HttpServletResponse
@@ -137,9 +137,9 @@ class BasicAuthTest extends ReposeValveTest {
         mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
     }
 
-    def "When the request send with invalid long key or username, then will fail to authenticate"() {
+    def "When the request send with invalid 0 < key < 100 , then will fail to authenticate"() {
         given: "the HTTP Basic authentication header containing the User Name and invalid API Key"
-        def key = RandomStringUtils.random(226, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
+        def key = RandomStringUtils.random(99, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
         def headers = [
                 (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + key).bytes)
         ]
@@ -147,8 +147,44 @@ class BasicAuthTest extends ReposeValveTest {
         when: "the request does have an HTTP Basic authentication header"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
 
-        then: "get a token and validate it"
+        then: "response with 400 bad request"
         mc.receivedResponse.code == HttpServletResponse.SC_UNAUTHORIZED.toString()
+        mc.handlings.size() == 0
+        mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
+    }
+
+    // identity currently return 400 bad request for api-key > 100 characters
+    // repose log REP-2880 to work on compliant with this response
+    @IgnoreIf({ new Date() < (new GregorianCalendar(2015, Calendar.NOVEMBER, 10)).getTime() })
+    def "When the request send with invalid long key > 100 , then will fail to authenticate"() {
+        given: "the HTTP Basic authentication header containing the User Name and invalid API Key"
+        def key = RandomStringUtils.random(120, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + key).bytes)
+        ]
+
+        when: "the request does have an HTTP Basic authentication header"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "response with 400 bad request"
+        mc.receivedResponse.code == HttpServletResponse.SC_BAD_REQUEST.toString()
+        mc.handlings.size() == 0
+        mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
+    }
+
+    @IgnoreIf({new Date() < (new GregorianCalendar(2015, Calendar.NOVEMBER, 10)).getTime()})
+    def "When the request send with username > 100 , then will fail to authenticate"() {
+        given: "the HTTP Basic authentication header containing the User Name and invalid API Key"
+        def username = RandomStringUtils.random(120, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString(( username + ":" +fakeIdentityService.client_apikey).bytes)
+        ]
+
+        when: "the request does have an HTTP Basic authentication header"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "response with 400 bad request"
+        mc.receivedResponse.code == HttpServletResponse.SC_BAD_REQUEST.toString()
         mc.handlings.size() == 0
         mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
@@ -141,7 +141,7 @@ class BasicAuthTest extends ReposeValveTest {
         given: "the HTTP Basic authentication header containing the User Name and invalid API Key"
         def key = RandomStringUtils.random(226, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
         def headers = [
-                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":"+key).bytes)
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + key).bytes)
         ]
 
         when: "the request does have an HTTP Basic authentication header"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
@@ -18,6 +18,7 @@
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.filters.identitybasicauth
+
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import org.apache.commons.codec.binary.Base64
@@ -172,12 +173,12 @@ class BasicAuthTest extends ReposeValveTest {
         mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
     }
 
-    @IgnoreIf({new Date() < (new GregorianCalendar(2015, Calendar.NOVEMBER, 10)).getTime()})
+    @IgnoreIf({ new Date() < (new GregorianCalendar(2015, Calendar.NOVEMBER, 10)).getTime() })
     def "When the request send with username > 100 , then will fail to authenticate"() {
         given: "the HTTP Basic authentication header containing the User Name and invalid API Key"
         def username = RandomStringUtils.random(120, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
         def headers = [
-                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString(( username + ":" +fakeIdentityService.client_apikey).bytes)
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((username + ":" + fakeIdentityService.client_apikey).bytes)
         ]
 
         when: "the request does have an HTTP Basic authentication header"


### PR DESCRIPTION
I tried to replicate Shinta's basic auth issue as claim invalid large key response with 500 but I couldn't. However, it's good to have these tests in place.
- verified basicauth authentication with invalid large key - 401 
- verified basicauth authentication with invalid large key delegation higher quality through (basicauth, authn, api-validator, herp, derp) - 401 with appropriate delegating error message.
