### PR TITLE
AkkaServiceClient - Connection pool ID

### DIFF
--- a/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationFilter.java
+++ b/repose-aggregator/components/filters/client-auth/src/main/java/org/openrepose/filters/clientauth/ClientAuthenticationFilter.java
@@ -25,7 +25,7 @@ import org.openrepose.core.filter.logic.impl.FilterLogicHandlerDelegate;
 import org.openrepose.core.services.config.ConfigurationService;
 import org.openrepose.core.services.datastore.DatastoreService;
 import org.openrepose.core.services.httpclient.HttpClientService;
-import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
+import org.openrepose.core.services.serviceclient.akka.AkkaServiceClientFactory;
 import org.openrepose.core.spring.ReposeSpringProperties;
 import org.openrepose.core.systemmodel.SystemModel;
 import org.openrepose.filters.clientauth.config.ClientAuthConfig;
@@ -48,7 +48,7 @@ public class ClientAuthenticationFilter implements Filter {
     private final DatastoreService datastoreService;
     private final ConfigurationService configurationService;
     private final HttpClientService httpClientService;
-    private final AkkaServiceClient akkaServiceClient;
+    private final AkkaServiceClientFactory akkaServiceClientFactory;
     private final String reposeVersion;
     private String config;
     private ClientAuthenticationHandlerFactory handlerFactory;
@@ -58,18 +58,21 @@ public class ClientAuthenticationFilter implements Filter {
     public ClientAuthenticationFilter(DatastoreService datastoreService,
                                       ConfigurationService configurationService,
                                       HttpClientService httpClientService,
-                                      AkkaServiceClient akkaServiceClient,
+                                      AkkaServiceClientFactory akkaServiceClientFactory,
                                       @Value(ReposeSpringProperties.CORE.REPOSE_VERSION) String reposeVersion) {
         this.datastoreService = datastoreService;
         this.httpClientService = httpClientService;
-        this.akkaServiceClient = akkaServiceClient;
+        this.akkaServiceClientFactory = akkaServiceClientFactory;
         this.configurationService = configurationService;
         this.reposeVersion = reposeVersion;
     }
 
     @Override
     public void destroy() {
-        handlerFactory.stopFeeds();
+        if (handlerFactory != null) {
+            handlerFactory.destroy();
+        }
+
         configurationService.unsubscribeFrom(config, handlerFactory);
         configurationService.unsubscribeFrom("system-model.cfg.xml", systemModelConfigurationListener);
     }
@@ -84,7 +87,7 @@ public class ClientAuthenticationFilter implements Filter {
         LOG.warn("This filter is deprecated; use the keystone-v2 filter");
         config = new FilterConfigHelper(filterConfig).getFilterConfig(DEFAULT_CONFIG);
         LOG.info("Initializing filter using config " + config);
-        handlerFactory = new ClientAuthenticationHandlerFactory(datastoreService.getDefaultDatastore(), httpClientService, akkaServiceClient, reposeVersion);
+        handlerFactory = new ClientAuthenticationHandlerFactory(datastoreService.getDefaultDatastore(), httpClientService, akkaServiceClientFactory, reposeVersion);
         URL xsdURL = getClass().getResource("/META-INF/schema/config/client-auth-n-configuration.xsd");
         configurationService.subscribeTo(filterConfig.getFilterName(), config, xsdURL, handlerFactory, ClientAuthConfig.class);
         URL smXsdURL = getClass().getResource("/META-INF/schema/system-model/system-model.xsd");

--- a/repose-aggregator/components/filters/client-authorization/src/main/java/org/openrepose/filters/authz/RackspaceAuthorizationFilter.java
+++ b/repose-aggregator/components/filters/client-authorization/src/main/java/org/openrepose/filters/authz/RackspaceAuthorizationFilter.java
@@ -25,7 +25,7 @@ import org.openrepose.core.filter.logic.impl.FilterLogicHandlerDelegate;
 import org.openrepose.core.services.config.ConfigurationService;
 import org.openrepose.core.services.datastore.DatastoreService;
 import org.openrepose.core.services.httpclient.HttpClientService;
-import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
+import org.openrepose.core.services.serviceclient.akka.AkkaServiceClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +44,7 @@ public class RackspaceAuthorizationFilter implements Filter {
     private final ConfigurationService configurationService;
     private final DatastoreService datastoreService;
     private final HttpClientService httpClientService;
-    private final AkkaServiceClient akkaServiceClient;
+    private final AkkaServiceClientFactory akkaServiceClientFactory;
     private String config;
     private RequestAuthorizationHandlerFactory handlerFactory;
 
@@ -52,11 +52,11 @@ public class RackspaceAuthorizationFilter implements Filter {
     public RackspaceAuthorizationFilter(ConfigurationService configurationService,
                                         DatastoreService datastoreService,
                                         HttpClientService httpClientService,
-                                        AkkaServiceClient akkaServiceClient) {
+                                        AkkaServiceClientFactory akkaServiceClientFactory) {
         this.configurationService = configurationService;
         this.datastoreService = datastoreService;
         this.httpClientService = httpClientService;
-        this.akkaServiceClient = akkaServiceClient;
+        this.akkaServiceClientFactory = akkaServiceClientFactory;
     }
 
     @Override
@@ -66,6 +66,10 @@ public class RackspaceAuthorizationFilter implements Filter {
 
     @Override
     public void destroy() {
+        if (handlerFactory != null) {
+            handlerFactory.destroy();
+        }
+
         configurationService.unsubscribeFrom(config, handlerFactory);
     }
 
@@ -74,7 +78,7 @@ public class RackspaceAuthorizationFilter implements Filter {
         LOG.warn("This filter is deprecated; use the keystone-v2 filter");
         config = new FilterConfigHelper(filterConfig).getFilterConfig(DEFAULT_CONFIG);
         LOG.info("Initializing filter using config " + config);
-        handlerFactory = new RequestAuthorizationHandlerFactory(datastoreService.getDefaultDatastore(), httpClientService, akkaServiceClient);
+        handlerFactory = new RequestAuthorizationHandlerFactory(datastoreService.getDefaultDatastore(), httpClientService, akkaServiceClientFactory);
         URL xsdURL = getClass().getResource("/META-INF/schema/config/openstack-authorization-configuration.xsd");
         configurationService.subscribeTo(filterConfig.getFilterName(), config, xsdURL, handlerFactory, RackspaceAuthorization.class);
     }

--- a/repose-aggregator/components/filters/keystone-v2/src/main/resources/META-INF/schema/config/keystone-v2.xsd
+++ b/repose-aggregator/components/filters/keystone-v2/src/main/resources/META-INF/schema/config/keystone-v2.xsd
@@ -86,14 +86,13 @@
             </xs:annotation>
         </xs:attribute>
 
-        <!-- todo: the AkkaServiceClient uses the default pool and is hard-coded... -->
-        <!--xs:attribute name="connection-pool-id" type="xs:string" use="optional">
+        <xs:attribute name="connection-pool-id" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     <html:p>Http Connection pool ID to use when talking to Rackspace Keystone V2 Identity</html:p>
                 </xs:documentation>
             </xs:annotation>
-        </xs:attribute-->
+        </xs:attribute>
         <xs:attribute name="set-roles-in-header" type="xs:boolean" use="optional" default="true">
             <xs:annotation>
                 <xs:documentation>

--- a/repose-aggregator/components/filters/keystone-v2/src/main/resources/META-INF/schema/examples/keystone-v2.cfg.xml
+++ b/repose-aggregator/components/filters/keystone-v2/src/main/resources/META-INF/schema/examples/keystone-v2.cfg.xml
@@ -22,6 +22,7 @@
 <keystone-v2 xmlns="http://docs.openrepose.org/repose/keystone-v2/v1.0">
     <identity-service
             uri="https://some.identity.com"
+            connection-pool-id="keystone-v2-pool"
             set-groups-in-header="true"
             set-catalog-in-header="false"
             />

--- a/repose-aggregator/components/filters/keystone-v2/src/test/scala/org/openrepose/filters/keystonev2/KeystoneV2FilterPrepTest.scala
+++ b/repose-aggregator/components/filters/keystone-v2/src/test/scala/org/openrepose/filters/keystonev2/KeystoneV2FilterPrepTest.scala
@@ -4,10 +4,12 @@ import java.net.URL
 
 import com.mockrunner.mock.web.MockFilterConfig
 import org.junit.runner.RunWith
+import org.mockito.AdditionalMatchers._
+import org.mockito.Matchers._
 import org.mockito.{ArgumentCaptor, Matchers => MockitoMatcher, Mockito}
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.core.services.datastore.{Datastore, DatastoreService}
-import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient
+import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClientFactory, AkkaServiceClient}
 import org.openrepose.core.systemmodel.SystemModel
 import org.openrepose.filters.keystonev2.config.KeystoneV2Config
 import org.scalatest.junit.JUnitRunner
@@ -30,8 +32,10 @@ class KeystoneV2FilterPrepTest extends FunSpec with Matchers with MockitoSugar w
   describe("when the filter is initialized") {
     it("should initialize the configuration") {
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
       val mockConfigService = mock[ConfigurationService]
-      val filter: KeystoneV2Filter = new KeystoneV2Filter(mockConfigService, mockAkkaServiceClient, mockDatastoreService)
+      Mockito.when(mockAkkaServiceClientFactory.newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String]))).thenReturn(mockAkkaServiceClient)
+      val filter: KeystoneV2Filter = new KeystoneV2Filter(mockConfigService, mockAkkaServiceClientFactory, mockDatastoreService)
 
       val config: MockFilterConfig = new MockFilterConfig
       config.setFilterName("KeystoneV2Filter")
@@ -56,8 +60,10 @@ class KeystoneV2FilterPrepTest extends FunSpec with Matchers with MockitoSugar w
 
     it("should initialize a configuration with a different name") {
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
       val mockConfigService = mock[ConfigurationService]
-      val filter: KeystoneV2Filter = new KeystoneV2Filter(mockConfigService, mockAkkaServiceClient, mockDatastoreService)
+      Mockito.when(mockAkkaServiceClientFactory.newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String]))).thenReturn(mockAkkaServiceClient)
+      val filter: KeystoneV2Filter = new KeystoneV2Filter(mockConfigService, mockAkkaServiceClientFactory, mockDatastoreService)
 
       val config: MockFilterConfig = new MockFilterConfig
       config.setFilterName("KeystoneV2Filter")
@@ -84,7 +90,7 @@ class KeystoneV2FilterPrepTest extends FunSpec with Matchers with MockitoSugar w
 
   it("deregisters from the configuration service when destroying") {
     val mockConfigService = mock[ConfigurationService]
-    val filter: KeystoneV2Filter = new KeystoneV2Filter(mockConfigService, mock[AkkaServiceClient], mockDatastoreService)
+    val filter: KeystoneV2Filter = new KeystoneV2Filter(mockConfigService, mock[AkkaServiceClientFactory], mockDatastoreService)
 
     val config: MockFilterConfig = new MockFilterConfig
     filter.init(config)
@@ -95,7 +101,7 @@ class KeystoneV2FilterPrepTest extends FunSpec with Matchers with MockitoSugar w
 
   describe("when the configuration is updated") {
     it("sets the current configuration on the filter asserting the defaults and initialized is true") {
-      val filter = new KeystoneV2Filter(mock[ConfigurationService], mock[AkkaServiceClient], mockDatastoreService)
+      val filter = new KeystoneV2Filter(mock[ConfigurationService], mock[AkkaServiceClientFactory], mockDatastoreService)
       filter.isInitialized shouldNot be(right = true)
 
       val configuration = Marshaller.keystoneV2ConfigFromString(
@@ -132,7 +138,7 @@ class KeystoneV2FilterPrepTest extends FunSpec with Matchers with MockitoSugar w
     }
 
     it("sets the default delegating quality to 0.7") {
-      val filter = new KeystoneV2Filter(mock[ConfigurationService], mock[AkkaServiceClient], mockDatastoreService)
+      val filter = new KeystoneV2Filter(mock[ConfigurationService], mock[AkkaServiceClientFactory], mockDatastoreService)
       filter.isInitialized shouldNot be(right = true)
 
       val configuration = Marshaller.keystoneV2ConfigFromString(

--- a/repose-aggregator/components/filters/keystone-v2/src/test/scala/org/openrepose/filters/keystonev2/MockedAkkaServiceClient.scala
+++ b/repose-aggregator/components/filters/keystone-v2/src/test/scala/org/openrepose/filters/keystonev2/MockedAkkaServiceClient.scala
@@ -98,6 +98,8 @@ trait MockedAkkaServiceClient {
         throw new Exception("OVERSTEPPED BOUNDARIES")
       }
     }
+
+    override def destroy(): Unit = {}
   }
 
   val mockAkkaServiceClient = new MockAkkaServiceClient

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/config/openstack-identity-v3.xsd
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/config/openstack-identity-v3.xsd
@@ -119,6 +119,14 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
+        <xs:attribute name="connection-pool-id" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Http Connection pool ID to use when talking to OpenStack Identity v3</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="WhiteList">

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/examples/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/resources/META-INF/schema/examples/openstack-identity-v3.cfg.xml
@@ -3,7 +3,8 @@
 <openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"
                        token-cache-timeout="300000"
                        groups-cache-timeout="300000"
-                       cache-offset="10000">
+                       cache-offset="10000"
+                       connection-pool-id="identity-v3-pool">
 
     <white-list>
         <uri-pattern>/application\.wadl$</uri-pattern>

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Filter.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Filter.scala
@@ -30,14 +30,14 @@ import org.openrepose.core.filter.logic.impl.FilterLogicHandlerDelegate
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.core.services.datastore.DatastoreService
 import org.openrepose.core.services.httpclient.HttpClientService
-import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient
+import org.openrepose.core.services.serviceclient.akka.AkkaServiceClientFactory
 import org.openrepose.filters.openstackidentityv3.config.OpenstackIdentityV3Config
 
 @Named
 class OpenStackIdentityV3Filter @Inject()(configurationService: ConfigurationService,
                                           datastoreService: DatastoreService,
                                           httpClientService: HttpClientService,
-                                          akkaServiceClient: AkkaServiceClient) extends Filter with LazyLogging {
+                                          akkaServiceClientFactory: AkkaServiceClientFactory) extends Filter with LazyLogging {
 
   private final val DEFAULT_CONFIG = "openstack-identity-v3.cfg.xml"
 
@@ -47,7 +47,7 @@ class OpenStackIdentityV3Filter @Inject()(configurationService: ConfigurationSer
   override def init(filterConfig: FilterConfig) {
     config = new FilterConfigHelper(filterConfig).getFilterConfig(DEFAULT_CONFIG)
     logger.info("Initializing filter using config " + config)
-    handlerFactory = new OpenStackIdentityV3HandlerFactory(akkaServiceClient, datastoreService)
+    handlerFactory = new OpenStackIdentityV3HandlerFactory(akkaServiceClientFactory, datastoreService)
     val xsdURL: URL = getClass.getResource("/META-INF/config/schema/openstack-identity-v3.xsd")
     // TODO: Clean up the asInstanceOf below, if possible?
     configurationService.subscribeTo(filterConfig.getFilterName,
@@ -62,6 +62,7 @@ class OpenStackIdentityV3Filter @Inject()(configurationService: ConfigurationSer
   }
 
   override def destroy() {
+    handlerFactory.destroy()
     configurationService.unsubscribeFrom(config, handlerFactory)
   }
 }

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3HandlerFactory.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3HandlerFactory.scala
@@ -24,14 +24,15 @@ import java.util
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.core.filter.logic.AbstractConfiguredFilterHandlerFactory
 import org.openrepose.core.services.datastore.DatastoreService
-import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient
+import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClientFactory, AkkaServiceClient}
 import org.openrepose.filters.openstackidentityv3.config.OpenstackIdentityV3Config
 import org.openrepose.filters.openstackidentityv3.utilities.OpenStackIdentityV3API
 
-class OpenStackIdentityV3HandlerFactory(akkaServiceClient: AkkaServiceClient, datastoreService: DatastoreService)
+class OpenStackIdentityV3HandlerFactory(akkaServiceClientFactory: AkkaServiceClientFactory, datastoreService: DatastoreService)
   extends AbstractConfiguredFilterHandlerFactory[OpenStackIdentityV3Handler] {
 
   private var keystoneHandler: OpenStackIdentityV3Handler = _
+  private var akkaServiceClient: AkkaServiceClient = _
 
   override def buildHandler: OpenStackIdentityV3Handler = {
     if (isInitialized) keystoneHandler
@@ -46,10 +47,18 @@ class OpenStackIdentityV3HandlerFactory(akkaServiceClient: AkkaServiceClient, da
     listenerMap
   }
 
+  def destroy(): Unit = {
+    akkaServiceClient.destroy()
+  }
+
   private class KeystoneV3ConfigurationListener extends UpdateListener[OpenstackIdentityV3Config] {
     private var initialized = false
 
     def configurationUpdated(config: OpenstackIdentityV3Config) {
+      val akkaServiceClientOld = Option(akkaServiceClient)
+      akkaServiceClient = akkaServiceClientFactory.newAkkaServiceClient(config.getConnectionPoolId)
+      akkaServiceClientOld.foreach(_.destroy())
+
       val identityAPI = new OpenStackIdentityV3API(config, datastoreService.getDefaultDatastore, akkaServiceClient)
       keystoneHandler = new OpenStackIdentityV3Handler(config, identityAPI)
       initialized = true

--- a/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3HandlerFactory.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3HandlerFactory.scala
@@ -48,7 +48,7 @@ class OpenStackIdentityV3HandlerFactory(akkaServiceClientFactory: AkkaServiceCli
   }
 
   def destroy(): Unit = {
-    akkaServiceClient.destroy()
+    Option(akkaServiceClient).foreach(_.destroy())
   }
 
   private class KeystoneV3ConfigurationListener extends UpdateListener[OpenstackIdentityV3Config] {

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/resources/META-INF/schema/config/rackspace-identity-basic-auth.xsd
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/resources/META-INF/schema/config/rackspace-identity-basic-auth.xsd
@@ -59,6 +59,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="connection-pool-id" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Http Connection pool ID to use when talking to Keystone v2 Identity</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="DelegatingType">

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/resources/META-INF/schema/examples/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/src/main/resources/META-INF/schema/examples/rackspace-identity-basic-auth.cfg.xml
@@ -3,4 +3,5 @@
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
         rackspace-identity-service-uri="http://identity.example.com:8080/v2.0/tokens"
-        token-cache-timeout-millis="600000"/>
+        token-cache-timeout-millis="600000"
+        connection-pool-id="basic-auth-pool"/>

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/config/valkyrie-authorization.xsd
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/config/valkyrie-authorization.xsd
@@ -71,6 +71,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="connection-pool-id" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Http Connection pool ID to use when talking to Valkyrie</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="ValkyrieServer">

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/examples/valkyrie-authorization.cfg.xml
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/examples/valkyrie-authorization.cfg.xml
@@ -3,7 +3,9 @@
         xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0"
         cache-timeout-millis="300000"
         enable-masking-403s="true"
-        enable-bypass-account-admin="false">
+        enable-bypass-account-admin="false"
+        connection-pool-id="valkyrie-auth-pool">
+
     <!-- Used is you wish to use delegating authorization, see derp filter -->
     <delegating quality="0.9"/>
     <!-- Which valkyrie instance to hit and with which credentials -->

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/test/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilterTest.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/test/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilterTest.scala
@@ -927,7 +927,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should remove null values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(setNullDeviceIdAction(createGenericValkyrieConfiguration(null), DeviceIdMismatchAction.REMOVE))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -954,7 +954,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should not remove null values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(setNullDeviceIdAction(createGenericValkyrieConfiguration(null), DeviceIdMismatchAction.KEEP))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -981,7 +981,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should fail on null values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(setNullDeviceIdAction(createGenericValkyrieConfiguration(null), DeviceIdMismatchAction.FAIL))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -1005,7 +1005,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should remove mismatched values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(setNullDeviceIdAction(createGenericValkyrieConfiguration(null), DeviceIdMismatchAction.REMOVE))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -1032,7 +1032,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should not remove mismatched values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(setNullDeviceIdAction(createGenericValkyrieConfiguration(null), DeviceIdMismatchAction.KEEP))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -1059,7 +1059,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should fail on mismatched values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(setNullDeviceIdAction(createGenericValkyrieConfiguration(null), DeviceIdMismatchAction.FAIL))
 
       val mockServletRequest = new MockHttpServletRequest

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/test/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilterTest.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/test/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilterTest.scala
@@ -29,6 +29,8 @@ import javax.servlet.{FilterChain, ServletRequest, ServletResponse}
 import com.mockrunner.mock.web.{MockFilterConfig, MockHttpServletRequest, MockHttpServletResponse}
 import com.rackspace.httpdelegation.{HttpDelegationHeaderNames, HttpDelegationManager}
 import org.junit.runner.RunWith
+import org.mockito.AdditionalMatchers._
+import org.mockito.Matchers._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.{ArgumentCaptor, Matchers, Mockito}
@@ -36,7 +38,7 @@ import org.openrepose.commons.utils.http.{CommonHttpHeader, ServiceClientRespons
 import org.openrepose.commons.utils.servlet.http.{MutableHttpServletRequest, MutableHttpServletResponse}
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.core.services.datastore.{Datastore, DatastoreService}
-import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClient, AkkaServiceClientException}
+import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClientFactory, AkkaServiceClient, AkkaServiceClientException}
 import org.openrepose.filters.valkyrieauthorization.config.DevicePath.Regex
 import org.openrepose.filters.valkyrieauthorization.config._
 import org.scalatest.junit.JUnitRunner
@@ -54,6 +56,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
   // probably still worthwhile. I think some describe mocking behavior where it's not neccessary as well. Short
   // timelines mean i can't dig into them right now.
   val akkaServiceClient = mock[AkkaServiceClient]
+  val akkaServiceClientFactory = mock[AkkaServiceClientFactory]
   val mockDatastoreService = mock[DatastoreService]
   val mockDatastore: Datastore = mock[Datastore]
   Mockito.when(mockDatastoreService.getDefaultDatastore).thenReturn(mockDatastore)
@@ -61,12 +64,15 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
   before {
     Mockito.reset(mockDatastore)
     Mockito.reset(akkaServiceClient)
+    Mockito.reset(akkaServiceClientFactory)
+
+    Mockito.when(akkaServiceClientFactory.newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String]))).thenReturn(akkaServiceClient)
   }
 
   describe("when initializing the filter") {
     it("should initialize the configuration to a given configuration") {
       val mockConfigService = mock[ConfigurationService]
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mockConfigService, akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mockConfigService, akkaServiceClientFactory, mockDatastoreService)
 
       val config: MockFilterConfig = new MockFilterConfig
       config.setFilterName("ValkyrieFilter")
@@ -86,7 +92,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
 
     it("should initialize the configuration to a given name") {
       val mockConfigService = mock[ConfigurationService]
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mockConfigService, akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mockConfigService, akkaServiceClientFactory, mockDatastoreService)
 
       val config: MockFilterConfig = new MockFilterConfig
       config.setInitParameter("filter-config", "another-name.cfg.xml")
@@ -105,7 +111,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
   describe("when destroying the filter") {
     it("should deregister the configuration from the configuration service") {
       val mockConfigService = mock[ConfigurationService]
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mockConfigService, akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mockConfigService, akkaServiceClientFactory, mockDatastoreService)
 
       val config: MockFilterConfig = new MockFilterConfig
       filter.init(config)
@@ -113,11 +119,23 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
 
       Mockito.verify(mockConfigService).unsubscribeFrom("valkyrie-authorization.cfg.xml", filter)
     }
+
+    it("should destroy the akka service client") {
+      val mockConfigService = mock[ConfigurationService]
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mockConfigService, akkaServiceClientFactory, mockDatastoreService)
+
+      val config: MockFilterConfig = new MockFilterConfig
+      filter.init(config)
+      filter.configurationUpdated(new ValkyrieAuthorizationConfig)
+      filter.destroy
+
+      Mockito.verify(akkaServiceClient).destroy()
+    }
   }
 
   describe("when the configuration is updated") {
     it("should set the current configuration on the filter with the defaults initially and flag that it is initialized") {
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
 
       assert(!filter.isInitialized)
 
@@ -131,7 +149,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     }
 
     it("should set the default delegation quality to .1") {
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
 
       assert(filter.configuration == null)
 
@@ -144,7 +162,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     }
 
     it("should set the configuration to current and update the cache timeout") {
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
 
       val configuration = new ValkyrieAuthorizationConfig
       filter.configurationUpdated(configuration)
@@ -157,6 +175,24 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
 
       assert(filter.configuration == newConfiguration)
       assert(filter.isInitialized)
+    }
+
+    it("should destroy the previous akka service client if one already existed") {
+      val firstAkkaServiceClient = mock[AkkaServiceClient]
+      val secondAkkaServiceClient = mock[AkkaServiceClient]
+      Mockito.when(akkaServiceClientFactory.newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String])))
+        .thenReturn(firstAkkaServiceClient)
+        .thenReturn(secondAkkaServiceClient)
+
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
+
+      val configuration = new ValkyrieAuthorizationConfig
+      filter.configurationUpdated(configuration)
+      filter.configurationUpdated(configuration)
+
+      Mockito.verify(akkaServiceClientFactory, Mockito.times(2)).newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String]))
+      Mockito.verify(firstAkkaServiceClient, Mockito.times(1)).destroy()
+      Mockito.verify(secondAkkaServiceClient, Mockito.never()).destroy()
     }
   }
 
@@ -174,7 +210,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
       it(s"should allow requests for $request with Valkyrie response of $valkyrie") {
         setMockAkkaBehavior("someTenant", request.headers.getOrElse("X-Contact-Id", "ThisIsMissingAContact"), valkyrie.code, valkyrie.payload)
 
-        val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+        val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
         filter.configurationUpdated(createGenericValkyrieConfiguration(null))
 
         val mockServletRequest = new MockHttpServletRequest
@@ -203,7 +239,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
       it(s"should allow requests for $request with Valkyrie response of $valkyrie without device id when on either accepted list") {
         setMockAkkaBehavior("someTenant", request.headers.getOrElse("X-Contact-Id", "ThisIsMissingAContact"), valkyrie.code, valkyrie.payload)
 
-        val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+        val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
         filter.configurationUpdated(createGenericValkyrieConfiguration(null))
 
         val mockServletRequest = new MockHttpServletRequest
@@ -239,7 +275,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
         it(s"should be ${result.code} where delegation is $delegating for $request with Valkyrie response of $valkyrie") {
           setMockAkkaBehavior("someTenant", request.headers.getOrElse("X-Contact-Id", "ThisIsMissingAContact"), valkyrie.code, valkyrie.payload)
 
-          val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+          val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
           filter.configurationUpdated(createGenericValkyrieConfiguration(delegation))
 
           val mockServletRequest = new MockHttpServletRequest
@@ -269,7 +305,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
       it(s"should return a 502 and delegation is $delegating with appropriate message when unable to communicate with Valkyrie") {
         Mockito.when(akkaServiceClient.get(Matchers.any(), Matchers.any(), Matchers.any())).thenThrow(new AkkaServiceClientException("Valkyrie is missing", new Exception()))
 
-        val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+        val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
         filter.configurationUpdated(createGenericValkyrieConfiguration(delegation))
 
         val mockServletRequest = new MockHttpServletRequest
@@ -294,7 +330,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     }
 
     it("should bypasses validation if the user has a role listed in pre-authorized-roles") {
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
 
       val configuration = createGenericValkyrieConfiguration(null)
       val preAuthorizedRoles: RolesList = new RolesList
@@ -324,7 +360,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
         200,
         createValkyrieResponse(devicePermissions("123456", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       Mockito.when(mockDatastore.get("VALKYRIE-FILTERanysomeTenant123456")).thenAnswer(new Answer[Serializable] {
         var firstAttempt = true
 
@@ -377,7 +413,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
 
         setMockAkkaBehavior("someTenant", request.headers.getOrElse("X-Contact-Id", "123456"), 200, createValkyrieResponse(devicePermissions("123456", "view_product")))
 
-        val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+        val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
         val configuration: ValkyrieAuthorizationConfig = createGenericValkyrieConfiguration(delegation)
         configuration.setEnableMasking403S(true)
         filter.configurationUpdated(configuration)
@@ -419,7 +455,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
           setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(accountPermissions("account_admin", "butts_permission"), devicePermissions(deviceIdInEffective, "admin_product")))
           setAdminAkkaBehavior("someTenant", "123456", 200, accountInventory(deviceIdInInventory, "10001"))
 
-          val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+          val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
           filter.configurationUpdated(createGenericValkyrieConfiguration(null, enableBypassAccountAdmin))
 
           val mockServletRequest = new MockHttpServletRequest
@@ -442,7 +478,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(accountPermissions("account_admin", "butts_permission"), devicePermissions("12345", "admin_product")))
       setAdminAkkaBehavior("someTenant", "123456", 500, "")
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(createGenericValkyrieConfiguration(null, false))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -468,7 +504,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
         Map("X-Auth-User" -> "someUser", "X-Auth-Token" -> "somePassword", CommonHttpHeader.TRACE_GUID.toString -> "test-guid")))
         .thenReturn(new ServiceClientResponse(200, new ByteArrayInputStream(createValkyrieResponse(devicePermissions("123456", "view_product")).getBytes)))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(createGenericValkyrieConfiguration(null))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -495,7 +531,8 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     val filterChain = mock[FilterChain]
     val mockServletRequest = new MockHttpServletRequest
     val mockServletResponse = new MockHttpServletResponse
-    val filter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+    Mockito.when(akkaServiceClientFactory.newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String]))).thenReturn(akkaServiceClient)
+    val filter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
     filter.configurationUpdated(config)
 
     def setup() = {
@@ -554,7 +591,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     val mockServletRequest = new MockHttpServletRequest
     val mockServletResponse = new MockHttpServletResponse
     val devices = devicePermissions("98765", "view_product")
-    val filter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+    val filter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
     filter.configurationUpdated(config)
 
     def setup() = {
@@ -681,7 +718,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     val filterChain = mock[FilterChain]
     val mockServletRequest = new MockHttpServletRequest
     val mockServletResponse = new MockHttpServletResponse
-    val filter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+    val filter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
     filter.configurationUpdated(config)
 
     def setup() = {
@@ -809,7 +846,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should remove some of the values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(createGenericValkyrieConfiguration(null))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -836,7 +873,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should remove all values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(createGenericValkyrieConfiguration(null))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -863,7 +900,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should remove no values") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(createGenericValkyrieConfiguration(null))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -1046,7 +1083,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should remove no values for account admins with Bypass Account Admin enabled") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(accountPermissions("account_admin", "butts_permission")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(createGenericValkyrieConfiguration(null))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -1074,7 +1111,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(accountPermissions("account_admin", "butts_permission")))
       setAdminAkkaBehavior("someTenant", "123456", 200, accountInventory("98765", "98766"))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(createGenericValkyrieConfiguration(null, enableBypassAccountAdmin = false))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -1101,7 +1138,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should remove no values for non-matching resources") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       filter.configurationUpdated(createGenericValkyrieConfiguration(null))
 
       val mockServletRequest = new MockHttpServletRequest
@@ -1128,7 +1165,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should throw a 500 when the regex is un-parseable") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       val configuration: ValkyrieAuthorizationConfig = createGenericValkyrieConfiguration(null)
       configuration.getCollectionResources.getResource.get(0).getCollection.get(0).getJson.getPathToDeviceId.getRegex.setValue("*/*")
       filter.configurationUpdated(configuration)
@@ -1155,7 +1192,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should throw a 500 when the capture group is to large") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       val configuration: ValkyrieAuthorizationConfig = createGenericValkyrieConfiguration(null)
       configuration.getCollectionResources.getResource.get(0).getCollection.get(0).getJson.getPathToDeviceId.getRegex.setCaptureGroup(52)
       filter.configurationUpdated(configuration)
@@ -1181,7 +1218,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should throw a 500 when the path for the collection is bad") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       val configuration: ValkyrieAuthorizationConfig = createGenericValkyrieConfiguration(null)
       configuration.getCollectionResources.getResource.get(0).getCollection.get(0).getJson.setPathToCollection("$.butts")
       filter.configurationUpdated(configuration)
@@ -1207,7 +1244,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should throw a 500 when the path for the device id is bad") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       val configuration: ValkyrieAuthorizationConfig = createGenericValkyrieConfiguration(null)
       configuration.getCollectionResources.getResource.get(0).getCollection.get(0).getJson.getPathToDeviceId.setPath("$.butts")
       filter.configurationUpdated(configuration)
@@ -1233,7 +1270,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should throw a 500 when the path for the count is bad") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       val configuration: ValkyrieAuthorizationConfig = createGenericValkyrieConfiguration(null)
       configuration.getCollectionResources.getResource.get(0).getCollection.get(0).getJson.setPathToItemCount("$.butts")
       filter.configurationUpdated(configuration)
@@ -1259,7 +1296,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
     it("should throw a 500 when the response contains bad json") {
       setMockAkkaBehavior("someTenant", "123456", 200, createValkyrieResponse(devicePermissions("98765", "view_product")))
 
-      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClient, mockDatastoreService)
+      val filter: ValkyrieAuthorizationFilter = new ValkyrieAuthorizationFilter(mock[ConfigurationService], akkaServiceClientFactory, mockDatastoreService)
       val configuration: ValkyrieAuthorizationConfig = createGenericValkyrieConfiguration(null)
       filter.configurationUpdated(configuration)
 

--- a/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
+++ b/repose-aggregator/core/core-lib/src/test/scala/org/openrepose/core/spring/CoreSpringProviderTest.scala
@@ -119,6 +119,8 @@ class CoreSpringProviderTest extends FunSpec with Matchers with TestFilterBundle
          * - Update TimeReceivedHandler.DEFAULT_DATE_FORMAT to "yyyy-MM-dd HH:mm:ss"
          *
          * - Update UnmarshallerValidatorValidationOnlyTest to un-ignore tests, remove namespace conversion hack
+         *
+         * - Revisit connection-pool-id default values in the auth filter config XSDs
          */
       }
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/diffpool/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/diffpool/http-connection-pool.cfg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+    <pool id="default"
+          default="false"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+    <pool id="basicauth-pool"
+          default="true"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="40000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="40000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/diffpool/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/diffpool/rackspace-identity-basic-auth.cfg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rackspace-identity-basic-auth
+        xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
+        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        token-cache-timeout-millis="0"
+        connection-pool-id="basicauth"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/http-connection-pool.cfg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+    <pool id="default"
+          default="true"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+    <pool id="basicauth-pool"
+          default="false"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="20000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="20000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/nopool/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/nopool/http-connection-pool.cfg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+    <pool id="default"
+          default="true"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+    <pool id="basicauth-pool"
+          default="false"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="20000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="20000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/rackspace-identity-basic-auth.cfg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rackspace-identity-basic-auth
+        xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
+        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        token-cache-timeout-millis="0"
+        connection-pool-id="basicauth-pool"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/akkatimeout/diffpool/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/akkatimeout/diffpool/openstack-identity-v3.cfg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"
+        connection-pool-id="keystone-v3">
+
+    <openstack-identity-service username="admin-username"
+                                password="admin-password"
+                                uri="http://localhost:${identityPort}"
+                                xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"/>
+</openstack-identity-v3>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/akkatimeout/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/akkatimeout/http-connection-pool.cfg.xml
@@ -15,13 +15,13 @@
           http.tcp.nodelay="true"
           keepalive.timeout="0"/>
 
-    <pool id="client-auth"
+    <pool id="keystone-v3-pool"
           default="false"
           http.conn-manager.max-total="200"
           http.conn-manager.max-per-route="20"
-          http.socket.timeout="30000"
+          http.socket.timeout="40000"
           http.socket.buffer-size="8192"
-          http.connection.timeout="30000"
+          http.connection.timeout="40000"
           http.connection.max-line-length="8192"
           http.connection.max-header-count="100"
           http.connection.max-status-line-garbage="100"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/akkatimeout/nopool/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/akkatimeout/nopool/openstack-identity-v3.cfg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0">
+
+    <openstack-identity-service username="admin-username"
+                                password="admin-password"
+                                uri="http://localhost:${identityPort}"
+                                xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"/>
+</openstack-identity-v3>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/akkatimeout/openstack-identity-v3.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identityv3/akkatimeout/openstack-identity-v3.cfg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"
+        connection-pool-id="keystone-v3-pool">
+
+    <openstack-identity-service username="admin-username"
+                                password="admin-password"
+                                uri="http://localhost:${identityPort}"
+                                xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"/>
+</openstack-identity-v3>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/diffpool/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/diffpool/http-connection-pool.cfg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+    <pool id="default"
+          default="false"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+    <pool id="keystone-v2-pool"
+          default="true"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="60000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="60000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/diffpool/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/diffpool/keystone-v2.cfg.xml
@@ -10,7 +10,6 @@
 
     <identity-service username="admin_username"
                       password="admin_password"
-                      uri="http://localhost:${identityPort}"
-                      connection-pool-id="keystone-v2-fool"/>
+                      uri="http://localhost:${identityPort}"/>
 
 </keystone-v2>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/diffpool/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/diffpool/keystone-v2.cfg.xml
@@ -10,6 +10,7 @@
 
     <identity-service username="admin_username"
                       password="admin_password"
-                      uri="http://localhost:${identityPort}"/>
+                      uri="http://localhost:${identityPort}"
+                      connection-pool-id="keystone-v2"/>
 
 </keystone-v2>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/http-connection-pool.cfg.xml
@@ -12,7 +12,7 @@
           http.connection.max-status-line-garbage="100"
           http.tcp.nodelay="true"
           keepalive.timeout="0"/>
-    <pool id="client-auth"
+    <pool id="keystone-v2-pool"
           default="false"
           http.conn-manager.max-total="200"
           http.conn-manager.max-per-route="20"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/httpConnTimeout60sec/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/httpConnTimeout60sec/http-connection-pool.cfg.xml
@@ -12,7 +12,7 @@
           http.connection.max-status-line-garbage="100"
           http.tcp.nodelay="true"
           keepalive.timeout="0"/>
-    <pool id="client-auth"
+    <pool id="keystone-v2-pool"
           default="true"
           http.conn-manager.max-total="200"
           http.conn-manager.max-per-route="20"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/keystone-v2.cfg.xml
@@ -10,6 +10,7 @@
 
     <identity-service username="admin_username"
                       password="admin_password"
-                      uri="http://localhost:${identityPort}"/>
+                      uri="http://localhost:${identityPort}"
+                      connection-pool-id="keystone-v2-pool"/>
 
 </keystone-v2>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/keystone-v2.cfg.xml
@@ -11,6 +11,6 @@
     <identity-service username="admin_username"
                       password="admin_password"
                       uri="http://localhost:${identityPort}"
-                      connection-pool-id="keystone-v2-fool"/>
+                      connection-pool-id="keystone-v2-pool"/>
 
 </keystone-v2>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/nopool/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/nopool/http-connection-pool.cfg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+    <pool id="default"
+          default="true"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="20000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="20000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+    <pool id="keystone-v2-pool"
+          default="false"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="60000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="60000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/nopool/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/akkatimeout/nopool/keystone-v2.cfg.xml
@@ -10,7 +10,6 @@
 
     <identity-service username="admin_username"
                       password="admin_password"
-                      uri="http://localhost:${identityPort}"
-                      connection-pool-id="keystone-v2-fool"/>
+                      uri="http://localhost:${identityPort}"/>
 
 </keystone-v2>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/authorizationonly/connectionpooling/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/authorizationonly/connectionpooling/http-connection-pool.cfg.xml
@@ -15,7 +15,7 @@
           http.tcp.nodelay="true"
           keepalive.timeout="0"/>
 
-    <pool id="client-auth-z"
+    <pool id="keystone-v2-z"
           default="false"
           http.conn-manager.max-total="200"
           http.conn-manager.max-per-route="20"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/authorizationonly/connectionpooling/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/authorizationonly/connectionpooling/keystone-v2.cfg.xml
@@ -3,7 +3,8 @@
 <keystone-v2 xmlns="http://docs.openrepose.org/repose/keystone-v2/v1.0">
     <identity-service username="joe"
                       password="secret"
-                      uri="http://localhost:${identityPort}"/>
+                      uri="http://localhost:${identityPort}"
+                      connection-pool-id="keystone-v2-z"/>
 
     <require-service-endpoint
             public-url="http://localhost:${targetPort}/"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/connectionpooling/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/connectionpooling/http-connection-pool.cfg.xml
@@ -15,7 +15,7 @@
           http.tcp.nodelay="true"
           keepalive.timeout="0"/>
 
-    <pool id="client-auth"
+    <pool id="keystone-v2-pool"
           default="false"
           http.conn-manager.max-total="200"
           http.conn-manager.max-per-route="20"
@@ -27,6 +27,5 @@
           http.connection.max-status-line-garbage="100"
           http.tcp.nodelay="true"
           keepalive.timeout="0"/>
-
 
 </http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/connectionpooling2/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/connectionpooling2/keystone-v2.cfg.xml
@@ -9,5 +9,6 @@
     <identity-service username="admin_username"
                       password="admin_password"
                       uri="http://localhost:${identityPort}"
+                      connection-pool-id="keystone-v2-pool"
                       set-groups-in-header="true"/>
 </keystone-v2>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/akkatimeout/diffpool/valkyrie-authorization.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/akkatimeout/diffpool/valkyrie-authorization.cfg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<valkyrie-authorization connection-pool-id="valkyrie"
+        xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0" cache-timeout-millis="3000">
+    <valkyrie-server uri="http://localhost:${valkyriePort}" username="user1" password="$6**YYLGrimey"/>
+</valkyrie-authorization>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/akkatimeout/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/akkatimeout/http-connection-pool.cfg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+    <pool id="default"
+          default="true"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+    <pool id="valkyrie-pool"
+          default="false"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="20000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="20000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/akkatimeout/nopool/valkyrie-authorization.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/akkatimeout/nopool/valkyrie-authorization.cfg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<valkyrie-authorization
+        xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0" cache-timeout-millis="3000">
+    <valkyrie-server uri="http://localhost:${valkyriePort}" username="user1" password="$6**YYLGrimey"/>
+</valkyrie-authorization>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/akkatimeout/valkyrie-authorization.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/akkatimeout/valkyrie-authorization.cfg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<valkyrie-authorization connection-pool-id="valkyrie-pool"
+        xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0" cache-timeout-millis="3000">
+    <valkyrie-server uri="http://localhost:${valkyriePort}" username="user1" password="$6**YYLGrimey"/>
+</valkyrie-authorization>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingConnPoolTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingConnPoolTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.identitybasicauth.akkatimeout
+
+import framework.ReposeLogSearch
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityService
+import org.apache.commons.codec.binary.Base64
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.core.HttpHeaders
+import org.junit.experimental.categories.Category
+
+/**
+ * Created by jennyvo on 11/9/15.
+ * using default pool with socket and http time out with 20 sec
+ */
+@Category(Slow.class)
+class BasicAuthAkkatimeoutUsingConnPoolTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static MockIdentityService fakeIdentityService
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
+
+        def params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/identitybasicauth", params);
+        repose.configurationProvider.applyConfigs("features/filters/identitybasicauth/akkatimeout", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+    }
+
+    def setup() {
+        fakeIdentityService.with {
+            // This is required to ensure that one piece of the authentication data is changed
+            // so that the cached version in the Akka Client is not used.
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+        }
+        reposeLogSearch = new ReposeLogSearch(properties.getLogFile())
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    def "akka timeout test, auth response time out is less than socket connection time out"() {
+        given: "the HTTP Basic authentication header containing the User Name and API Key"
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + fakeIdentityService.client_apikey).bytes)
+        ]
+        "Delay 19 sec"
+        fakeIdentityService.with {
+            sleeptime = 19000
+        }
+
+        when: "the request does have an HTTP Basic authentication header with UserName/ApiKey"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "Request should be passed from repose"
+        mc.receivedResponse.code == HttpServletResponse.SC_OK.toString()
+        mc.handlings.size() == 1
+        mc.handlings[0].request.headers.getCountByName("X-Auth-Token") == 1
+        mc.handlings[0].request.headers.getFirstValue("X-Auth-Token").equals(fakeIdentityService.client_token)
+    }
+
+    def "akka timeout test, auth response time out is greater than socket connection time out"() {
+        given: "the HTTP Basic authentication header containing the User Name and API Key"
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + fakeIdentityService.client_apikey).bytes)
+        ]
+        "Delay 19 sec"
+        fakeIdentityService.with {
+            sleeptime = 22000
+        }
+
+        when: "the request does have an HTTP Basic authentication header with UserName/ApiKey"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == "500"//HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .21000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingDefaultConnPoolTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingDefaultConnPoolTest.groovy
@@ -1,3 +1,22 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
 package features.filters.identitybasicauth.akkatimeout
 
 import framework.ReposeLogSearch

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingDefaultConnPoolTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingDefaultConnPoolTest.groovy
@@ -1,0 +1,103 @@
+package features.filters.identitybasicauth.akkatimeout
+
+import framework.ReposeLogSearch
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityService
+import org.apache.commons.codec.binary.Base64
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.core.HttpHeaders
+import org.junit.experimental.categories.Category
+
+/**
+ * Created by jennyvo on 11/9/15.
+ *  using default pool with socket and http time out
+ */
+@Category(Slow.class)
+class BasicAuthAkkatimeoutUsingDefaultConnPoolTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static MockIdentityService fakeIdentityService
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
+
+        def params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/identitybasicauth", params);
+        repose.configurationProvider.applyConfigs("features/filters/identitybasicauth/akkatimeout/nopool", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+    }
+
+    def setup() {
+        fakeIdentityService.with {
+            // This is required to ensure that one piece of the authentication data is changed
+            // so that the cached version in the Akka Client is not used.
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+        }
+        reposeLogSearch = new ReposeLogSearch(properties.getLogFile())
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    def "akka timeout test, auth response time out is less than socket connection time out"() {
+        given: "the HTTP Basic authentication header containing the User Name and API Key"
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + fakeIdentityService.client_apikey).bytes)
+        ]
+        "Delay 19 sec"
+        fakeIdentityService.with {
+            sleeptime = 29000
+        }
+
+        when: "the request does have an HTTP Basic authentication header with UserName/ApiKey"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "Request should be passed from repose"
+        mc.receivedResponse.code == HttpServletResponse.SC_OK.toString()
+        mc.handlings.size() == 1
+        mc.handlings[0].request.headers.getCountByName("X-Auth-Token") == 1
+        mc.handlings[0].request.headers.getFirstValue("X-Auth-Token").equals(fakeIdentityService.client_token)
+    }
+
+    def "akka timeout test, auth response time out is greater than socket connection time out"() {
+        given: "the HTTP Basic authentication header containing the User Name and API Key"
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + fakeIdentityService.client_apikey).bytes)
+        ]
+        "Delay 19 sec"
+        fakeIdentityService.with {
+            sleeptime = 32000
+        }
+
+        when: "the request does have an HTTP Basic authentication header with UserName/ApiKey"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == "500"//HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .31000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingPoolNotExistTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingPoolNotExistTest.groovy
@@ -1,3 +1,22 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
 package features.filters.identitybasicauth.akkatimeout
 
 import framework.ReposeLogSearch

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingPoolNotExistTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingPoolNotExistTest.groovy
@@ -1,0 +1,104 @@
+package features.filters.identitybasicauth.akkatimeout
+
+import framework.ReposeLogSearch
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityService
+import org.apache.commons.codec.binary.Base64
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.core.HttpHeaders
+import org.junit.experimental.categories.Category
+
+/**
+ * Created by jennyvo on 11/9/15.
+ *  using xsd default socket and http time out
+ */
+@Category(Slow.class)
+class BasicAuthAkkatimeoutUsingPoolNotExistTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static MockIdentityService fakeIdentityService
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
+
+        def params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/identitybasicauth", params);
+        repose.configurationProvider.applyConfigs("features/filters/identitybasicauth/akkatimeout/diffpool", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+    }
+
+    def setup() {
+        fakeIdentityService.with {
+            // This is required to ensure that one piece of the authentication data is changed
+            // so that the cached version in the Akka Client is not used.
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+        }
+        reposeLogSearch = new ReposeLogSearch(properties.getLogFile())
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    def "akka timeout test, auth response time out is less than socket connection time out"() {
+        given: "the HTTP Basic authentication header containing the User Name and API Key"
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + fakeIdentityService.client_apikey).bytes)
+        ]
+        "Delay 19 sec"
+        fakeIdentityService.with {
+            sleeptime = 29000
+        }
+
+        when: "the request does have an HTTP Basic authentication header with UserName/ApiKey"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "Request should be passed from repose"
+        mc.receivedResponse.code == HttpServletResponse.SC_OK.toString()
+        mc.handlings.size() == 1
+        mc.handlings[0].request.headers.getCountByName("X-Auth-Token") == 1
+        mc.handlings[0].request.headers.getFirstValue("X-Auth-Token").equals(fakeIdentityService.client_token)
+    }
+
+    def "akka timeout test, auth response time out is greater than socket connection time out"() {
+        given: "the HTTP Basic authentication header containing the User Name and API Key"
+        def headers = [
+                (HttpHeaders.AUTHORIZATION): 'Basic ' + Base64.encodeBase64URLSafeString((fakeIdentityService.client_username + ":" + fakeIdentityService.client_apikey).bytes)
+        ]
+        "Delay 19 sec"
+        fakeIdentityService.with {
+            sleeptime = 32000
+        }
+
+        when: "the request does have an HTTP Basic authentication header with UserName/ApiKey"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'GET', headers: headers)
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == "500"//HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        // should get this error or something else but not something with [41000 milliseconds]
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .31000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/akkatimeout/AkkatimeoutUsingConnPoolTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/akkatimeout/AkkatimeoutUsingConnPoolTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.identityv3.akkatimeout
+
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityV3Service
+import org.joda.time.DateTime
+import org.junit.experimental.categories.Category
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+/**
+ * Created by jennyvo on 11/9/15.
+ */
+@Category(Slow.class)
+class AkkatimeoutUsingConnPoolTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static MockIdentityV3Service fakeIdentityV3Service
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/identityv3", params)
+        repose.configurationProvider.applyConfigs("features/filters/identityv3/akkatimeout", params)
+        repose.start()
+        waitUntilReadyToServiceRequests('401')
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityV3Service = new MockIdentityV3Service(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort,
+                'identity service', null, fakeIdentityV3Service.handler)
+    }
+
+    def cleanupSpec() {
+        if (deproxy)
+            deproxy.shutdown()
+        if (repose)
+            repose.stop()
+    }
+
+    def setup() {
+        fakeIdentityV3Service.resetParameters()
+        fakeIdentityV3Service.resetHandlers()
+    }
+
+    def "Identity V3 akka service client using connection pool"() {
+        given:
+        def reqDomain = fakeIdentityV3Service.client_domainid
+        def reqUserId = fakeIdentityV3Service.client_userid
+
+        fakeIdentityV3Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_domainid = reqDomain
+            client_userid = reqUserId
+            sleeptime = 39000
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/$reqDomain/",
+                method: 'GET',
+                headers: [
+                        'content-type'   : 'application/json',
+                        'X-Subject-Token': fakeIdentityV3Service.client_token,
+                ]
+        )
+
+        then: "Request should pass through"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+    }
+
+    def "Identity V3 akka service client using connection pool time out"() {
+        given:
+        def reqDomain = fakeIdentityV3Service.client_domainid
+        def reqUserId = fakeIdentityV3Service.client_userid
+
+        fakeIdentityV3Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_domainid = reqDomain
+            client_userid = reqUserId
+            sleeptime = 42000
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/$reqDomain/",
+                method: 'GET',
+                headers: [
+                        'content-type'   : 'application/json',
+                        'X-Subject-Token': fakeIdentityV3Service.client_token,
+                ]
+        )
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == "500"//HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .41000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/akkatimeout/AkkatimeoutUsingDefaultConnPoolTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identityv3/akkatimeout/AkkatimeoutUsingDefaultConnPoolTest.groovy
@@ -1,0 +1,127 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.identityv3.akkatimeout
+
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityV3Service
+import org.joda.time.DateTime
+import org.junit.experimental.categories.Category
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+/**
+ * Created by jennyvo on 11/9/15.
+ *  When no config pool id in keystone-v3 filter it will use default pool
+ */
+@Category(Slow.class)
+class AkkatimeoutUsingDefaultConnPoolTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static MockIdentityV3Service fakeIdentityV3Service
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/identityv3", params)
+        repose.configurationProvider.applyConfigs("features/filters/identityv3/akkatimeout", params)
+        repose.configurationProvider.applyConfigs("features/filters/identityv3/akkatimeout/nopool", params)
+        repose.start()
+        waitUntilReadyToServiceRequests('401')
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityV3Service = new MockIdentityV3Service(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort,
+                'identity service', null, fakeIdentityV3Service.handler)
+    }
+
+    def cleanupSpec() {
+        if (deproxy)
+            deproxy.shutdown()
+        if (repose)
+            repose.stop()
+    }
+
+    def setup() {
+        fakeIdentityV3Service.resetParameters()
+        fakeIdentityV3Service.resetHandlers()
+    }
+
+    def "Identity V3 akka service client using connection pool"() {
+        given:
+        def reqDomain = fakeIdentityV3Service.client_domainid
+        def reqUserId = fakeIdentityV3Service.client_userid
+
+        fakeIdentityV3Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_domainid = reqDomain
+            client_userid = reqUserId
+            sleeptime = 28000
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/$reqDomain/",
+                method: 'GET',
+                headers: [
+                        'content-type'   : 'application/json',
+                        'X-Subject-Token': fakeIdentityV3Service.client_token,
+                ]
+        )
+
+        then: "Request should pass through"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+    }
+
+    def "Identity V3 akka service client using connection pool time out"() {
+        given:
+        def reqDomain = fakeIdentityV3Service.client_domainid
+        def reqUserId = fakeIdentityV3Service.client_userid
+
+        fakeIdentityV3Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_domainid = reqDomain
+            client_userid = reqUserId
+            sleeptime = 32000
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/$reqDomain/",
+                method: 'GET',
+                headers: [
+                        'content-type'   : 'application/json',
+                        'X-Subject-Token': fakeIdentityV3Service.client_token,
+                ]
+        )
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == "500"//HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .31000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/akkatimeout/AkkaTimeoutSameAsHttpConnTimeoutTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/akkatimeout/AkkaTimeoutSameAsHttpConnTimeoutTest.groovy
@@ -91,7 +91,7 @@ class AkkaTimeoutSameAsHttpConnTimeoutTest extends ReposeValveTest {
                 ]
         )
 
