### PR TITLE
REP-2972 Valkyrie account_admin enhancement.

### DIFF
--- a/repose-aggregator/components/filters/valkyrie-authorization/pom.xml
+++ b/repose-aggregator/components/filters/valkyrie-authorization/pom.xml
@@ -39,11 +39,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.openrepose</groupId>
-            <artifactId>http-delegation</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
             <artifactId>scala-logging-slf4j_2.10</artifactId>
         </dependency>

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/config/valkyrie-authorization.xsd
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/config/valkyrie-authorization.xsd
@@ -26,8 +26,6 @@
            attributeFormDefault="unqualified">
 
     <!-- Elements -->
-    <!-- This provides for the original behavior by default and the new root element provides the long term default. -->
-    <!-- NOTE: The default behavior of the root element's enable-bypass-account-admin attribute will be changing in a future release. -->
     <xs:element name="valkyrie-authorization" type="ValkyrieAuthorizationConfig"/>
 
     <!-- Types -->

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/config/valkyrie-authorization.xsd
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/config/valkyrie-authorization.xsd
@@ -18,8 +18,6 @@
   limitations under the License.
   =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
   -->
-
-
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:html="http://www.w3.org/1999/xhtml"
            xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0"
@@ -28,13 +26,17 @@
            attributeFormDefault="unqualified">
 
     <!-- Elements -->
+    <!-- This provides for the original behavior by default and the new root element provides the long term default. -->
+    <!-- NOTE: The default behavior of the root element's enable-bypass-account-admin attribute will be changing in a future release. -->
     <xs:element name="valkyrie-authorization" type="ValkyrieAuthorizationConfig"/>
+    <xs:element name="valkyrie-authorization-new" type="ValkyrieAuthorizationConfig-NEW"/>
 
     <!-- Types -->
     <xs:complexType name="ValkyrieAuthorizationConfig">
         <xs:annotation>
             <xs:documentation>
                 <html:p>The root config type for the valkyrie authorization filter configuration file.</html:p>
+                <html:p>NOTE: The default behavior of this element's enable-bypass-account-admin attribute will be inverted in a future release.</html:p>
             </xs:documentation>
         </xs:annotation>
 
@@ -56,6 +58,66 @@
             <xs:annotation>
                 <xs:documentation>
                     <html:p>Instead of returning a 403, instead return a 404 instead</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-bypass-account-admin" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        If enabled (true), then the secondary authorization call is bypassed and also no culling of the
+                        Origin Service response will occur (DEFAULT).
+                    </html:p>
+                    <html:p>
+                        If disabled (false), then a secondary authorization call will be made and has the potential to increase
+                        in the response time.
+                    </html:p>
+                    <html:p>NOTE: The default value of this attribute will be inverted in a future release.</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ValkyrieAuthorizationConfig-NEW">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>The new root config type for the valkyrie authorization filter configuration file.</html:p>
+                <html:p>NOTE: This NEW element will be removed in a future release and will become the default behavior of the original element in a future release.</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:sequence>
+            <xs:element name="delegating" type="DelegatingType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="valkyrie-server" type="ValkyrieServer" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="translate-permissions-to-roles" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="collection-resources" type="CollectionResources" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="pre-authorized-roles" type="RolesList" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="cache-timeout-millis" type="ZeroOrPositiveInteger" use="optional" default="300000">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Time in milliseconds to cache valkyrie response. The default is 5 minutes.</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-masking-403s" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Instead of returning a 403, instead return a 404 instead</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-bypass-account-admin" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        If disabled (false), then a secondary authorization call will be made and has the potential to increase
+                        in the response time (DEFAULT).
+                    </html:p>
+                    <html:p>
+                        If enabled (true), then the secondary authorization call is bypassed and also no culling of the
+                        Origin Service response will occur.
+                    </html:p>
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/config/valkyrie-authorization.xsd
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/config/valkyrie-authorization.xsd
@@ -29,60 +29,12 @@
     <!-- This provides for the original behavior by default and the new root element provides the long term default. -->
     <!-- NOTE: The default behavior of the root element's enable-bypass-account-admin attribute will be changing in a future release. -->
     <xs:element name="valkyrie-authorization" type="ValkyrieAuthorizationConfig"/>
-    <xs:element name="valkyrie-authorization-new" type="ValkyrieAuthorizationConfig-NEW"/>
 
     <!-- Types -->
     <xs:complexType name="ValkyrieAuthorizationConfig">
         <xs:annotation>
             <xs:documentation>
                 <html:p>The root config type for the valkyrie authorization filter configuration file.</html:p>
