### PR TITLE
REP 2880

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/BasicAuthHerpDerpRMSMultiMatchAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/BasicAuthHerpDerpRMSMultiMatchAuthTest.groovy
@@ -18,18 +18,15 @@
 * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.filters.herp
-
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import org.apache.commons.codec.binary.Base64
 import org.apache.commons.lang.RandomStringUtils
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
-import spock.lang.IgnoreIf
 
 import javax.servlet.http.HttpServletResponse
 import javax.ws.rs.core.HttpHeaders
-
 /**
  * Created by jennyvo on 10/7/15.
  */
@@ -122,7 +119,6 @@ class BasicAuthHerpDerpRMSMultiMatchAuthTest extends ReposeValveTest {
 
     // identity currently return 400 bad request for api-key > 100 characters
     // repose log REP-2880 to work on compliant with this response
-    @IgnoreIf({ new Date() < (new GregorianCalendar(2015, Calendar.NOVEMBER, 10)).getTime() })
     def "When req with invalid key > 100 char using delegable mode with quality"() {
         given:
         def key = RandomStringUtils.random(120, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
@@ -138,10 +134,10 @@ class BasicAuthHerpDerpRMSMultiMatchAuthTest extends ReposeValveTest {
                 headers: headers)
 
         then:
-        mc.receivedResponse.code == "400"
+        mc.receivedResponse.code == "401"
         mc.receivedResponse.headers.contains("content-type")
         // may expect different message here
-        mc.receivedResponse.body.contains("Failed to authenticate user: " + fakeIdentityService.client_username)
+        mc.receivedResponse.body.contains("Bad Request received from identity service for " + fakeIdentityService.client_username)
         mc.handlings.size() == 0
         mc.getOrphanedHandlings().size() == 1
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/BasicAuthHerpDerpRMSMultiMatchAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/herp/BasicAuthHerpDerpRMSMultiMatchAuthTest.groovy
@@ -18,6 +18,7 @@
 * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
 package features.filters.herp
+
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityService
 import org.apache.commons.codec.binary.Base64
@@ -27,6 +28,7 @@ import org.rackspace.deproxy.MessageChain
 
 import javax.servlet.http.HttpServletResponse
 import javax.ws.rs.core.HttpHeaders
+
 /**
  * Created by jennyvo on 10/7/15.
  */

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthDelegatingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthDelegatingTest.groovy
@@ -157,6 +157,14 @@ class BasicAuthDelegatingTest extends ReposeValveTest {
         "Invalid key or username" | "DELETE" | "status_code=401`component=Rackspace Identity Basic Auth`message=Failed to authenticate user: $fakeIdentityService.client_username"
         "Invalid key or username" | "PATCH"  | "status_code=401`component=Rackspace Identity Basic Auth`message=Failed to authenticate user: $fakeIdentityService.client_username"
     }
+    /*
+        REP-2880 - Basic auth repose response
+        Identity response
+            400 => 401, make sure this is logged as it could be caused by a broken contract.
+                suggested test case -root cause was the api key length was 1 char over the limit. This caused a 500 back to feeds because we weren't catching the case.
+            403 => 403
+            404 => 401
+     */
 
     @Unroll("Sending request with auth admin response set to HTTP #identityStatusCode")
     def "when failing to authenticate admin client"() {
@@ -184,10 +192,10 @@ class BasicAuthDelegatingTest extends ReposeValveTest {
 
         where:
         reqTenant | identityStatusCode          | delegatedMsg //(these msgs need to be update when done with impl
-        9400      | SC_BAD_REQUEST              | "status_code=500`component=Rackspace Identity Basic Auth`message=Failed with internal server error"
+        9400      | SC_BAD_REQUEST              | "status_code=401`component=Rackspace Identity Basic Auth`message=Bad Request received from identity service for username"
         9401      | SC_UNAUTHORIZED             | "status_code=401`component=Rackspace Identity Basic Auth`message=Failed to authenticate user: $fakeIdentityService.client_username"
-        9403      | SC_FORBIDDEN                | "status_code=500`component=Rackspace Identity Basic Auth`message=Failed with internal server error"
-        9404      | SC_NOT_FOUND                | "status_code=500`component=Rackspace Identity Basic Auth`message=Failed with internal server error"
+        9403      | SC_FORBIDDEN                | "status_code=403`component=Rackspace Identity Basic Auth`message=$fakeIdentityService.client_username is forbidden"
+        9404      | SC_NOT_FOUND                | "status_code=401`component=Rackspace Identity Basic Auth`message=Failed to authenticate user: $fakeIdentityService.client_username"
         9500      | SC_INTERNAL_SERVER_ERROR    | "status_code=500`component=Rackspace Identity Basic Auth`message=Failed with internal server error"
         9501      | SC_NOT_IMPLEMENTED          | "status_code=500`component=Rackspace Identity Basic Auth`message=Failed with internal server error"
         9502      | SC_BAD_GATEWAY              | "status_code=500`component=Rackspace Identity Basic Auth`message=Failed with internal server error"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthStandaloneTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthStandaloneTest.groovy
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -299,10 +299,10 @@ class BasicAuthStandaloneTest extends ReposeValveTest {
 
         where:
         reqTenant | identityStatusCode       | filterStatusCode
-        9400      | SC_BAD_REQUEST           | SC_INTERNAL_SERVER_ERROR
+        9400      | SC_BAD_REQUEST           | SC_UNAUTHORIZED
         9401      | SC_UNAUTHORIZED          | SC_UNAUTHORIZED
-        9403      | SC_FORBIDDEN             | SC_INTERNAL_SERVER_ERROR
-        9404      | SC_NOT_FOUND             | SC_INTERNAL_SERVER_ERROR
+        9403      | SC_FORBIDDEN             | SC_FORBIDDEN
+        9404      | SC_NOT_FOUND             | SC_UNAUTHORIZED
         9500      | SC_INTERNAL_SERVER_ERROR | SC_INTERNAL_SERVER_ERROR
         9501      | SC_NOT_IMPLEMENTED       | SC_INTERNAL_SERVER_ERROR
         9502      | SC_BAD_GATEWAY           | SC_INTERNAL_SERVER_ERROR

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
@@ -26,8 +26,6 @@ import org.apache.commons.lang.RandomStringUtils
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.Response
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import javax.servlet.http.HttpServletResponse
@@ -55,6 +53,7 @@ class BasicAuthTest extends ReposeValveTest {
     }
 
     def setup() {
+        fakeIdentityService.resetHandlers()
         fakeIdentityService.with {
             // This is required to ensure that one piece of the authentication data is changed
             // so that the cached version in the Akka Client is not used.
@@ -216,9 +215,7 @@ class BasicAuthTest extends ReposeValveTest {
         mc.handlings.size() == 0
         mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
     }
-
-
-    @Ignore
+    // REP-2880 - should fix this (removed @Ignore)
     // This test was removed due to a current limitation of the MockIdentityService to not differentiate between the two services calling it.
     @Unroll("Sending request with admin response set to HTTP #identityStatusCode")
     def "when failing to authenticate admin client"() {
@@ -243,9 +240,9 @@ class BasicAuthTest extends ReposeValveTest {
 
         where:
         reqTenant | identityStatusCode                           | filterStatusCode
-        9400      | HttpServletResponse.SC_BAD_REQUEST           | HttpServletResponse.SC_INTERNAL_SERVER_ERROR
+        9400      | HttpServletResponse.SC_BAD_REQUEST           | HttpServletResponse.SC_UNAUTHORIZED
         9401      | HttpServletResponse.SC_UNAUTHORIZED          | HttpServletResponse.SC_UNAUTHORIZED
-        9403      | HttpServletResponse.SC_FORBIDDEN             | HttpServletResponse.SC_INTERNAL_SERVER_ERROR
+        9403      | HttpServletResponse.SC_FORBIDDEN             | HttpServletResponse.SC_FORBIDDEN
         9404      | HttpServletResponse.SC_NOT_FOUND             | HttpServletResponse.SC_UNAUTHORIZED
         9500      | HttpServletResponse.SC_INTERNAL_SERVER_ERROR | HttpServletResponse.SC_INTERNAL_SERVER_ERROR
         9501      | HttpServletResponse.SC_NOT_IMPLEMENTED       | HttpServletResponse.SC_INTERNAL_SERVER_ERROR

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -155,8 +155,6 @@ class BasicAuthTest extends ReposeValveTest {
     }
 
     // identity currently return 400 bad request for api-key > 100 characters
-    // repose log REP-2880 to work on compliant with this response
-    @IgnoreIf({ new Date() < (new GregorianCalendar(2015, Calendar.NOVEMBER, 10)).getTime() })
     def "When the request send with invalid long key > 100 , then will fail to authenticate"() {
         given: "the HTTP Basic authentication header containing the User Name and invalid API Key"
         def key = RandomStringUtils.random(120, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
@@ -167,25 +165,24 @@ class BasicAuthTest extends ReposeValveTest {
         when: "the request does have an HTTP Basic authentication header"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
 
-        then: "response with 400 bad request"
-        mc.receivedResponse.code == HttpServletResponse.SC_BAD_REQUEST.toString()
+        then: "response with 401 Unauthorized"
+        mc.receivedResponse.code == HttpServletResponse.SC_UNAUTHORIZED.toString()
         mc.handlings.size() == 0
         mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
     }
 
-    @IgnoreIf({ new Date() < (new GregorianCalendar(2015, Calendar.NOVEMBER, 10)).getTime() })
     def "When the request send with username > 100 , then will fail to authenticate"() {
         given: "the HTTP Basic authentication header containing the User Name and invalid API Key"
         def username = RandomStringUtils.random(120, 'ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwyz-_1234567890')
         def headers = [
-                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((username + ":" + fakeIdentityService.client_apikey).bytes)
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((username + ":" + "randomAPIKey").bytes)
         ]
 
         when: "the request does have an HTTP Basic authentication header"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
 
-        then: "response with 400 bad request"
-        mc.receivedResponse.code == HttpServletResponse.SC_BAD_REQUEST.toString()
+        then: "response with 401 Unauthorized"
+        mc.receivedResponse.code == HttpServletResponse.SC_UNAUTHORIZED.toString()
         mc.handlings.size() == 0
         mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
@@ -186,7 +186,7 @@ class BasicAuthTest extends ReposeValveTest {
         mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
     }
 
-    def "When identity returns a 403 Unauthorized, repose will also return a 403 unauthorized"() {
+    def "When identity returns a 403 Forbidden, repose will also return a 403 Forbidden"() {
         given: "the HTTP Basic authentication header containing the User Name and forbidden API key"
         def headers = [
                 (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + fakeIdentityService.forbidden_apikey).bytes)

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/BasicAuthTest.groovy
@@ -199,7 +199,7 @@ class BasicAuthTest extends ReposeValveTest {
         then: "response with 403 Forbidden"
         mc.receivedResponse.code == HttpServletResponse.SC_FORBIDDEN.toString()
         mc.handlings.size() == 0
-        mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
+        !mc.receivedResponse.getHeaders().findAll(HttpHeaders.WWW_AUTHENTICATE).contains("Basic realm=\"RAX-KEY\"")
     }
 
     def "When identity returns a 404 Not Found, repose will return a 401 Unauthorized"() {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -556,7 +556,19 @@ class MockIdentityService {
                 template = identitySuccessJsonTemplate
             }
         } else {
-            code = 401
+            //If the username or the apikey are longer than 120 characters, barf back a 400, bad request response
+            //I have to parse the XML body of the request to mimic behavior in identity
+            def auth = new XmlSlurper().parseText(request.body.toString())
+            String username = auth.apiKeyCredentials['@username']
+            String apikey = auth.apiKeyCredentials['@apiKey']
+
+            //Magic numbers are how large of a value identity will parse before giving back a 400 Bad Request
+            if (apikey.length() > 100 || username.length() > 100) {
+                code = 400
+            } else {
+                code = 401
+            }
+
             if (xml) {
                 template = identityFailureXmlTemplate
             } else {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -134,6 +134,8 @@ class MockIdentityService {
     def client_username = 'username';
     def client_userid = 12345; //TODO: this should not be an int, userIDs are UUIDs
     def client_apikey = 'this-is-the-api-key';
+    def forbidden_apikey = 'this-api-key-results-in-forbidden'
+    def not_found_apikey = 'this-api-key-results-in-not-found'
     def admin_token = 'this-is-the-admin-token';
     def admin_tenant = 'this-is-the-admin-tenant'
     def admin_username = 'admin_username';
@@ -158,6 +160,8 @@ class MockIdentityService {
         client_username = 'username';
         client_userid = 12345; //TODO: this should not be an int, userIDs are UUIDs
         client_apikey = 'this-is-the-api-key';
+        forbidden_apikey = 'this-api-key-results-in-forbidden'
+        not_found_apikey = 'this-api-key-results-in-not-found'
         admin_token = 'this-is-the-admin-token';
         admin_tenant = 'this-is-the-admin-tenant'
         admin_username = 'admin_username';
@@ -565,11 +569,16 @@ class MockIdentityService {
             //Magic numbers are how large of a value identity will parse before giving back a 400 Bad Request
             if (apikey.length() > 100 || username.length() > 100) {
                 code = 400
+            } else if (request.body.toString().contains(forbidden_apikey)) {
+                code = 403
+            }else if (request.body.toString().contains(not_found_apikey)) {
+                code = 404
             } else {
                 code = 401
             }
 
             if (xml) {
+                //TODO: This failure template is *ONLY* valid for token not found, NOT USEFUL
                 template = identityFailureXmlTemplate
             } else {
                 template = identityFailureJsonTemplate

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -571,7 +571,7 @@ class MockIdentityService {
                 code = 400
             } else if (request.body.toString().contains(forbidden_apikey)) {
                 code = 403
-            }else if (request.body.toString().contains(not_found_apikey)) {
+            } else if (request.body.toString().contains(not_found_apikey)) {
                 code = 404
             } else {
                 code = 401


### PR DESCRIPTION
Un-ignored the ignored tests, updated their acceptance criteria. Added a couple more tests for the other response codes.

Updated the mess of the mock identity service, now it's even more of a mess :( Tried to make the least mess.

Did the implementation. When 400 is received from identity, I log the response that came from identity. This could expose credentials to the logs, but it would only be what identity already is approved to expose. Just goes into our logs instead of back to the client. It's logged at the warn level, because a bad request response from identity probably isn't a good thing.