-        then: "Request should not be passed from repose"
+        then: "Request should be passed from repose"
         mc.receivedResponse.code == "200"
         mc.handlings.size() == 1
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/akkatimeout/DiffPoolIdAkkaTimeoutUsingDefaultTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/akkatimeout/DiffPoolIdAkkaTimeoutUsingDefaultTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.keystonev2.akkatimeout
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityV2Service
+import org.joda.time.DateTime
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import org.junit.experimental.categories.Category
+import javax.servlet.http.HttpServletResponse
+/**
+ * Created by jennyvo on 11/9/15.
+ *  Verify wrong pool id in the keystone config will take default from xsd
+ */
+@Category(Slow)
+class DiffPoolIdAkkaTimeoutUsingDefaultTest extends ReposeValveTest {
+
+    def static originEndpoint
+    def static identityEndpoint
+
+    def static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+
+        deproxy = new Deproxy()
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/keystonev2/common", params)
+        repose.configurationProvider.applyConfigs("features/filters/keystonev2/akkatimeout/diffpool", params)
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort,
+                'identity service', null, fakeIdentityV2Service.handler)
+
+
+    }
+
+    def cleanupSpec() {
+        if (deproxy)
+            deproxy.shutdown()
+        if (repose)
+            repose.stop()
+    }
+
+    def setup() {
+        fakeIdentityV2Service.resetHandlers()
+    }
+
+    def "akka timeout test, auth response time out is less than socket connection time out, but greater than the system default of 20 seconds"() {
+        fakeIdentityV2Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_tenantid = 613
+            service_admin_role = "not-admin"
+            client_userid = 1234
+            sleeptime = 29000
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/613/",
+                method: 'GET',
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityV2Service.client_token
+                ]
+        )
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+    }
+
+    def "akka timeout test, auth response time out greater than socket connection time out"() {
+        reposeLogSearch.cleanLog()
+        fakeIdentityV2Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_tenantid = 613
+            service_admin_role = "not-admin"
+            client_userid = 1234
+            sleeptime = 35000
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/613/",
+                method: 'GET',
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityV2Service.client_token
+                ]
+        )
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .31000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/akkatimeout/NoPoolIdAkkaTimeoutUsingDefaultTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/akkatimeout/NoPoolIdAkkaTimeoutUsingDefaultTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.keystonev2.akkatimeout
+
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityV2Service
+import org.joda.time.DateTime
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import org.junit.experimental.categories.Category
+
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Created by jennyvo on 11/9/15.
+ *  Verify no pool id in the keystone config will take default connection pool
+ */
+@Category(Slow.class)
+class NoPoolIdAkkaTimeoutUsingDefaultTest extends ReposeValveTest {
+
+    def static originEndpoint
+    def static identityEndpoint
+
+    def static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+
+        deproxy = new Deproxy()
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/keystonev2/common", params)
+        repose.configurationProvider.applyConfigs("features/filters/keystonev2/akkatimeout/nopool", params)
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort,
+                'identity service', null, fakeIdentityV2Service.handler)
+
+
+    }
+
+    def cleanupSpec() {
+        if (deproxy)
+            deproxy.shutdown()
+        if (repose)
+            repose.stop()
+    }
+
+    def setup() {
+        fakeIdentityV2Service.resetHandlers()
+    }
+
+    def "akka timeout test, auth response time out is less than socket connection time out, but greater than the system default of 20 seconds"() {
+        fakeIdentityV2Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_tenantid = 613
+            service_admin_role = "not-admin"
+            client_userid = 1234
+            sleeptime = 19000
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/613/",
+                method: 'GET',
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityV2Service.client_token
+                ]
+        )
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+    }
+
+    def "akka timeout test, auth response time out greater than socket connection time out"() {
+        reposeLogSearch.cleanLog()
+        fakeIdentityV2Service.with {
+            client_token = UUID.randomUUID().toString()
+            tokenExpiresAt = DateTime.now().plusDays(1)
+            client_tenantid = 613
+            service_admin_role = "not-admin"
+            client_userid = 1234
+            sleeptime = 250000
+        }
+
+        when: "User passes a request through repose"
+        MessageChain mc = deproxy.makeRequest(
+                url: "$reposeEndpoint/servers/613/",
+                method: 'GET',
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityV2Service.client_token
+                ]
+        )
+
+        then: "Request should not be passed from repose"
+        mc.receivedResponse.code == HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .21000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/authorizationonly/connectionpooling/KeystoneV2ZConnectionPoolingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/authorizationonly/connectionpooling/KeystoneV2ZConnectionPoolingTest.groovy
@@ -17,7 +17,7 @@
  * limitations under the License.
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
-package features.filters.keystonev2.connectionpooling
+package features.filters.keystonev2.authorizationonly.connectionpooling
 
 import framework.ReposeConfigurationProvider
 import framework.ReposeValveLauncher
