### PR TITLE
Add tests for client auth-n and keystonev2 to ensure racker token (no…

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/removetenant/tenantednondelegable/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/removetenant/tenantednondelegable/keystone-v2.cfg.xml
@@ -2,7 +2,7 @@
 <keystone-v2 xmlns="http://docs.openrepose.org/repose/keystone-v2/v1.0">
     <cache>
         <timeouts>
-            <token>600000</token>
+            <token>0</token>
             <group>600000</group>
         </timeouts>
     </cache>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/tenantvalidation/NonTenantedAuthTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/clientauthn/tenantvalidation/NonTenantedAuthTest.groovy
@@ -79,6 +79,26 @@ class NonTenantedAuthTest extends ReposeValveTest {
         mc.handlings.size() == 1
     }
 
+    def "Validate RackerSSO token no tenant"() {
+        given: "client auth with racker user access"
+        fakeIdentityService.with {
+            client_token = "rackerSSO"
+            service_admin_role = "non-admin"
+        }
+
+        when: "pass request with request tenant"
+        def mc =
+                deproxy.makeRequest(
+                        url: reposeEndpoint + "/servers/12345",
+                        method: 'GET',
+                        headers: ['content-type': 'application/json', 'X-Auth-Token': fakeIdentityService.client_token]
+                )
+
+        then: "should satisfy the following"
+        mc.receivedResponse.code == "200"
+        mc.handlings.size() == 1
+    }
+
     def "Fails when a racker token doesn't have the authorized role"() {
         fakeIdentityService.with {
             client_token = "rackerFailure"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/TenantedNonDelegableTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/tenantvalidation/TenantedNonDelegableTest.groovy
@@ -61,6 +61,7 @@ class TenantedNonDelegableTest extends ReposeValveTest {
 
     def setup() {
         fakeIdentityV2Service.resetHandlers()
+        fakeIdentityV2Service.resetDefaultParameters()
     }
 
     @Unroll("tenant: #requestTenant, with return from identity with HTTP code (#authResponseCode), group HTTP code (#groupResponseCode) and response tenant: #responseTenant")
@@ -390,5 +391,24 @@ class TenantedNonDelegableTest extends ReposeValveTest {
         mc.handlings.size() == 1
         mc.getHandlings().get(0).getRequest().getHeaders().contains("x-tenant-id")
         mc.getHandlings().get(0).getRequest().getHeaders().getFirstValue("x-tenant-id") == hybridtenant
+    }
+
+    def "Racker token fails with tenanted mode and non service admin role" () {
+        given: "keystone v2 with racker user access"
+        fakeIdentityV2Service.with {
+            client_token = "rackerSSO"
+            service_admin_role = "non-admin"
+        }
+
+        when: "pass request with request tenant"
+        def mc =
+                deproxy.makeRequest(
+                        url: reposeEndpoint + "/servers/12345",
+                        method: 'GET',
+                        headers: ['content-type': 'application/json', 'X-Auth-Token': fakeIdentityV2Service.client_token]
+                )
+
+        then: "should satisfy the following"
+        mc.receivedResponse.code == "401"
     }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityService.groovy
@@ -392,6 +392,8 @@ class MockIdentityService {
             if (xml) {
                 if (tokenId == "rackerButts") {
                     template = rackerTokenXmlTemplate
+                } else if (tokenId == "rackerSSO") {
+                    template = rackerSuccessfulValidateRespXmlTemplate
                 } else if (tokenId == "failureRacker") {
                     template = rackerTokenWithoutProperRoleXmlTemplate
                 } else if (tokenId == "dedicatedUser") {
@@ -404,6 +406,8 @@ class MockIdentityService {
             } else {
                 if (impersonate_id != "") {
                     template = impersonateSuccessfulJsonRespTemplate
+                } else if (tokenId == "rackerSSO") {
+                    template = rackerSuccessfulValidateRespJsonTemplate
                 } else if (tokenId == "dedicatedUser") {
                     template = dedicatedUserSuccessfulRespJsonTemplate
                 } else {
@@ -1149,7 +1153,59 @@ class MockIdentityService {
     </user>
 </access>
 """
-
+    def rackerSuccessfulValidateRespXmlTemplate =
+            """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<access xmlns="http://docs.openstack.org/identity/api/v2.0"
+    xmlns:ns2="http://www.w3.org/2005/Atom"
+    xmlns:os-ksadm="http://docs.openstack.org/identity/api/ext/OS-KSADM/v1.0"
+    xmlns:rax-ksqa="http://docs.rackspace.com/identity/api/ext/RAX-KSQA/v1.0"
+    xmlns:rax-kskey="http://docs.rackspace.com/identity/api/ext/RAX-KSKEY/v1.0"
+    xmlns:os-ksec2="http://docs.openstack.org/identity/api/ext/OS-KSEC2/v1.0"
+    xmlns:rax-auth="http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1.0">
+    <token id="\${token}"
+        expires="\${expires}"/>
+    <user id="rackerSSOUsername">
+        <roles>
+            <role id="9" name="\${serviceadmin}"
+                description="Defines a user as being a Racker"
+                serviceId="18e7a7032733486cd32f472d7bd58f709ac0d221"/>
+            <role id="100" name="dl_RackUSA" />
+            <role name="dl_RackGlobal"/>
+            <role name="dl_cloudblock"/>
+            <role name="dl_US Managers"/>
+            <role name="DL_USManagers"/>
+        </roles>
+    </user>
+</access>
+"""
+    def rackerSuccessfulValidateRespJsonTemplate =
+            """{
+  "access": {
+    "token": {
+      "expires": "\${expires}",
+      "id": "\${token}"
+    },
+    "user": {
+      "RAX-AUTH:defaultRegion": "",
+      "roles": [
+        {
+          "name": "\${serviceadmin}",
+          "description": "Defines a user as being a Racker",
+          "id": "9",
+          "serviceId": "18e7a7032733486cd32f472d7bd58f709ac0d221"
+        },
+        {
+          "name": "test_repose",
+          "id" : "100",
+          "description" : "Defines a user a repose dev",
+          "serviceId": "18e7a7032733486cd32f472d7bd58f709ac0d221"
+        }
+      ],
+      "id": "rackerSSOUsername"
+    }
+  }
+}
+"""
     def rackerTokenWithoutProperRoleXmlTemplate =
             """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <access xmlns="http://docs.openstack.org/identity/api/v2.0"


### PR DESCRIPTION
…n-tenant) in tenanted and nontenanted modes behave as expected