### PR TITLE
Rep 2886

### DIFF
--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/objects/OpenStackIdentityV3Objects.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/objects/OpenStackIdentityV3Objects.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -148,7 +148,7 @@ case class Scope(domain: Option[DomainScope] = None,
 
 case class Group(id: String,
                  name: String,
-                 description: String,
+                 description: Option[String] = None,
                  domain_id: Option[String] = None) extends Serializable
 
 case class Groups(groups: List[Group]) extends Serializable

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/test/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3APITest.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/test/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3APITest.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -477,7 +477,7 @@ class OpenStackIdentityV3APITest extends FunSpec with BeforeAndAfter with Matche
     }
 
     it("should return a Success for cached groups") {
-      when(mockDatastore.get(anyString)).thenReturn(List(Group("", "", "")).toBuffer.asInstanceOf[Serializable], Nil: _*)
+      when(mockDatastore.get(anyString)).thenReturn(List(Group("", "", Some(""))).toBuffer.asInstanceOf[Serializable], Nil: _*)
 
       identityV3API invokePrivate getGroups("test-user-id", None, false) shouldBe a[Success[_]]
       identityV3API.invokePrivate(getGroups("test-user-id", None, false)).get shouldBe a[List[_]]

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/IdentityV3Test.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/IdentityV3Test.groovy
@@ -38,6 +38,7 @@ class IdentityV3Test extends ReposeValveTest {
 
     def setupSpec() {
         deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
         def params = properties.defaultTemplateParams
         repose.configurationProvider.applyConfigs("common", params)
         repose.configurationProvider.applyConfigs("features/filters/identityv3/common", params)
@@ -87,6 +88,9 @@ class IdentityV3Test extends ReposeValveTest {
         then: "Request body sent from repose to the origin service should contain"
         mc.receivedResponse.code == "200"
         mc.handlings.size() == 1
+        // REP-2886 fix: ERROR org.openrepose.powerfilter.PowerFilterChain - Failure in filter: OpenStackIdentityV3Filter
+        // when missing group discription
+        reposeLogSearch.searchByString("ERROR org.openrepose.powerfilter.PowerFilterChain - Failure in filter: OpenStackIdentityV3Filter").size() == 0
     }
 
     def "Tracing header should include in request to Identity"() {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/IdentityV3Test.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/IdentityV3Test.groovy
@@ -90,7 +90,7 @@ class IdentityV3Test extends ReposeValveTest {
         mc.handlings.size() == 1
         // REP-2886 fix: ERROR org.openrepose.powerfilter.PowerFilterChain - Failure in filter: OpenStackIdentityV3Filter
         // when missing group discription
-        reposeLogSearch.searchByString("ERROR org.openrepose.powerfilter.PowerFilterChain - Failure in filter: OpenStackIdentityV3Filter").size() == 0
+        reposeLogSearch.searchByString("ERROR org.openrepose.powerfilter.PowerFilterChain - Failure in filter: OpenStackIdentityV3Filter  -  Reason: Object is missing required member 'description'").size() == 0
     }
 
     def "Tracing header should include in request to Identity"() {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV3Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV3Service.groovy
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -684,7 +684,6 @@ class MockIdentityV3Service {
                 "name": "Developers"
             },
             {
-                "description": "Developers cleared for work on secret projects",
                 "domain_id": "\${domainid}",
                 "id": "a62db1",
                 "links": {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV3Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV3Service.groovy
@@ -689,6 +689,14 @@ class MockIdentityV3Service {
                 "links": {
                     "self": "https://identity:35357/v3/groups/a62db1"
                 },
+                "name": "Repose Developers"
+            },
+            {
+                "domain_id": "\${domainid}",
+                "id": "a62db2",
+                "links": {
+                    "self": "https://identity:35357/v3/groups/a62db2"
+                },
                 "name": "Secure Developers"
             }
         ],


### PR DESCRIPTION
Just making the `description` an `Optional[String]` works.

Of note, this wouldn't be a problem if we refactor IdentityV3 to use play-json and json pathing. We'd only extract the things we care about, and we'd be more resiliant to contract oddities.