@@ -33,7 +33,7 @@ import spock.lang.Specification
  * User: izrik
  *
  */
-class AuthNConnectionPoolingTest extends Specification {
+class KeystoneV2ZConnectionPoolingTest extends Specification {
 
     int reposePort
     int originServicePort
@@ -55,6 +55,7 @@ class AuthNConnectionPoolingTest extends Specification {
 
         // get ports
         properties = new TestProperties()
+
         reposePort = properties.reposePort
         originServicePort = properties.targetPort
         identityServicePort = properties.identityPort
@@ -88,18 +89,17 @@ class AuthNConnectionPoolingTest extends Specification {
 
         def params = properties.getDefaultTemplateParams()
         reposeConfigProvider.applyConfigs("common", params)
-        reposeConfigProvider.applyConfigs("features/filters/keystonev2/connectionpooling", params)
-        reposeConfigProvider.applyConfigs("features/filters/keystonev2/connectionpooling2", params)
+        reposeConfigProvider.applyConfigs("features/filters/keystonev2/authorizationonly/connectionpooling", params)
         repose.start()
     }
 
     def "when a client makes requests, Repose should re-use the connection to the Identity service"() {
 
-        setup: "craft an url to a resource that requires authentication"
+        setup:
         def url = "${urlBase}/servers/tenantid/resource"
 
 
-        when: "making two authenticated requests to Repose"
+        when: "making two requests to Repose"
         def mc1 = deproxy.makeRequest(url: url, headers: ['X-Auth-Token': 'token1'])
         def mc2 = deproxy.makeRequest(url: url, headers: ['X-Auth-Token': 'token2'])
         // collect all of the handlings that make it to the identity endpoint into one list

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/connectionpooling/KeystoneV2ConnectionPoolingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/connectionpooling/KeystoneV2ConnectionPoolingTest.groovy
@@ -17,7 +17,7 @@
  * limitations under the License.
  * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
  */
-package features.filters.keystonev2.authorizationonly.connectionpooling
+package features.filters.keystonev2.connectionpooling
 
 import framework.ReposeConfigurationProvider
 import framework.ReposeValveLauncher
@@ -33,7 +33,7 @@ import spock.lang.Specification
  * User: izrik
  *
  */
-class AuthZConnectionPoolingTest extends Specification {
+class KeystoneV2ConnectionPoolingTest extends Specification {
 
     int reposePort
     int originServicePort
@@ -55,7 +55,6 @@ class AuthZConnectionPoolingTest extends Specification {
 
         // get ports
         properties = new TestProperties()
-
         reposePort = properties.reposePort
         originServicePort = properties.targetPort
         identityServicePort = properties.identityPort
@@ -89,17 +88,18 @@ class AuthZConnectionPoolingTest extends Specification {
 
         def params = properties.getDefaultTemplateParams()
         reposeConfigProvider.applyConfigs("common", params)
-        reposeConfigProvider.applyConfigs("features/filters/keystonev2/authorizationonly/connectionpooling", params)
+        reposeConfigProvider.applyConfigs("features/filters/keystonev2/connectionpooling", params)
+        reposeConfigProvider.applyConfigs("features/filters/keystonev2/connectionpooling2", params)
         repose.start()
     }
 
     def "when a client makes requests, Repose should re-use the connection to the Identity service"() {
 
-        setup:
+        setup: "craft an url to a resource that requires authentication"
         def url = "${urlBase}/servers/tenantid/resource"
 
 
-        when: "making two requests to Repose"
+        when: "making two authenticated requests to Repose"
         def mc1 = deproxy.makeRequest(url: url, headers: ['X-Auth-Token': 'token1'])
         def mc2 = deproxy.makeRequest(url: url, headers: ['X-Auth-Token': 'token2'])
         // collect all of the handlings that make it to the identity endpoint into one list

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/akkatimeout/AkkatimeoutUsingConnPoolTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/akkatimeout/AkkatimeoutUsingConnPoolTest.groovy
@@ -1,0 +1,145 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.valkyrie.akkatimeout
+
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityService
+import framework.mocks.MockValkyrie
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import org.junit.experimental.categories.Category
+
+/**
+ * Created by jennyvo on 11/10/15.
+ *  when connection pool id is config valkyrie using connection pool time out
+ */
+@Category(Slow.class)
+class AkkatimeoutUsingConnPoolTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static valkyrieEndpoint
+
+    def static MockIdentityService fakeIdentityService
+    def static MockValkyrie fakeValkyrie
+    def static Map params = [:]
+
+    def static random = new Random()
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+
+        params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie/akkatimeout", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+
+        fakeValkyrie = new MockValkyrie(properties.valkyriePort)
+        valkyrieEndpoint = deproxy.addEndpoint(properties.valkyriePort, 'valkyrie service', null, fakeValkyrie.handler)
+    }
+
+    def setup() {
+        fakeIdentityService.resetHandlers()
+        fakeIdentityService.resetDefaultParameters()
+        fakeValkyrie.resetHandlers()
+        fakeValkyrie.resetParameters()
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    def "Akka service client using connection pool test - before time out is reached"() {
+        given: "A device ID with a particular permission level defined in Valkyrie"
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = randomTenant()
+        }
+
+        fakeValkyrie.with {
+            device_id = "520707"
+            device_perm = "view_product"
+            sleeptime = 19000
+        }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/520707", method: "GET",
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+    }
+
+    def "Akka service client using connection pool test - connection time out is reached"() {
+        given: "A device ID with a particular permission level defined in Valkyrie"
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = randomTenant()
+        }
+
+        fakeValkyrie.with {
+            device_id = "520707"
+            device_perm = "view_product"
+            sleeptime = 22000
+        }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/520707", method: "GET",
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == "502"//HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .21000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+
+    def String randomTenant() {
+        "hybrid:" + random.nextInt()
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/akkatimeout/AkkatimeoutUsingDefaultConnPoolTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/akkatimeout/AkkatimeoutUsingDefaultConnPoolTest.groovy
@@ -1,0 +1,146 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.valkyrie.akkatimeout
+
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityService
+import framework.mocks.MockValkyrie
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import org.junit.experimental.categories.Category
+
+/**
+ * Created by jennyvo on 11/10/15.
+ *  when no connection pool id in config valkyrie using default connection pool time out
+ */
+@Category(Slow.class)
+class AkkatimeoutUsingDefaultConnPoolTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static valkyrieEndpoint
+
+    def static MockIdentityService fakeIdentityService
+    def static MockValkyrie fakeValkyrie
+    def static Map params = [:]
+
+    def static random = new Random()
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+
+        params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie/akkatimeout", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie/akkatimeout/nopool", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+
+        fakeValkyrie = new MockValkyrie(properties.valkyriePort)
+        valkyrieEndpoint = deproxy.addEndpoint(properties.valkyriePort, 'valkyrie service', null, fakeValkyrie.handler)
+    }
+
+    def setup() {
+        fakeIdentityService.resetHandlers()
+        fakeIdentityService.resetDefaultParameters()
+        fakeValkyrie.resetHandlers()
+        fakeValkyrie.resetParameters()
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    def "Akka service client using connection pool test - before time out is reached"() {
+        given: "A device ID with a particular permission level defined in Valkyrie"
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = randomTenant()
+        }
+
+        fakeValkyrie.with {
+            device_id = "520707"
+            device_perm = "view_product"
+            sleeptime = 29000
+        }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/520707", method: "GET",
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+    }
+
+    def "Akka service client using connection pool test - connection time out is reached"() {
+        given: "A device ID with a particular permission level defined in Valkyrie"
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = randomTenant()
+        }
+
+        fakeValkyrie.with {
+            device_id = "520707"
+            device_perm = "view_product"
+            sleeptime = 32000
+        }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/520707", method: "GET",
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == "502"//HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .31000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+
+    def String randomTenant() {
+        "hybrid:" + random.nextInt()
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/akkatimeout/NoMatchingPoolAkkatimeoutTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/akkatimeout/NoMatchingPoolAkkatimeoutTest.groovy
@@ -1,0 +1,147 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.valkyrie.akkatimeout
+
+import framework.ReposeValveTest
+import framework.category.Slow
+import framework.mocks.MockIdentityService
+import framework.mocks.MockValkyrie
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import org.junit.experimental.categories.Category
+
+/**
+ * Created by jennyvo on 11/10/15.
+ *  when connection pool id in config valkyrie not matched connection pool config
+ *      timeout using default in xsd (30 sec)
+ */
+@Category(Slow.class)
+class NoMatchingPoolAkkatimeoutTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static valkyrieEndpoint
+
+    def static MockIdentityService fakeIdentityService
+    def static MockValkyrie fakeValkyrie
+    def static Map params = [:]
+
+    def static random = new Random()
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+
+        params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie/akkatimeout", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie/akkatimeout/diffpool", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+
+        fakeValkyrie = new MockValkyrie(properties.valkyriePort)
+        valkyrieEndpoint = deproxy.addEndpoint(properties.valkyriePort, 'valkyrie service', null, fakeValkyrie.handler)
+    }
+
+    def setup() {
+        fakeIdentityService.resetHandlers()
+        fakeIdentityService.resetDefaultParameters()
+        fakeValkyrie.resetHandlers()
+        fakeValkyrie.resetParameters()
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    def "Akka service client using connection pool test - before time out is reached"() {
+        given: "A device ID with a particular permission level defined in Valkyrie"
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = randomTenant()
+        }
+
+        fakeValkyrie.with {
+            device_id = "520707"
+            device_perm = "view_product"
+            sleeptime = 29000
+        }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/520707", method: "GET",
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+    }
+
+    def "Akka service client using connection pool test - connection time out is reached"() {
+        given: "A device ID with a particular permission level defined in Valkyrie"
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = randomTenant()
+        }
+
+        fakeValkyrie.with {
+            device_id = "520707"
+            device_perm = "view_product"
+            sleeptime = 32000
+        }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/520707", method: "GET",
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == "502"//HttpServletResponse.SC_GATEWAY_TIMEOUT.toString()
+        mc.handlings.size() == 0
+        sleep(1000)
+        reposeLogSearch.searchByString("Error acquiring value from akka .* or the cache. Reason: Futures timed out after .31000 milliseconds.").size() > 0
+        reposeLogSearch.searchByString("NullPointerException").size() == 0
+    }
+
+    def String randomTenant() {
+        "hybrid:" + random.nextInt()
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV3Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV3Service.groovy
@@ -152,6 +152,7 @@ class MockIdentityV3Service {
     def impersonate_id = ""
     def impersonate_name = ""
     def default_region = "ORD"
+    def sleeptime = 0;
     Validator validator
 
     void resetParameters() {
@@ -173,6 +174,7 @@ class MockIdentityV3Service {
         impersonate_id = ""
         impersonate_name = ""
         default_region = "ORD"
+        sleeptime = 0
     }
 
     def templateEngine = new SimpleTemplateEngine()
@@ -390,7 +392,9 @@ class MockIdentityV3Service {
         }
 
         def body = templateEngine.createTemplate(template).make(params)
-
+        if (sleeptime > 0) {
+            sleep(sleeptime)
+        }
         return new Response(code, null, headers, body)
     }
 
@@ -437,7 +441,9 @@ class MockIdentityV3Service {
         }
 
         def body = templateEngine.createTemplate(template).make(params)
-
+        if (sleeptime > 0) {
+            sleep(sleeptime)
+        }
         return new Response(code, null, headers, body)
     }
 

--- a/repose-aggregator/services/phone-home/src/main/scala/org/openrepose/core/services/phonehome/PhoneHomeService.scala
+++ b/repose-aggregator/services/phone-home/src/main/scala/org/openrepose/core/services/phonehome/PhoneHomeService.scala
@@ -29,7 +29,7 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.CommonHttpHeader
 import org.openrepose.core.services.config.ConfigurationService
-import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient
+import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClientFactory, AkkaServiceClient}
 import org.openrepose.core.spring.ReposeSpringProperties
 import org.openrepose.core.systemmodel.{FilterList, PhoneHomeServiceConfig, ServicesList, SystemModel}
 import org.slf4j.LoggerFactory
@@ -55,13 +55,14 @@ import scala.collection.JavaConverters._
 @Named
 class PhoneHomeService @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_VERSION) reposeVer: String,
                                  configurationService: ConfigurationService,
-                                 akkaServiceClient: AkkaServiceClient)
+                                 akkaServiceClientFactory: AkkaServiceClientFactory)
   extends LazyLogging {
 
   private final val msgLogger = LoggerFactory.getLogger("phone-home-message")
   private final val defaultCollectionUri = new PhoneHomeServiceConfig().getCollectionUri
 
   private var systemModel: SystemModel = _
+  private var akkaServiceClient: AkkaServiceClient = _
 
   @PostConstruct
   def init(): Unit = {
@@ -71,6 +72,7 @@ class PhoneHomeService @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_VERSI
       SystemModelConfigurationListener,
       classOf[SystemModel]
     )
+    akkaServiceClient = akkaServiceClientFactory.newAkkaServiceClient()
   }
 
   private def sendUpdate(): Unit = {

--- a/repose-aggregator/services/phone-home/src/test/scala/org/openrepose/core/services/phonehome/PhoneHomeServiceTest.scala
+++ b/repose-aggregator/services/phone-home/src/test/scala/org/openrepose/core/services/phonehome/PhoneHomeServiceTest.scala
@@ -33,7 +33,7 @@ import org.mockito.Mockito.{never, verify, verifyZeroInteractions, when}
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.{CommonHttpHeader, ServiceClientResponse}
 import org.openrepose.core.services.config.ConfigurationService
-import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient
+import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClientFactory, AkkaServiceClient}
 import org.openrepose.core.systemmodel._
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
@@ -50,16 +50,33 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
   describe("init") {
     it("should register a system model configuration listener") {
       val mockConfigurationService = mock[ConfigurationService]
-      val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
       phoneHomeService.init()
 
       verify(mockConfigurationService)
         .subscribeTo(anyString(), any[UpdateListener[SystemModel]](), mockitoEq(classOf[SystemModel]))
+    }
+
+    it("should use the factory to get an instance of the akka service client") {
+      val mockConfigurationService = mock[ConfigurationService]
+      val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
+
+      val phoneHomeService = new PhoneHomeService(
+        "1.0.0",
+        mockConfigurationService,
+        mockAkkaServiceClientFactory)
+
+      phoneHomeService.init()
+
+      verify(mockAkkaServiceClientFactory).newAkkaServiceClient()
     }
   }
 
@@ -84,6 +101,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
 
       val mockConfigurationService = mock[ConfigurationService]
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
 
       when(
         mockAkkaServiceClient.post(anyString(),
@@ -96,8 +116,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
+      phoneHomeService.init()
       phoneHomeService.SystemModelConfigurationListener.configurationUpdated(systemModel)
 
       verify(mockAkkaServiceClient).post(
@@ -128,6 +149,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
 
       val mockConfigurationService = mock[ConfigurationService]
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
 
       when(
         mockAkkaServiceClient.post(anyString(),
@@ -140,8 +164,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
+      phoneHomeService.init()
       phoneHomeService.SystemModelConfigurationListener.configurationUpdated(systemModel)
 
       verify(mockAkkaServiceClient, never()).post(
@@ -164,12 +189,16 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
 
       val mockConfigurationService = mock[ConfigurationService]
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
 
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
+      phoneHomeService.init()
       phoneHomeService.SystemModelConfigurationListener.configurationUpdated(systemModel)
 
       val msgLogEvents = msgListAppender.getEvents
@@ -201,12 +230,16 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
 
       val mockConfigurationService = mock[ConfigurationService]
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
 
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
+      phoneHomeService.init()
       phoneHomeService.SystemModelConfigurationListener.configurationUpdated(systemModel)
 
       val msgLogEvents = msgListAppender.getEvents
@@ -238,6 +271,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
 
       val mockConfigurationService = mock[ConfigurationService]
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
 
       when(
         mockAkkaServiceClient.post(anyString(),
@@ -250,8 +286,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
+      phoneHomeService.init()
       phoneHomeService.SystemModelConfigurationListener.configurationUpdated(systemModel)
 
       val msgLogEvents = msgListAppender.getEvents
@@ -292,6 +329,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
 
       val mockConfigurationService = mock[ConfigurationService]
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
 
       when(
         mockAkkaServiceClient.post(anyString(),
@@ -304,8 +344,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
+      phoneHomeService.init()
       phoneHomeService.SystemModelConfigurationListener.configurationUpdated(systemModel)
 
       verify(mockAkkaServiceClient).post(
@@ -337,6 +378,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
 
       val mockConfigurationService = mock[ConfigurationService]
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
 
       when(
         mockAkkaServiceClient.post(anyString(),
@@ -349,8 +393,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
+      phoneHomeService.init()
       phoneHomeService.SystemModelConfigurationListener.configurationUpdated(systemModel)
 
       verify(mockAkkaServiceClient).post(
@@ -396,6 +441,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
 
       val mockConfigurationService = mock[ConfigurationService]
       val mockAkkaServiceClient = mock[AkkaServiceClient]
+      val mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn(mockAkkaServiceClient)
 
       when(
         mockAkkaServiceClient.post(anyString(),
@@ -408,7 +456,7 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       val phoneHomeService = new PhoneHomeService(
         "1.0.0",
         mockConfigurationService,
-        mockAkkaServiceClient)
+        mockAkkaServiceClientFactory)
 
       val expectedMessage = Json.stringify(Json.obj(
         "serviceId" -> "foo-service",
@@ -434,6 +482,7 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       // Insert the Date/Time/Version RegEx.
       expectedBuilder.insert(idx, """"createdAt":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z","createdAtMillis":[0-9]{13},"jreVersion":".*","jvmName":".*",""")
 
+      phoneHomeService.init()
       phoneHomeService.SystemModelConfigurationListener.configurationUpdated(systemModel)
 
       verify(mockAkkaServiceClient).post(

--- a/repose-aggregator/services/service-client/api/src/main/java/org/openrepose/core/services/serviceclient/akka/AkkaServiceClient.java
+++ b/repose-aggregator/services/service-client/api/src/main/java/org/openrepose/core/services/serviceclient/akka/AkkaServiceClient.java
@@ -32,4 +32,6 @@ public interface AkkaServiceClient {
     ServiceClientResponse get(String token, String uri, Map<String, String> headers) throws AkkaServiceClientException;
 
     ServiceClientResponse post(String requestKey, String uri, Map<String, String> headers, String payload, MediaType contentMediaType) throws AkkaServiceClientException;
+
+    void destroy();
 }

--- a/repose-aggregator/services/service-client/api/src/main/java/org/openrepose/core/services/serviceclient/akka/AkkaServiceClientFactory.java
+++ b/repose-aggregator/services/service-client/api/src/main/java/org/openrepose/core/services/serviceclient/akka/AkkaServiceClientFactory.java
@@ -1,0 +1,28 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.core.services.serviceclient.akka;
+
+/**
+ * Interface for the factory that creates instances of AkkaServiceClient
+ */
+public interface AkkaServiceClientFactory {
+    AkkaServiceClient newAkkaServiceClient(String connectionPoolId);
+}

--- a/repose-aggregator/services/service-client/api/src/main/java/org/openrepose/core/services/serviceclient/akka/AkkaServiceClientFactory.java
+++ b/repose-aggregator/services/service-client/api/src/main/java/org/openrepose/core/services/serviceclient/akka/AkkaServiceClientFactory.java
@@ -24,5 +24,6 @@ package org.openrepose.core.services.serviceclient.akka;
  * Interface for the factory that creates instances of AkkaServiceClient
  */
 public interface AkkaServiceClientFactory {
+    AkkaServiceClient newAkkaServiceClient();
     AkkaServiceClient newAkkaServiceClient(String connectionPoolId);
 }

--- a/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientFactoryImpl.java
+++ b/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientFactoryImpl.java
@@ -1,0 +1,44 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.core.services.serviceclient.akka.impl;
+
+import org.openrepose.core.services.httpclient.HttpClientService;
+import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient;
+import org.openrepose.core.services.serviceclient.akka.AkkaServiceClientFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class AkkaServiceClientFactoryImpl implements AkkaServiceClientFactory {
+
+    private final HttpClientService httpClientService;
+
+    @Inject
+    public AkkaServiceClientFactoryImpl(HttpClientService httpClientService) {
+        this.httpClientService = httpClientService;
+    }
+
+    @Override
+    public AkkaServiceClient newAkkaServiceClient(String connectionPoolId) {
+        return new AkkaServiceClientImpl(connectionPoolId, httpClientService);
+    }
+}

--- a/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientFactoryImpl.java
+++ b/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientFactoryImpl.java
@@ -38,6 +38,11 @@ public class AkkaServiceClientFactoryImpl implements AkkaServiceClientFactory {
     }
 
     @Override
+    public AkkaServiceClient newAkkaServiceClient() {
+        return newAkkaServiceClient(null);
+    }
+
+    @Override
     public AkkaServiceClient newAkkaServiceClient(String connectionPoolId) {
         return new AkkaServiceClientImpl(connectionPoolId, httpClientService);
     }

--- a/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientImpl.java
+++ b/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientImpl.java
@@ -35,9 +35,6 @@ import org.slf4j.Logger;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 
-import javax.annotation.PreDestroy;
-import javax.inject.Inject;
-import javax.inject.Named;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -47,7 +44,6 @@ import java.util.concurrent.TimeUnit;
 import static akka.pattern.Patterns.ask;
 import static akka.routing.ConsistentHashingRouter.ConsistentHashable;
 
-@Named
 public class AkkaServiceClientImpl implements AkkaServiceClient {
 
     private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(AkkaServiceClientImpl.class);
@@ -59,9 +55,8 @@ public class AkkaServiceClientImpl implements AkkaServiceClient {
     private ActorSystem actorSystem;
     private ActorRef tokenActorRef;
 
-    @Inject
-    public AkkaServiceClientImpl(HttpClientService httpClientService) {
-        this.serviceClient = getServiceClient(httpClientService);
+    public AkkaServiceClientImpl(String connectionPoolId, HttpClientService httpClientService) {
+        this.serviceClient = getServiceClient(connectionPoolId, httpClientService);
         final int numberOfActors = serviceClient.getPoolSize();
 
         Config customConf = ConfigFactory.load();
@@ -72,7 +67,6 @@ public class AkkaServiceClientImpl implements AkkaServiceClient {
                 .expireAfterWrite(FUTURE_CACHE_TTL, FUTURE_CACHE_UNIT)
                 .build();
 
-
         tokenActorRef = actorSystem.actorOf(new Props(new UntypedActorFactory() {
             public UntypedActor create() {
 
@@ -82,9 +76,7 @@ public class AkkaServiceClientImpl implements AkkaServiceClient {
     }
 
 
-    @PreDestroy
     public void destroy() {
-        //Tie this actor system to our bean lifecycle
         actorSystem.shutdown();
     }
 
@@ -131,7 +123,7 @@ public class AkkaServiceClientImpl implements AkkaServiceClient {
         });
     }
 
-    public ServiceClient getServiceClient(HttpClientService httpClientService) {
-        return new ServiceClient(null, httpClientService);
+    public ServiceClient getServiceClient(String connectionPoolId, HttpClientService httpClientService) {
+        return new ServiceClient(connectionPoolId, httpClientService);
     }
 }

--- a/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientImpl.java
+++ b/repose-aggregator/services/service-client/impl/src/main/java/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientImpl.java
@@ -56,7 +56,7 @@ public class AkkaServiceClientImpl implements AkkaServiceClient {
     private ActorRef tokenActorRef;
 
     public AkkaServiceClientImpl(String connectionPoolId, HttpClientService httpClientService) {
-        this.serviceClient = getServiceClient(connectionPoolId, httpClientService);
+        this.serviceClient = new ServiceClient(connectionPoolId, httpClientService);
         final int numberOfActors = serviceClient.getPoolSize();
 
         Config customConf = ConfigFactory.load();
@@ -121,9 +121,5 @@ public class AkkaServiceClientImpl implements AkkaServiceClient {
                 return ask(tokenActorRef, hashableRequest, timeout);
             }
         });
-    }
-
-    public ServiceClient getServiceClient(String connectionPoolId, HttpClientService httpClientService) {
-        return new ServiceClient(connectionPoolId, httpClientService);
     }
 }

--- a/repose-aggregator/services/service-client/impl/src/test/scala/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientFactoryImplTest.scala
+++ b/repose-aggregator/services/service-client/impl/src/test/scala/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientFactoryImplTest.scala
@@ -36,7 +36,7 @@ class AkkaServiceClientFactoryImplTest extends FunSpec with Matchers with Mockit
 
   describe("the factory will return an instance when") {
     List(null, "", "test_conn_pool").foreach { connectionPoolId =>
-      it(s"the connection pool id is $connectionPoolId") {
+      it(s"the specified connection pool id is $connectionPoolId") {
         when(httpClientService.getMaxConnections(or(anyString(), isNull.asInstanceOf[String]))).thenReturn(20)
         val akkaServiceClientFactoryImpl = new AkkaServiceClientFactoryImpl(httpClientService)
 
@@ -44,6 +44,15 @@ class AkkaServiceClientFactoryImplTest extends FunSpec with Matchers with Mockit
 
         akkaServiceClient should not be null
       }
+    }
+
+    it("the default method with no connection pool id is called") {
+      when(httpClientService.getMaxConnections(or(anyString(), isNull.asInstanceOf[String]))).thenReturn(20)
+      val akkaServiceClientFactoryImpl = new AkkaServiceClientFactoryImpl(httpClientService)
+
+      val akkaServiceClient = akkaServiceClientFactoryImpl.newAkkaServiceClient()
+
+      akkaServiceClient should not be null
     }
   }
 }

--- a/repose-aggregator/services/service-client/impl/src/test/scala/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientFactoryImplTest.scala
+++ b/repose-aggregator/services/service-client/impl/src/test/scala/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientFactoryImplTest.scala
@@ -1,0 +1,49 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.core.services.serviceclient.akka.impl
+
+import org.junit.runner.RunWith
+import org.mockito.AdditionalMatchers._
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.openrepose.core.services.httpclient.HttpClientService
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class AkkaServiceClientFactoryImplTest extends FunSpec with Matchers with MockitoSugar {
+
+  val httpClientService = mock[HttpClientService]
+
+  describe("the factory will return an instance when") {
+    List(null, "", "test_conn_pool").foreach { connectionPoolId =>
+      it(s"the connection pool id is $connectionPoolId") {
+        when(httpClientService.getMaxConnections(or(anyString(), isNull.asInstanceOf[String]))).thenReturn(20)
+        val akkaServiceClientFactoryImpl = new AkkaServiceClientFactoryImpl(httpClientService)
+
+        val akkaServiceClient = akkaServiceClientFactoryImpl.newAkkaServiceClient(connectionPoolId)
+
+        akkaServiceClient should not be null
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added ability to set a connection pool ID in the AkkaServiceClient.

If none is specified, the old behavior is used, so this update is backwards compatible.