### PR TITLE
Here is an interim solution that will fix the Debian WAR installations.

### DIFF
--- a/repose-aggregator/installation/deb/repose-cli-utils/src/deb/control/control
+++ b/repose-aggregator/installation/deb/repose-cli-utils/src/deb/control/control
@@ -6,4 +6,4 @@ Architecture: all
 Maintainer: Repose Development <repose-development@lists.openrepose.org>
 Description: Debian Package for the Repose Valve
 Homepage: http://openrepose.org
-Depends: java7-runtime-headless, repose-valve (=[[version]]) | repose-war (=[[version]])
+Depends: java7-runtime-headless, repose-valve (=[[version]]) | repose-war (=[[version]]) | repose-deb-war (=[[version]])

--- a/repose-aggregator/installation/deb/repose-extensions-filter-bundle/src/deb/control/control
+++ b/repose-aggregator/installation/deb/repose-extensions-filter-bundle/src/deb/control/control
@@ -7,4 +7,4 @@ Maintainer: Repose Development <repose-development@lists.openrepose.org>
 Description: Debian Package for Repose Extension Filter Bundle
 Homepage: http://openrepose.org
 Provides: repose
-Depends: java7-runtime-headless, repose-valve (=[[version]]) | repose-war (=[[version]])
+Depends: java7-runtime-headless, repose-valve (=[[version]]) | repose-war (=[[version]]) | repose-deb-war (=[[version]])

--- a/repose-aggregator/installation/deb/repose-filter-bundle/src/deb/control/control
+++ b/repose-aggregator/installation/deb/repose-filter-bundle/src/deb/control/control
@@ -6,4 +6,4 @@ Architecture: all
 Maintainer: Repose Development <repose-development@lists.openrepose.org>
 Description: Debian Package for the Repose Filter Bundle
 Homepage: http://openrepose.org
-Depends: java7-runtime-headless, repose-valve (=[[version]]) | repose-war (=[[version]])
+Depends: java7-runtime-headless, repose-valve (=[[version]]) | repose-war (=[[version]]) | repose-deb-war (=[[version]])


### PR DESCRIPTION
It adds the additional incorrect package name to the possible dependencies list.