-                <html:p>NOTE: The default behavior of this element's enable-bypass-account-admin attribute will be inverted in a future release.</html:p>
-            </xs:documentation>
-        </xs:annotation>
-
-        <xs:sequence>
-            <xs:element name="delegating" type="DelegatingType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="valkyrie-server" type="ValkyrieServer" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="translate-permissions-to-roles" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="collection-resources" type="CollectionResources" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="pre-authorized-roles" type="RolesList" minOccurs="0" maxOccurs="1"/>
-        </xs:sequence>
-        <xs:attribute name="cache-timeout-millis" type="ZeroOrPositiveInteger" use="optional" default="300000">
-            <xs:annotation>
-                <xs:documentation>
-                    <html:p>Time in milliseconds to cache valkyrie response. The default is 5 minutes.</html:p>
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="enable-masking-403s" type="xs:boolean" use="optional" default="false">
-            <xs:annotation>
-                <xs:documentation>
-                    <html:p>Instead of returning a 403, instead return a 404 instead</html:p>
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="enable-bypass-account-admin" type="xs:boolean" use="optional" default="true">
-            <xs:annotation>
-                <xs:documentation>
-                    <html:p>
-                        If enabled (true), then the secondary authorization call is bypassed and also no culling of the
-                        Origin Service response will occur (DEFAULT).
-                    </html:p>
-                    <html:p>
-                        If disabled (false), then a secondary authorization call will be made and has the potential to increase
-                        in the response time.
-                    </html:p>
-                    <html:p>NOTE: The default value of this attribute will be inverted in a future release.</html:p>
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-
-    <xs:complexType name="ValkyrieAuthorizationConfig-NEW">
-        <xs:annotation>
-            <xs:documentation>
-                <html:p>The new root config type for the valkyrie authorization filter configuration file.</html:p>
-                <html:p>NOTE: This NEW element will be removed in a future release and will become the default behavior of the original element in a future release.</html:p>
             </xs:documentation>
         </xs:annotation>
 

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/examples/valkyrie-authorization.cfg.xml
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/resources/META-INF/schema/examples/valkyrie-authorization.cfg.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <valkyrie-authorization
-        xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0" cache-timeout-millis="300000" enable-masking-403s="true">
+        xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0"
+        cache-timeout-millis="300000"
+        enable-masking-403s="true"
+        enable-bypass-account-admin="false">
     <!-- Used is you wish to use delegating authorization, see derp filter -->
     <delegating quality="0.9"/>
     <!-- Which valkyrie instance to hit and with which credentials -->

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
@@ -168,12 +168,7 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
 
       headerResult match {
         case UserInfo(tenant, contact) =>
-          //  authorize device            || cull list                  || translate account permissions
-          if (requestedDeviceId.isDefined || matchingResources.nonEmpty || translateAccountPermissions.isDefined) {
-            datastoreValue(tenant, contact, ACCOUNT_ADMIN, configuration.getValkyrieServer, _.asInstanceOf[UserPermissions], parseInventory, tracingHeader)
-          } else {
-            ResponseResult(200)
-          }
+          datastoreValue(tenant, contact, ACCOUNT_ADMIN, configuration.getValkyrieServer, _.asInstanceOf[UserPermissions], parseInventory, tracingHeader)
         case _ => headerResult
       }
     }

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
@@ -316,7 +316,7 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
 
     potentialUserPermissions match {
       case UserPermissions(roles, devicePermissions) =>
-        if (!roles.contains("account_admin")) {
+        if (!configuration.isEnableBypassAccountAdmin || !roles.contains("account_admin")) {
           if (matchingResources.nonEmpty) {
             val input: String = Source.fromInputStream(response.getBufferedOutputAsInputStream).getLines() mkString ""
             val initialJson: JsValue = Try(Json.parse(input))

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
@@ -143,7 +143,7 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
         @tailrec
         def parseJson(deviceToPermissions: List[DeviceToPermission], values: List[JsValue]): UserPermissions = {
           if (values.isEmpty) {
-            UserPermissions(List(ACCOUNT_ADMIN).toVector, deviceToPermissions.toVector)
+            UserPermissions(Vector.empty[String], deviceToPermissions.toVector)
           } else {
             val currentItem: JsValue = values.head
             (currentItem \ "id").as[Int] match {

--- a/repose-aggregator/components/filters/valkyrie-authorization/src/test/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilterTest.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/test/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilterTest.scala
@@ -464,7 +464,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
         filter.doFilter(mockServletRequest, mockServletResponse, filterChain)
 
         Mockito.verify(filterChain).doFilter(captor.capture(), Matchers.any(classOf[ServletResponse]))
-        val roles: Iterator[String] = captor.getValue.getHeaders("X-Roles").asScala
+        val roles = captor.getValue.getHeaders("X-Roles").asScala.toList
         assert(roles.contains("some_permission"))
         assert(roles.contains("a_different_permission"))
         assert(roles.contains(devicePermission))
@@ -519,7 +519,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
       filter.doFilter(mockServletRequest, mockServletResponse, filterChain)
 
       Mockito.verify(filterChain).doFilter(captor.capture(), Matchers.any(classOf[ServletResponse]))
-      val roles: Iterator[String] = captor.getValue.getHeaders("X-Roles").asScala
+      val roles = captor.getValue.getHeaders("X-Roles").asScala.toList
       assert(roles.contains("a_different_permission"))
       assert(roles.contains("some_permission"))
     }
@@ -605,7 +605,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
       filter.doFilter(mockServletRequest, mockServletResponse, filterChain)
       Mockito.verify(filterChain).doFilter(captor.capture(), Matchers.any(classOf[ServletResponse]))
 
-      val roles: Iterator[String] = captor.getValue.getHeaders("X-Roles").asScala
+      val roles = captor.getValue.getHeaders("X-Roles").asScala.toList
       assert(roles.contains("some_permission"))
       assert(roles.contains("a_different_permission"))
 
@@ -646,7 +646,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
       filter.doFilter(mockServletRequest, mockServletResponse, filterChain)
 
       Mockito.verify(filterChain).doFilter(captor.capture(), Matchers.any(classOf[ServletResponse]))
-      val roles: Iterator[String] = captor.getValue.getHeaders("X-Roles").asScala
+      val roles = captor.getValue.getHeaders("X-Roles").asScala.toList
       assert(roles.contains("a_different_permission"))
       assert(roles.contains("some_permission"))
     }
@@ -798,7 +798,7 @@ class ValkyrieAuthorizationFilterTest extends FunSpec with BeforeAndAfter with M
 
       val content: String = originalResponse.getOutputStreamContent
       val json: JsValue = Json.parse(content)
-      assert((json \ "values").asInstanceOf[JsArray].value.size == 0)
+      assert((json \ "values").asInstanceOf[JsArray].value.isEmpty)
       assert((json \ "metadata" \ "count").asInstanceOf[JsNumber].as[Int] == 0)
     }
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/accountadmin/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/accountadmin/http-connection-pool.cfg.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+    <pool id="default"
+          default="true"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="20"
+          http.socket.timeout="120000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="120000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/accountadmin/valkyrie-authorization.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/accountadmin/valkyrie-authorization.cfg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<valkyrie-authorization xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0"
+                        cache-timeout-millis="300000">
+    <valkyrie-server uri="http://localhost:${valkyriePort}" username="user1" password="$6**YYLGrimey"/>
+    <translate-permissions-to-roles/>
+</valkyrie-authorization>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/collectionresources/valkyrie-authorization.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/valkyrie/collectionresources/valkyrie-authorization.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <valkyrie-authorization
-        xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0" cache-timeout-millis="3000">
+        xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0" cache-timeout-millis="3000" enable-bypass-account-admin="true">
     <valkyrie-server uri="http://localhost:${valkyriePort}" username="user1" password="$6**YYLGrimey"/>
     <collection-resources>
         <resource>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/AccountAdminTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/AccountAdminTest.groovy
@@ -1,0 +1,121 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.valkyrie
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityService
+import framework.mocks.MockValkyrie
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import spock.lang.Unroll
+
+class AccountAdminTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static valkyrieEndpoint
+
+    def static MockIdentityService fakeIdentityService
+    def static MockValkyrie fakeValkyrie
+    def static Map params = [:]
+
+    def static random = new Random()
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+
+        params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie", params);
+        repose.configurationProvider.applyConfigs("features/filters/valkyrie/accountadmin", params);
+
+        repose.setDoSuspend(true)
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+
+        fakeValkyrie = new MockValkyrie(properties.valkyriePort)
+        valkyrieEndpoint = deproxy.addEndpoint(properties.valkyriePort, 'valkyrie service', null, fakeValkyrie.handler)
+    }
+
+    def setup() {
+        fakeIdentityService.resetHandlers()
+        fakeIdentityService.resetDefaultParameters()
+        fakeValkyrie.resetHandlers()
+        fakeValkyrie.resetParameters()
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    @Unroll("#method device #deviceID with permission #permission, tenant: #tenantID should return a #responseCode")
+    def "#method device #deviceID with permission #permission, tenant: #tenantID should return a #responseCode"() {
+        given: "A "
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = tenantID
+        }
+
+        fakeValkyrie.with {
+            device_id = deviceID
+            device_perm = permission
+            multiplier = 5000
+        }
+
+        when: "a #method request is made to access device #deviceID"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/" + deviceID, method: method,
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "the response should be #responseCode and #permission should be in the Requests the X-Roles header"
+        mc.receivedResponse.code == responseCode
+        // user device permission translate to roles
+        mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains(permission)
+        mc.getHandlings().get(0).getRequest().headers.getFirstValue("x-device-id") == deviceID
+
+        where:
+        method   | tenantID       | deviceID | permission      | responseCode
+        "HEAD"   | randomTenant() | "520707" | "account_admin" | "200"
+        "GET"    | randomTenant() | "520707" | "account_admin" | "200"
+        "PUT"    | randomTenant() | "520707" | "account_admin" | "200"
+        "POST"   | randomTenant() | "520707" | "account_admin" | "200"
+        "PATCH"  | randomTenant() | "520707" | "account_admin" | "200"
+        "DELETE" | randomTenant() | "520707" | "account_admin" | "200"
+    }
+
+    def String randomTenant() {
+        "hybrid:" + random.nextInt()
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/AccountAdminTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/AccountAdminTest.groovy
@@ -98,7 +98,7 @@ class AccountAdminTest extends ReposeValveTest {
         fakeValkyrie.with {
             device_id = deviceID
             device_perm = permission
-            multiplier = 500
+            inventory_multiplier = 500
         }
 
         when: "a #method request is made to access device #deviceID"
@@ -141,7 +141,7 @@ class AccountAdminTest extends ReposeValveTest {
 
         fakeValkyrie.with {
             account_perm = "account_admin"
-            multiplier = 500
+            inventory_multiplier = 500
         }
 
         def jsonbody = genJsonResp(5000)

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/AccountAdminTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/AccountAdminTest.groovy
@@ -46,7 +46,6 @@ class AccountAdminTest extends ReposeValveTest {
         repose.configurationProvider.applyConfigs("features/filters/valkyrie", params);
         repose.configurationProvider.applyConfigs("features/filters/valkyrie/accountadmin", params);
 
-        repose.setDoSuspend(true)
         repose.start()
 
         originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/AccountAdminTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/valkyrie/AccountAdminTest.groovy
@@ -20,12 +20,24 @@
 package features.filters.valkyrie
 
 import framework.ReposeValveTest
+import framework.category.Slow
 import framework.mocks.MockIdentityService
 import framework.mocks.MockValkyrie
+import groovy.json.JsonSlurper
+import org.junit.experimental.categories.Category
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
+import org.rackspace.deproxy.Response
 import spock.lang.Unroll
 
+/**
+ * Updated by jennyvo on 11/04/15.
+ * if account_admin role make additional call (inventory) to valkyrie to get the full list of devices
+ *  Test with:
+ *      mock valkyrie return with a list of > 500 devices
+ *      mock origin services response return > 5000 devices
+ */
+@Category(Slow)
 class AccountAdminTest extends ReposeValveTest {
     def static originEndpoint
     def static identityEndpoint
@@ -77,7 +89,6 @@ class AccountAdminTest extends ReposeValveTest {
     @Unroll("#method device #deviceID with permission #permission, tenant: #tenantID should return a #responseCode")
     def "#method device #deviceID with permission #permission, tenant: #tenantID should return a #responseCode"() {
         given: "A "
-
         fakeIdentityService.with {
             client_apikey = UUID.randomUUID().toString()
             client_token = UUID.randomUUID().toString()
@@ -87,7 +98,7 @@ class AccountAdminTest extends ReposeValveTest {
         fakeValkyrie.with {
             device_id = deviceID
             device_perm = permission
-            multiplier = 5000
+            multiplier = 500
         }
 
         when: "a #method request is made to access device #deviceID"
@@ -98,11 +109,17 @@ class AccountAdminTest extends ReposeValveTest {
                 ]
         )
 
+        def accountid = fakeValkyrie.tenant_id
+        def contactid = fakeIdentityService.contact_id
+
         then: "the response should be #responseCode and #permission should be in the Requests the X-Roles header"
         mc.receivedResponse.code == responseCode
         // user device permission translate to roles
         mc.getHandlings().get(0).getRequest().headers.findAll("x-roles").contains(permission)
         mc.getHandlings().get(0).getRequest().headers.getFirstValue("x-device-id") == deviceID
+        // orphanedhandlings should include the original call + account inventoty call
+        mc.orphanedHandlings.request.path.toString().contains("/account/" + accountid + "/permissions/contacts/any/by_contact/" + contactid + "/effective")
+        mc.orphanedHandlings.request.path.toString().contains("/account/" + accountid + "/inventory")
 
         where:
         method   | tenantID       | deviceID | permission      | responseCode
@@ -114,7 +131,101 @@ class AccountAdminTest extends ReposeValveTest {
         "DELETE" | randomTenant() | "520707" | "account_admin" | "200"
     }
 
+    def "Test get match resource list with large list 5000 devices"() {
+        given: "a list permission devices defined in Valkyrie"
+        def tenantID = randomTenant()
+        fakeIdentityService.with {
+            client_token = UUID.randomUUID().toString()
+            client_tenant = tenantID
+        }
+
+        fakeValkyrie.with {
+            account_perm = "account_admin"
+            multiplier = 500
+        }
+
+        def jsonbody = genJsonResp(5000)
+
+        "Json Response from origin service"
+        def jsonResp = { request -> return new Response(200, "OK", ["content-type": "application/json"], jsonbody) }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/9999", method: "GET",
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                        'x-contact-id': '123456',
+                        'x-tenant-id' : tenantID
+                ],
+                defaultHandler: jsonResp
+        )
+        def accountid = fakeValkyrie.tenant_id
+        def contactid = fakeIdentityService.contact_id
+        def body = new String(mc.receivedResponse.body)
+        def slurper = new JsonSlurper()
+        def result = slurper.parseText(body)
+
+        then: "check response"
+        mc.handlings.size() == 1
+        mc.receivedResponse.code == "200"
+        result.values.size == 5001
+        result.metadata.count == 5001
+        // orphanedhandlings should include the original call + account inventoty call
+        mc.orphanedHandlings.request.path.toString().contains("/account/" + accountid + "/permissions/contacts/any/by_contact/" + contactid + "/effective")
+        mc.orphanedHandlings.request.path.toString().contains("/account/" + accountid + "/inventory")
+    }
+
     def String randomTenant() {
         "hybrid:" + random.nextInt()
+    }
+
+    def String randomDevice() {
+        def listdevices = ["520707", "520708", "520709", "520710", "520711", "520712", "520713"]
+        return listdevices.get(random.nextInt(listdevices.size()))
+    }
+
+    def String genJsonResp(def number) {
+        def value = number + 1
+        String meat = """{
+        "values": ["""
+        1.upto(number) {
+            meat += """{
+                "id": "en6bShuX7a",
+                "label": "brad@morgabra.com",
+                "ip_addresses": null,
+                "metadata": {
+                    "userId": "325742",
+                    "email": "brad@morgabra.com"
+                },
+                "managed": false,
+                "uri": "http://core.rackspace.com/accounts/123456/devices/""" + randomDevice() + """",
+                "agent_id": "e333a7d9-6f98-43ea-aed3-52bd06ab929f",
+                "active_suppressions": [],
+                "scheduled_suppressions": [],
+                "created_at": 1405963090100,
+                "updated_at": 1409247144717
+            },"""
+        }
+        meat += """{
+                "id": "enADqSly1y",
+                "label": "test",
+                "ip_addresses": null,
+                "metadata": null,
+                "managed": false,
+                "uri": "http://core.rackspace.com/accounts/123456/devices/""" + randomDevice() + """",
+                "agent_id": null,
+                "active_suppressions": [],
+                "scheduled_suppressions": [],
+                "created_at": 1411055897191,
+                "updated_at": 1411055897191
+            }],
+            "metadata": {
+                "count": $value,
+                "limit": $value,
+                "marker": null,
+                "next_marker": "enB11JvqNv",
+                "next_href": "https://monitoring.api.rackspacecloud.com/v1.0/731078/entities?limit=2&marker=enB11JvqNv"
+            }
+        }"""
     }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
@@ -76,8 +76,8 @@ class MockValkyrie {
     String account_perm = "also_butts"
     String contact_id = ""
     String tenant_id = ""
-    Integer fixnumber = 10
-    Integer multiplier = 1
+    Integer device_multiplier = 10
+    Integer inventory_multiplier = 1
 
     def sleeptime = 0
 
@@ -308,7 +308,7 @@ class MockValkyrie {
 
         //Build up a pile of hyoog json results
         StringBuilder lotsOJson = new StringBuilder()
-        fixnumber.times { x ->
+        device_multiplier.times { x ->
             lotsOJson.append(templateEngine.createTemplate("""{
                             "item_type_id": 2,
                             "item_type_name": "devices",
@@ -377,7 +377,7 @@ class MockValkyrie {
 
         //Build up a pile of hyoog json results
         StringBuilder lotsOJson = new StringBuilder()
-        multiplier.times { x ->
+        inventory_multiplier.times { x ->
             lotsOJson.append(templateEngine.createTemplate("""{
                         "status": "Online",
                         "datacenter": "Datacenter (ABC1)",
@@ -405,6 +405,4 @@ class MockValkyrie {
         //Now glue all the things together
         originalTemplate + lotsOJson + "]}"
     }
-
-
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
@@ -182,7 +182,7 @@ class MockValkyrie {
 
         //Build up a pile of hyoog json results
         StringBuilder lotsOJson = new StringBuilder()
-        10.times { x ->
+        1000.times { x ->
             lotsOJson.append(templateEngine.createTemplate("""{
                             "item_type_id": 2,
                             "item_type_name": "accounts",

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
@@ -40,9 +40,9 @@ class MockValkyrie {
 
     int port
 
-    boolean missingRequestHeaders = false;
+    boolean missingRequestHeaders = false
 
-    protected AtomicInteger _authorizeCount = new AtomicInteger(0);
+    protected AtomicInteger _authorizeCount = new AtomicInteger(0)
 
 
     void resetCounts() {
@@ -76,10 +76,11 @@ class MockValkyrie {
     String account_perm = "also_butts"
     String contact_id = ""
     String tenant_id = ""
+    Integer multiplier = 1
 
-    def sleeptime = 0;
+    def sleeptime = 0
 
-    def templateEngine = new SimpleTemplateEngine();
+    def templateEngine = new SimpleTemplateEngine()
 
     def handler = { Request request -> return handleRequest(request) }
 
@@ -124,12 +125,12 @@ class MockValkyrie {
                 return authorizeHandler(tenant, contact, request)
             } else {
                 // return default error response if required headers are present
-                return new Response(403);
+                return new Response(403)
             }
 
         }
 
-        return new Response(501);
+        return new Response(501)
     }
 
     static
@@ -144,23 +145,22 @@ class MockValkyrie {
                 deviceID2   : device_id2,
                 permission  : device_perm,
                 account_perm: account_perm,
-        ];
+        ]
 
-        def code;
-        def template;
-        def headers = [:];
+        def code
+        def headers = [:]
 
         headers.put('Content-type', 'application/json')
 
+        def body
         if (!missingRequestHeaders) {
-            code = 200;
-            template = validationSuccessTemplate(params)
+            code = 200
+            body = validationSuccessTemplate(params)
         } else {
             code = 403
-            template = validationFailureTemplate(params)
+            body = validationFailureTemplate(params)
         }
 
-        def body = template//templateEngine.createTemplate(template).make(params)
         if (sleeptime > 0) {
             sleep(sleeptime)
         }
@@ -182,7 +182,11 @@ class MockValkyrie {
 
         //Build up a pile of hyoog json results
         StringBuilder lotsOJson = new StringBuilder()
+<<<<<<< HEAD
         1000.times { x ->
+=======
+        multiplier.times { x ->
+>>>>>>> Added a multiplier for the MockValkyrie success template in order to force large (i.e. hyoog) success returns.
             lotsOJson.append(templateEngine.createTemplate("""{
                             "item_type_id": 2,
                             "item_type_name": "accounts",

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
@@ -76,6 +76,7 @@ class MockValkyrie {
     String account_perm = "also_butts"
     String contact_id = ""
     String tenant_id = ""
+    Integer fixnumber = 10
     Integer multiplier = 1
 
     def sleeptime = 0
@@ -112,7 +113,6 @@ class MockValkyrie {
         else
             password = request.headers.getFirstValue('X-Auth-Token')
 
-
         if (method == "GET") {
             if (!missingRequestHeaders) {
                 if (request.getPath().contains("inventory")) {
@@ -123,7 +123,7 @@ class MockValkyrie {
                 } else /*if (request.getPath().contains("permissions"))*/ {
                     def match = (requestPath =~ permissionsRegex)
                     tenant_id = match[0][1]
-                    contact_id = match[0][3]
+                    contact_id = match[0][2]
                     _authorizeCount.incrementAndGet()
                 }
                 return authorizeHandler(tenant_id, contact_id, request)
@@ -308,7 +308,7 @@ class MockValkyrie {
 
         //Build up a pile of hyoog json results
         StringBuilder lotsOJson = new StringBuilder()
-        multiplier.times { x ->
+        fixnumber.times { x ->
             lotsOJson.append(templateEngine.createTemplate("""{
                             "item_type_id": 2,
                             "item_type_name": "devices",
@@ -316,7 +316,7 @@ class MockValkyrie {
                             "account_number": \${tenant},
                             "permission_type_id": 7,
                             "permission_name": "hyoog_json",
-                            "item_id": ${x + 5000},
+                            "item_id": ${x + 1000},
                             "id": 0
                         },""").make(params))
         }
@@ -381,7 +381,7 @@ class MockValkyrie {
             lotsOJson.append(templateEngine.createTemplate("""{
                         "status": "Online",
                         "datacenter": "Datacenter (ABC1)",
-                        "name": "${x + 7000}-hyp1.abc.rvi.local",
+                        "name": "${x + 5000}-hyp1.abc.rvi.local",
                         "ipv6_network": "",
                         "type": "Server",
                         "primary_ipv4": "",
@@ -393,7 +393,7 @@ class MockValkyrie {
                         "os": "Penguin Power",
                         "account_number": 11,
                         "primary_ipv4_netmask": "",
-                        "id": ${x + 7000},
+                        "id": ${x + 5000},
                         "ipv6_server_allocation_block": "",
                         "permissions": [
                             "hyoog_json"
@@ -405,4 +405,6 @@ class MockValkyrie {
         //Now glue all the things together
         originalTemplate + lotsOJson + "]}"
     }
+
+
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
@@ -115,14 +115,18 @@ class MockValkyrie {
 
         if (method == "GET") {
             if (!missingRequestHeaders) {
-                def match = (requestPath =~ permissionsRegex)
-                def tenant = match[0][1]
-                def call = match[0][2]
-                def contact = match[0][3]
-                contact_id = contact
-                tenant_id = tenant
-                _authorizeCount.incrementAndGet()
-                return authorizeHandler(tenant, contact, request)
+                if (request.getPath().contains("inventory")) {
+                    def match = (requestPath =~ inventoryRegex)
+                    tenant_id = match[0][1]
+                    contact_id = null
+                    _authorizeCount.incrementAndGet()
+                } else /*if (request.getPath().contains("permissions"))*/ {
+                    def match = (requestPath =~ permissionsRegex)
+                    tenant_id = match[0][1]
+                    contact_id = match[0][3]
+                    _authorizeCount.incrementAndGet()
+                }
+                return authorizeHandler(tenant_id, contact_id, request)
             } else {
                 // return default error response if required headers are present
                 return new Response(403)
@@ -132,6 +136,9 @@ class MockValkyrie {
 
         return new Response(501)
     }
+
+    static
+    final String inventoryRegex = /^\/account\/([^\/]+)\/inventory/
 
     static
     final String permissionsRegex = /^\/account\/([^\/]+)\/permissions\/contacts\/any\/by_contact\/([^\/]+)\/effective/
@@ -339,7 +346,7 @@ class MockValkyrie {
                         "os": "Penguin Power",
                         "account_number": 11,
                         "primary_ipv4_netmask": "",
-                        "id": \${deviceID}
+                        "id": \${deviceID},
                         "ipv6_server_allocation_block": "",
                         "permissions": [
                             "racker"
@@ -360,7 +367,7 @@ class MockValkyrie {
                         "os": "Penguin Power",
                         "account_number": 11,
                         "primary_ipv4_netmask": "",
-                        "id": \${deviceID2}
+                        "id": \${deviceID2},
                         "ipv6_server_allocation_block": "",
                         "permissions": [
                             "racker"
@@ -374,7 +381,7 @@ class MockValkyrie {
             lotsOJson.append(templateEngine.createTemplate("""{
                         "status": "Online",
                         "datacenter": "Datacenter (ABC1)",
-                        "name": "${x + 5000}-hyp1.abc.rvi.local",
+                        "name": "${x + 7000}-hyp1.abc.rvi.local",
                         "ipv6_network": "",
                         "type": "Server",
                         "primary_ipv4": "",
@@ -386,7 +393,7 @@ class MockValkyrie {
                         "os": "Penguin Power",
                         "account_number": 11,
                         "primary_ipv4_netmask": "",
-                        "id": ${x + 5000},
+                        "id": ${x + 7000},
                         "ipv6_server_allocation_block": "",
                         "permissions": [
                             "hyoog_json"

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockValkyrie.groovy
@@ -155,7 +155,11 @@ class MockValkyrie {
         def body
         if (!missingRequestHeaders) {
             code = 200
-            body = validationSuccessTemplate(params)
+            if (request.getPath().contains("inventory")) {
+                body = inventorySuccessTemplate(params)
+            } else /*if (request.getPath().contains("permissions"))*/ {
+                body = validationSuccessTemplate(params)
+            }
         } else {
             code = 403
             body = validationFailureTemplate(params)
@@ -179,26 +183,6 @@ class MockValkyrie {
     }
 
     String validationSuccessTemplate(Map<String, String> params) {
-
-        //Build up a pile of hyoog json results
-        StringBuilder lotsOJson = new StringBuilder()
-<<<<<<< HEAD
-        1000.times { x ->
-=======
-        multiplier.times { x ->
->>>>>>> Added a multiplier for the MockValkyrie success template in order to force large (i.e. hyoog) success returns.
-            lotsOJson.append(templateEngine.createTemplate("""{
-                            "item_type_id": 2,
-                            "item_type_name": "accounts",
-                            "contact_id": \${contact},
-                            "account_number": \${tenant},
-                            "permission_type_id": 7,
-                            "permission_name": "edit_domain",
-                            "item_id": ${x + 5000},
-                            "id": 0
-                        },""").make(params))
-        }
-        lotsOJson.deleteCharAt(lotsOJson.size() - 1) //Delete the pesky trailing comma
 
         //Create the original template stuff and get a string of it
         String originalTemplate = templateEngine.createTemplate("""{
@@ -239,7 +223,7 @@ class MockValkyrie {
                             "item_type_name": "devices",
                             "contact_id": \${contact},
                             "account_number": \${tenant},
-                            "permission_name": "edid_product",
+                            "permission_name": "edit_product",
                             "item_id": 862323,
                             "id": 0
                         },
@@ -314,6 +298,102 @@ class MockValkyrie {
                             "id": 0
                         },
                 """).make(params).toString()
+
+        //Build up a pile of hyoog json results
+        StringBuilder lotsOJson = new StringBuilder()
+        multiplier.times { x ->
+            lotsOJson.append(templateEngine.createTemplate("""{
+                            "item_type_id": 2,
+                            "item_type_name": "devices",
+                            "contact_id": \${contact},
+                            "account_number": \${tenant},
+                            "permission_type_id": 7,
+                            "permission_name": "hyoog_json",
+                            "item_id": ${x + 5000},
+                            "id": 0
+                        },""").make(params))
+        }
+        lotsOJson.deleteCharAt(lotsOJson.size() - 1) //Delete the pesky trailing comma
+
+        //Now glue all the things together
+        originalTemplate + lotsOJson + "]}"
+    }
+
+    String inventorySuccessTemplate(Map<String, String> params) {
+
+        //Create the original template stuff and get a string of it
+        String originalTemplate = templateEngine.createTemplate("""{
+                "inventory": [
+                    {
+                        "status": "Online",
+                        "datacenter": "Datacenter (ABC1)",
+                        "name": "\${deviceID}-hyp1.abc.rvi.local",
+                        "ipv6_network": "",
+                        "type": "Server",
+                        "primary_ipv4": "",
+                        "primary_ipv6": "",
+                        "primary_ipv4_gateway": "",
+                        "datacenter_id": 1,
+                        "platform": "Super Server",
+                        "nickname": null,
+                        "os": "Penguin Power",
+                        "account_number": 11,
+                        "primary_ipv4_netmask": "",
+                        "id": \${deviceID}
+                        "ipv6_server_allocation_block": "",
+                        "permissions": [
+                            "racker"
+                        ]
+                    },
+                    {
+                        "status": "Online",
+                        "datacenter": "Datacenter (ABC1)",
+                        "name": "\${deviceID2}-hyp1.abc.rvi.local",
+                        "ipv6_network": "",
+                        "type": "Server",
+                        "primary_ipv4": "",
+                        "primary_ipv6": "",
+                        "primary_ipv4_gateway": "",
+                        "datacenter_id": 1,
+                        "platform": "Super Server",
+                        "nickname": null,
+                        "os": "Penguin Power",
+                        "account_number": 11,
+                        "primary_ipv4_netmask": "",
+                        "id": \${deviceID2}
+                        "ipv6_server_allocation_block": "",
+                        "permissions": [
+                            "racker"
+                        ]
+                    },
+                """).make(params).toString()
+
+        //Build up a pile of hyoog json results
+        StringBuilder lotsOJson = new StringBuilder()
+        multiplier.times { x ->
+            lotsOJson.append(templateEngine.createTemplate("""{
+                        "status": "Online",
+                        "datacenter": "Datacenter (ABC1)",
+                        "name": "${x + 5000}-hyp1.abc.rvi.local",
+                        "ipv6_network": "",
+                        "type": "Server",
+                        "primary_ipv4": "",
+                        "primary_ipv6": "",
+                        "primary_ipv4_gateway": "",
+                        "datacenter_id": 1,
+                        "platform": "Super Server",
+                        "nickname": null,
+                        "os": "Penguin Power",
+                        "account_number": 11,
+                        "primary_ipv4_netmask": "",
+                        "id": ${x + 5000},
+                        "ipv6_server_allocation_block": "",
+                        "permissions": [
+                            "hyoog_json"
+                        ]
+                    },""").make(params))
+        }
+        lotsOJson.deleteCharAt(lotsOJson.size() - 1) //Delete the pesky trailing comma
 
         //Now glue all the things together
         originalTemplate + lotsOJson + "]}"


### PR DESCRIPTION
This enhancement provided a backwards compatible way to make the Valkyrie filter's config able to support the new expected default behavior. Part of this behavior required adding a second call to Valkyrie in order to obtain the Account Device Inventory when the original Direct Permissions by Contact call returns a role of 'account_admin'.