### PR TITLE
Added device level permissions to X-Roles headers

### DIFF
--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
@@ -133,7 +133,7 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
       }
     }
 
-    def authorizeDevice(permissions: ValkyrieResult, deviceId: Option[String]): ValkyrieResult = {
+    def authorizeDevice(valkyrieCallResult: ValkyrieResult, deviceId: Option[String]): ValkyrieResult = {
       def authorize(deviceId: String, permissions: UserPermissions, method: String): ValkyrieResult = {
         val deviceBasedResult: ValkyrieResult = permissions.devices.find(_.device.toString == deviceId).map { deviceToPermission =>
           lazy val permissionsWithDevicePermissions = permissions.copy(roles = permissions.roles :+ deviceToPermission.permission)
@@ -158,7 +158,7 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
         }
       }
 
-      (permissions, deviceId) match {
+      (valkyrieCallResult, deviceId) match {
         case (permissions: UserPermissions, Some(device)) => authorize(device, permissions, mutableHttpRequest.getMethod)
         case (result, _) => result
       }

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
@@ -133,7 +133,7 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
       }
     }
 
-    def authorizeDevice(valkyrieCallResult: ValkyrieResult, deviceId: Option[String]): ValkyrieResult = {
+    def authorizeDevice(valkyrieCallResult: ValkyrieResult, deviceIdHeader: Option[String]): ValkyrieResult = {
       def authorize(deviceId: String, permissions: UserPermissions, method: String): ValkyrieResult = {
         val deviceBasedResult: ValkyrieResult = permissions.devices.find(_.device.toString == deviceId).map { deviceToPermission =>
           lazy val permissionsWithDevicePermissions = permissions.copy(roles = permissions.roles :+ deviceToPermission.permission)
@@ -158,8 +158,8 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
         }
       }
 
-      (valkyrieCallResult, deviceId) match {
-        case (permissions: UserPermissions, Some(device)) => authorize(device, permissions, mutableHttpRequest.getMethod)
+      (valkyrieCallResult, deviceIdHeader) match {
+        case (permissions: UserPermissions, Some(deviceId)) => authorize(deviceId, permissions, mutableHttpRequest.getMethod)
         case (result, _) => result
       }
     }

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
@@ -136,10 +136,11 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
     def authorizeDevice(permissions: ValkyrieResult, deviceId: Option[String]): ValkyrieResult = {
       def authorize(deviceId: String, permissions: UserPermissions, method: String): ValkyrieResult = {
         val deviceBasedResult: ValkyrieResult = permissions.devices.find(_.device.toString == deviceId).map { deviceToPermission =>
+          lazy val permissionsWithDevicePermissions = permissions.copy(roles = permissions.roles :+ deviceToPermission.permission)
           deviceToPermission.permission match {
-            case "view_product" if List("GET", "HEAD").contains(method) => permissions
-            case "edit_product" => permissions
-            case "admin_product" => permissions
+            case "view_product" if List("GET", "HEAD").contains(method) => permissionsWithDevicePermissions
+            case "edit_product" => permissionsWithDevicePermissions
+            case "admin_product" => permissionsWithDevicePermissions
             case _ => ResponseResult(403, "Not Authorized")
           }
         } getOrElse {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/translatepermissionstoroles/devicelevel/validator.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/translatepermissionstoroles/devicelevel/validator.cfg.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<validators xmlns='http://docs.openrepose.org/repose/validator/v1.0'>
+
+    <validator role="raxRolesDisabled" default="true" enable-rax-roles="false" >
+        <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <resources base="http://localhost:${targetPort}">
+                <resource path="/resource">
+                    <resource id="device" path="{id}">
+                        <param name="id" type="xsd:string" rax:captureHeader="X-DEVICE-ID" style="template">
+                            <doc>Identifies a device ID at this resource level</doc>
+                        </param>
+                        <method name="GET"/>
+                        <method name="HEAD"/>
+                        <method name="POST"/>
+                        <method name="PUT"/>
+                        <method name="DELETE"/>
+                        <method name="PATCH"/>
+                    </resource>
+                </resource>
+            </resources>
+        </application>
+    </validator>
+</validators>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/DeviceLevelPermissionToRolesTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/DeviceLevelPermissionToRolesTest.groovy
@@ -1,0 +1,141 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.valkyrie
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityService
+import framework.mocks.MockValkyrie
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import spock.lang.Unroll
+
+/**
+ * Created by jennyvo on 10/7/15.
+ */
+class DeviceLevelPermissionToRolesTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static valkyrieEndpoint
+
+    def static MockIdentityService fakeIdentityService
+    def static MockValkyrie fakeValkyrie
+    def static Map params = [:]
+
+    def static random = new Random()
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+
+        params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie/translatepermissionstoroles", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie/translatepermissionstoroles/devicelevel", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+
+        fakeValkyrie = new MockValkyrie(properties.valkyriePort)
+        valkyrieEndpoint = deproxy.addEndpoint(properties.valkyriePort, 'valkyrie service', null, fakeValkyrie.handler)
+    }
+
+    def setup() {
+        fakeIdentityService.resetHandlers()
+        fakeIdentityService.resetDefaultParameters()
+        fakeValkyrie.resetHandlers()
+        fakeValkyrie.resetParameters()
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    @Unroll("#method device #deviceID with permission #permission, tenant: #tenantID should return a #responseCode")
+    def "Test verify only user request device permission will be added to x-roles"() {
+        given: "A device ID with a particular permission level defined in Valkyrie"
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = tenantID
+        }
+
+        fakeValkyrie.with {
+            device_id = deviceID
+            device_perm = permission
+        }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/" + deviceID, method: method,
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == responseCode
+        // account permissions are added to x-roles
+        mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains("upgrade_account")
+        mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains("edit_ticket")
+        mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains("edit_domain")
+        mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains("manage_users")
+        mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains("view_domain")
+        mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains("view_reports")
+        // user device permission translate to roles
+        mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains(permission)
+        mc.getHandlings().get(0).getRequest().headers.getFirstValue("x-device-id") == deviceID
+        // other device permissions not included
+        !mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains(notincluderoles[0])
+        !mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains(notincluderoles[1])
+
+        where:
+        method   | tenantID       | deviceID | permission      | notincluderoles                   | responseCode
+        "GET"    | randomTenant() | "520707" | "view_product"  | ['admin_product', 'edit_product'] | "200"
+        "HEAD"   | randomTenant() | "520707" | "view_product"  | ['admin_product', 'edit_product'] | "200"
+        "GET"    | randomTenant() | "520707" | "admin_product" | ['view_product', 'edit_product']  | "200"
+        "HEAD"   | randomTenant() | "520707" | "admin_product" | ['view_product', 'edit_product']  | "200"
+        "PUT"    | randomTenant() | "520707" | "admin_product" | ['view_product', 'edit_product']  | "200"
+        "POST"   | randomTenant() | "520707" | "admin_product" | ['view_product', 'edit_product']  | "200"
+        "PATCH"  | randomTenant() | "520707" | "admin_product" | ['view_product', 'edit_product']  | "200"
+        "DELETE" | randomTenant() | "520707" | "admin_product" | ['view_product', 'edit_product']  | "200"
+        "GET"    | randomTenant() | "520708" | "edit_product"  | ['view_product', 'admin_product'] | "200"
+        "HEAD"   | randomTenant() | "520708" | "edit_product"  | ['view_product', 'admin_product'] | "200"
+        "PUT"    | randomTenant() | "520708" | "edit_product"  | ['view_product', 'admin_product'] | "200"
+        "POST"   | randomTenant() | "520708" | "edit_product"  | ['view_product', 'admin_product'] | "200"
+        "PATCH"  | randomTenant() | "520708" | "edit_product"  | ['view_product', 'admin_product'] | "200"
+        "DELETE" | randomTenant() | "520708" | "edit_product"  | ['view_product', 'admin_product'] | "200"
+    }
+
+    def String randomTenant() {
+        "hybrid:" + random.nextInt()
+    }
+}


### PR DESCRIPTION
In the Valkyrie filter, when configured to translate account permissions and given a request with an "X-Device-Id" header, instead of just verifying the Device ID permission allows the request to go through, the Device ID permission will also be added to the list of permission roles which in turn get added as values to the X-Roles header.  This includes the Device ID permissions "view_product", "edit_product", and "admin_product".  The "account_admin" case is already handled as it will already be in the list of role permissions.

A unit test covering the combination of being configured to translate account permissions and handling a request with an "X-Device-Id" header did not already exist, so I added one.