### PR TITLE
Rep 2128 url extraction to header filter

### DIFF
--- a/repose-aggregator/components/filters/filter-bundle/pom.xml
+++ b/repose-aggregator/components/filters/filter-bundle/pom.xml
@@ -204,6 +204,11 @@
             <artifactId>cors</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>url-extractor-to-header</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
     </dependencies>
 

--- a/repose-aggregator/components/filters/filter-bundle/src/main/application/WEB-INF/web-fragment.xml
+++ b/repose-aggregator/components/filters/filter-bundle/src/main/application/WEB-INF/web-fragment.xml
@@ -163,5 +163,9 @@
         <filter-name>cors</filter-name>
         <filter-class>org.openrepose.filters.cors.CorsFilter</filter-class>
     </filter>
+    <filter>
+        <filter-name>url-extractor-to-header</filter-name>
+        <filter-class>org.openrepose.filters.urlextractortoheader.UrlExtractorToHeaderFilter</filter-class>
+    </filter>
 
 </web-fragment>

--- a/repose-aggregator/components/filters/pom.xml
+++ b/repose-aggregator/components/filters/pom.xml
@@ -49,6 +49,7 @@
         <module>valkyrie-authorization</module>
         <module>keystone-v2</module>
         <module>cors</module>
+        <module>url-extractor-to-header</module>
     </modules>
 
     <properties>

--- a/repose-aggregator/components/filters/url-extractor-to-header/pom.xml
+++ b/repose-aggregator/components/filters/url-extractor-to-header/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.openrepose</groupId>
+        <artifactId>filters-support</artifactId>
+        <version>7.2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <name>Repose Components - URL Extractor to Header</name>
+    <artifactId>url-extractor-to-header</artifactId>
+    <packaging>jar</packaging>
+
+    <description>
+        This filter extracts a configured portion of the URL and puts it in a header.
+    </description>
+
+    <properties>
+        <sonar.jacoco.itReportPath>${project.basedir}/../../../target/jacoco-it.exec</sonar.jacoco.itReportPath>
+    </properties>
+
+    <dependencies>
+        <!-- Let's use Scala -->
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.10</artifactId>
+        </dependency>
+
+        <!-- Lazy logging -->
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging-slf4j_2.10</artifactId>
+        </dependency>
+
+        <!-- These three are required because of our coupling between filters and core -->
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>core-lib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>core-service-api</artifactId>
+        </dependency>
+
+        <!-- JAXB -->
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics-runtime</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jvnet.jaxb2.maven2</groupId>
+                <artifactId>maven-jaxb2-plugin</artifactId>
+                <configuration>
+                    <specVersion>2.1</specVersion>
+
+                    <schemaIncludes>
+                        <include>**/*.xsd</include>
+                    </schemaIncludes>
+                    <bindingIncludes>
+                        <include>**/*.xjb</include>
+                    </bindingIncludes>
+
+                    <strict>true</strict>
+                    <verbose>false</verbose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/repose-aggregator/components/filters/url-extractor-to-header/pom.xml
+++ b/repose-aggregator/components/filters/url-extractor-to-header/pom.xml
@@ -48,6 +48,26 @@
             <artifactId>core-service-api</artifactId>
         </dependency>
 
+        <!-- MutableHttpServletRequest -->
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>utilities</artifactId>
+        </dependency>
+
+        <!-- LogFactory, needed by MockHttpServletRequest/Response -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- MockHttpServletRequest/Response -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- JAXB -->
         <dependency>
             <groupId>org.jvnet.jaxb2_commons</groupId>

--- a/repose-aggregator/components/filters/url-extractor-to-header/src/main/resources/META-INF/schema/config/bindings.xjb
+++ b/repose-aggregator/components/filters/url-extractor-to-header/src/main/resources/META-INF/schema/config/bindings.xjb
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  ~ Repose
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+
+<bindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/jaxb"
+          version="2.0"
+          xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+          schemaLocation="url-extractor-to-header.xsd">
+
+    <schemaBindings>
+        <package name="org.openrepose.filters.urlextractortoheader.config"/>
+    </schemaBindings>
+</bindings>

--- a/repose-aggregator/components/filters/url-extractor-to-header/src/main/resources/META-INF/schema/config/url-extractor-to-header.xsd
+++ b/repose-aggregator/components/filters/url-extractor-to-header/src/main/resources/META-INF/schema/config/url-extractor-to-header.xsd
@@ -25,9 +25,9 @@
            targetNamespace="http://docs.openrepose.org/repose/url-extractor-to-header/v1.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified">
-    <xs:element name="url-extractor-to-header" type="UrlExtractorToHeader"/>
+    <xs:element name="url-extractor-to-header" type="UrlExtractorToHeaderConfig"/>
 
-    <xs:complexType name="UrlExtractorToHeader">
+    <xs:complexType name="UrlExtractorToHeaderConfig">
         <xs:annotation>
             <xs:documentation>
                 <html:p>The root config type for the URL Extractor to Header filter configuration file.</html:p>

--- a/repose-aggregator/components/filters/url-extractor-to-header/src/main/resources/META-INF/schema/config/url-extractor-to-header.xsd
+++ b/repose-aggregator/components/filters/url-extractor-to-header/src/main/resources/META-INF/schema/config/url-extractor-to-header.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  ~ Repose
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:html="http://www.w3.org/1999/xhtml"
+           xmlns="http://docs.openrepose.org/repose/url-extractor-to-header/v1.0"
+           targetNamespace="http://docs.openrepose.org/repose/url-extractor-to-header/v1.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+    <xs:element name="url-extractor-to-header" type="UrlExtractorToHeader"/>
+
+    <xs:complexType name="UrlExtractorToHeader">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>The root config type for the URL Extractor to Header filter configuration file.</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:sequence>
+            <xs:element name="extraction" type="Extractor" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Extractor">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>Config type for a URL extraction to a header value.</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:attribute name="header" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>The name of the header to put the extracted value into.</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="url-regex" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        The regex to be applied to the URL in order to extract the desired value.  The value will
+                        specifically be extracted from group 1 of the regex.  For example, a regex of
+                        ".*/(hybrid:\d+)/entities/.+" and a URL of "/v1/hybrid:12345/entities/89" would result in the
+                        value of "hybrid:12345" being used as the header value.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="default" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        The default value to use when the regex doesn't match the URL.  If no default attribute is
+                        supplied, the header will not be added in the event of no match.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/repose-aggregator/components/filters/url-extractor-to-header/src/main/resources/META-INF/schema/examples/url-extractor-to-header.cfg.xml
+++ b/repose-aggregator/components/filters/url-extractor-to-header/src/main/resources/META-INF/schema/examples/url-extractor-to-header.cfg.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  ~ Repose
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+<url-extractor-to-header xmlns="http://docs.openrepose.org/repose/url-extractor-to-header/v1.0">
+    <!-- Grab the Device ID from the path immediately preceding 'entities'; default to an empty header -->
+    <extraction header="X-Device-Id" url-regex=".*/(hybrid:\d+)/entities/.+" default=""/>
+
+    <!-- Grab the Server ID from the resource immediately following 'servers'; don't include header if URL doesn't match -->
+    <extraction header="X-Server-Id" url-regex=".*/servers/([^/]+).*"/>
+
+    <!-- Grab the filter parameter; default to 'none' if a filter wasn't supplied -->
+    <extraction header="X-Filter-Param" url-regex=".*\?.*filter=([^&amp;]+).*" default="none"/>
+</url-extractor-to-header>

--- a/repose-aggregator/components/filters/url-extractor-to-header/src/main/scala/org/openrepose/filters/urlextractortoheader/UrlExtractorToHeaderFilter.scala
+++ b/repose-aggregator/components/filters/url-extractor-to-header/src/main/scala/org/openrepose/filters/urlextractortoheader/UrlExtractorToHeaderFilter.scala
@@ -1,0 +1,30 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package org.openrepose.filters.urlextractortoheader
+
+import javax.servlet._
+
+class UrlExtractorToHeaderFilter extends Filter {
+  override def init(filterConfig: FilterConfig): Unit = ???
+
+  override def doFilter(servletRequest: ServletRequest, servletResponse: ServletResponse, filterChain: FilterChain): Unit = ???
+
+  override def destroy(): Unit = ???
+}

--- a/repose-aggregator/components/filters/url-extractor-to-header/src/test/scala/org/openrepose/filters/urlextractortoheader/UrlExtractorToHeaderFilterTest.scala
+++ b/repose-aggregator/components/filters/url-extractor-to-header/src/test/scala/org/openrepose/filters/urlextractortoheader/UrlExtractorToHeaderFilterTest.scala
@@ -21,6 +21,7 @@
 package org.openrepose.filters.urlextractortoheader
 
 import org.junit.runner.RunWith
+import org.openrepose.filters.urlextractortoheader.config.{UrlExtractorToHeaderConfig, Extractor}
 import org.scalatest.{Matchers, BeforeAndAfter, FunSpec}
 import org.scalatest.junit.JUnitRunner
 
@@ -31,5 +32,35 @@ class UrlExtractorToHeaderFilterTest extends FunSpec with BeforeAndAfter with Ma
     it("should do nothing") {
       // everyone is a winner!
     }
+  }
+
+  describe("configuration") {
+    it("can be loaded when a default value is specified") {
+      val config = new UrlExtractorToHeaderConfig
+      config.getExtraction.add(createConfigExtractor("X-Device-Id", ".*/(hybrid:\\d+)/entities/.+", Some("no-value")))
+      val filter = new UrlExtractorToHeaderFilter(null)
+
+      filter.configurationUpdated(config)
+    }
+
+    it("can be loaded when a default value is NOT specified") {
+      val config = new UrlExtractorToHeaderConfig
+      config.getExtraction.add(createConfigExtractor("X-Device-Id", ".*/(hybrid:\\d+)/entities/.+", None))
+      val filter = new UrlExtractorToHeaderFilter(null)
+
+      filter.configurationUpdated(config)
+    }
+  }
+
+  def createConfigExtractor(headerName: String, urlRegex: String, defaultValue: Option[String]): Extractor = {
+    val extractor = new Extractor
+    extractor.setHeader(headerName)
+    extractor.setUrlRegex(urlRegex)
+    extractor.setDefault(defaultValue match {
+      case Some(default) => default
+      case None => null
+    })
+
+    extractor
   }
 }

--- a/repose-aggregator/components/filters/url-extractor-to-header/src/test/scala/org/openrepose/filters/urlextractortoheader/UrlExtractorToHeaderFilterTest.scala
+++ b/repose-aggregator/components/filters/url-extractor-to-header/src/test/scala/org/openrepose/filters/urlextractortoheader/UrlExtractorToHeaderFilterTest.scala
@@ -1,0 +1,35 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.filters.urlextractortoheader
+
+import org.junit.runner.RunWith
+import org.scalatest.{Matchers, BeforeAndAfter, FunSpec}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class UrlExtractorToHeaderFilterTest extends FunSpec with BeforeAndAfter with Matchers {
+
+  describe("doFilter") {
+    it("should do nothing") {
+      // everyone is a winner!
+    }
+  }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/system-model.cfg.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  ~ Repose
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+  <repose-cluster id="repose">
+
+    <nodes>
+      <node id="simple-node" hostname="localhost" http-port="${reposePort}"/>
+    </nodes>
+
+    <filters>
+      <filter name="url-extractor-to-header" />
+    </filters>
+
+    <destinations>
+        <endpoint id="target" protocol="http" hostname="localhost" root-path="/" port="${targetPort}" default="true" />
+    </destinations>
+
+  </repose-cluster>
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/url-extractor-to-header.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/url-extractor-to-header.cfg.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  ~ Repose
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+<url-extractor-to-header xmlns="http://docs.openrepose.org/repose/url-extractor-to-header/v1.0">
+    <!-- Grab the Device ID from the path immediately preceding 'entities'; default to an empty header -->
+    <extraction header="X-Device-Id" url-regex="/resource/(\d*)" default=""/>
+
+    <!-- Grab the Server ID from the resource immediately following 'servers'; don't include header if URL doesn't match -->
+    <extraction header="X-Server-Id" url-regex=".*/servers/([^/]+).*"/>
+
+    <!-- Grab the filter parameter; default to 'none' if a filter wasn't supplied -->
+    <extraction header="X-Filter-Param" url-regex=".*\?.*filter=([^&amp;]+).*" default="none"/>
+</url-extractor-to-header>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/wvalkyrie/client-auth-n.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/wvalkyrie/client-auth-n.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<client-auth xmlns="http://docs.openrepose.org/repose/client-auth/v1.0">
+    <openstack-auth tenanted="false"
+                    request-groups="true"
+                    token-cache-timeout="1000"
+                    user-cache-timeout="1000"
+                    group-cache-timeout="600000"
+                    xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
+        <identity-service username="admin_username"
+                          password="admin_password"
+                          uri="http://localhost:${identityPort}" />
+        <client-mapping id-regex=".*/servers/([:|-|\w]+)/?.*"/>
+    </openstack-auth>
+</client-auth>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/wvalkyrie/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/wvalkyrie/system-model.cfg.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+  <repose-cluster id="repose">
+
+    <nodes>
+      <node id="simple-node" hostname="localhost" http-port="${reposePort}"/>
+    </nodes>
+
+    <filters>
+      <filter name="client-auth"/>
+      <filter name="url-extractor-to-header"/>
+      <filter name="valkyrie-authorization"/>
+    </filters>
+
+    <destinations>
+        <endpoint id="target" protocol="http" hostname="localhost" root-path="/" port="${targetPort}" default="true" />
+    </destinations>
+
+  </repose-cluster>
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/wvalkyrie/valkyrie-authorization.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/urlextractortoheader/wvalkyrie/valkyrie-authorization.cfg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<valkyrie-authorization
+        xmlns="http://docs.openrepose.org/repose/valkyrie-authorization/v1.0" cache-timeout-millis="3000">
+    <valkyrie-server uri="http://localhost:${valkyriePort}" username="user1" password="$6**YYLGrimey"/>
+</valkyrie-authorization>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/urlextractortoheader/UrlExtractorToHeaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/urlextractortoheader/UrlExtractorToHeaderTest.groovy
@@ -100,7 +100,7 @@ class UrlExtractorToHeaderTest extends ReposeValveTest {
 
         then: "check response"
         mc.receivedResponse.code == responseCode
-        mc.handlings.get(0).request.headers.contains("x-device-id")
+        mc.handlings.get(0).request.headers.contains("x-server-id")
         mc.handlings.get(0).request.headers.getFirstValue("x-server-id") == serverID
         //**This for tracing header on failed response REP-2147
         mc.receivedResponse.headers.contains("x-trans-id")

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/urlextractortoheader/UrlExtractorToHeaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/urlextractortoheader/UrlExtractorToHeaderTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.urlextractortoheader
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import spock.lang.Unroll
+
+/**
+ * Created by jennyvo on 11/23/15.
+ *  url-extractor-to-header test
+ */
+class UrlExtractorToHeaderTest extends ReposeValveTest {
+    def static originEndpoint
+    def static Map params = [:]
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
+
+        params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/urlextractortoheader", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+    }
+
+    def setup() {
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+    @Unroll("#method with deviceID: #deviceID should return a #responseCode")
+    def "Test regex extract deviceId from url set to header"() {
+        given: "A device ID in the url request"
+
+        when: "a request is made against a device"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/" + deviceID, method: method,
+                headers: [
+                        'content-type': 'application/json',
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == responseCode
+        mc.handlings.get(0).request.headers.contains("x-device-id")
+        mc.handlings.get(0).request.headers.getFirstValue("x-device-id") == deviceID
+        //**This for tracing header on failed response REP-2147
+        mc.receivedResponse.headers.contains("x-trans-id")
+
+        where:
+        method   | deviceID | responseCode
+        "GET"    | "520707" | "200"
+        "HEAD"   | "520708" | "200"
+        "PUT"    | "520708" | "200"
+        "POST"   | "520709" | "200"
+        "PATCH"  | "520710" | "200"
+        "DELETE" | "520711" | "200"
+    }
+
+    @Unroll("#method with serverID: #serverID should return a #responseCode")
+    def "Test regex extract server name from url set to header"() {
+        given: "A server ID in the url request"
+
+        when: "a request is made against a device"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/v2.0/servers/" + serverID, method: method,
+                headers: [
+                        'content-type': 'application/json',
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == responseCode
+        mc.handlings.get(0).request.headers.contains("x-device-id")
+        mc.handlings.get(0).request.headers.getFirstValue("x-server-id") == serverID
+        //**This for tracing header on failed response REP-2147
+        mc.receivedResponse.headers.contains("x-trans-id")
+
+        where:
+        method   | serverID     | responseCode
+        "GET"    | "test520707" | "200"
+        "HEAD"   | "test520708" | "200"
+        "PUT"    | "ser_520708" | "200"
+        "POST"   | "sss-520709" | "200"
+        "PATCH"  | "sss:520710" | "200"
+        "DELETE" | "ebc.520711" | "200"
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/urlextractortoheader/UrlExtractorToHeaderWValkyrieTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/urlextractortoheader/UrlExtractorToHeaderWValkyrieTest.groovy
@@ -1,0 +1,140 @@
+package features.filters.urlextractortoheader
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityService
+import framework.mocks.MockValkyrie
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import static org.junit.Assert.*;
+import spock.lang.Unroll
+
+/**
+ * Created by jennyvo on 11/23/15.
+ *  Test valkyrie without need of validator but using url-extractor-to-header
+ */
+class UrlExtractorToHeaderWValkyrieTest extends ReposeValveTest {
+    def static originEndpoint
+    def static identityEndpoint
+    def static valkyrieEndpoint
+
+    def static MockIdentityService fakeIdentityService
+    def static MockValkyrie fakeValkyrie
+    def static Map params = [:]
+
+    def static random = new Random()
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+
+        params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/urlextractortoheader", params);
+        repose.configurationProvider.applyConfigs("features/filters/urlextractortoheader/wvalkyrie", params);
+
+        repose.start()
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityService(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+        fakeIdentityService.checkTokenValid = true
+
+        fakeValkyrie = new MockValkyrie(properties.valkyriePort)
+        valkyrieEndpoint = deproxy.addEndpoint(properties.valkyriePort, 'valkyrie service', null, fakeValkyrie.handler)
+    }
+
+    def setup() {
+        fakeIdentityService.resetHandlers()
+        fakeIdentityService.resetDefaultParameters()
+        fakeValkyrie.resetHandlers()
+        fakeValkyrie.resetParameters()
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
+    }
+
+
+    @Unroll("permission: #permission for #method with tenant: #tenantID and deviceID: #deviceID should return a #responseCode")
+    def "Test Valkyrie with url-extractor-to-header"() {
+        given: "A device ID with a particular permission level defined in Valkyrie"
+
+        fakeIdentityService.with {
+            client_apikey = UUID.randomUUID().toString()
+            client_token = UUID.randomUUID().toString()
+            client_tenant = tenantID
+        }
+
+        fakeValkyrie.with {
+            device_id = deviceID
+            device_perm = permission
+        }
+
+        when: "a request is made against a device with Valkyrie set permissions"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + "/resource/" + deviceID, method: method,
+                headers: [
+                        'content-type': 'application/json',
+                        'X-Auth-Token': fakeIdentityService.client_token,
+                ]
+        )
+
+        then: "check response"
+        mc.receivedResponse.code == responseCode
+        if (responseCode.equals("200")) {
+            assertTrue(mc.handlings.get(0).request.headers.contains("x-device-id"))
+            assertTrue(mc.handlings.get(0).request.headers.getFirstValue("x-device-id") == deviceID)
+        }
+        //**This for tracing header on failed response REP-2147
+        mc.receivedResponse.headers.contains("x-trans-id")
+        //**This part for tracing header test REP-1704**
+        // any requests send to identity also include tracing header
+        mc.orphanedHandlings.each {
+            e -> assertTrue(e.request.headers.contains("x-trans-id"))
+        }
+
+        where:
+        method   | tenantID                   | deviceID | permission      | responseCode
+        "GET"    | randomTenant()             | "520707" | "view_product"  | "200"
+        "HEAD"   | randomTenant()             | "520707" | "view_product"  | "200"
+        "GET"    | randomTenant() - "hybrid:" | "520707" | "view_product"  | "403"
+        "PUT"    | randomTenant()             | "520707" | "view_product"  | "403"
+        "POST"   | randomTenant()             | "520707" | "view_product"  | "403"
+        "DELETE" | randomTenant()             | "520707" | "view_product"  | "403"
+        "PATCH"  | randomTenant()             | "520707" | "view_product"  | "403"
+        "GET"    | randomTenant()             | "520707" | "admin_product" | "200"
+        "HEAD"   | randomTenant()             | "520707" | "admin_product" | "200"
+        "PUT"    | randomTenant()             | "520707" | "admin_product" | "200"
+        "POST"   | randomTenant()             | "520707" | "admin_product" | "200"
+        "PATCH"  | randomTenant()             | "520707" | "admin_product" | "200"
+        "DELETE" | randomTenant()             | "520707" | "admin_product" | "200"
+        "GET"    | randomTenant()             | "520707" | "edit_product"  | "200"
+        "HEAD"   | randomTenant()             | "520707" | "edit_product"  | "200"
+        "PUT"    | randomTenant()             | "520707" | "edit_product"  | "200"
+        "POST"   | randomTenant()             | "520707" | "edit_product"  | "200"
+        "PATCH"  | randomTenant()             | "520707" | "edit_product"  | "200"
+        "DELETE" | randomTenant()             | "520707" | "edit_product"  | "200"
+        "GET"    | randomTenant()             | "520707" | ""              | "403"
+        "HEAD"   | randomTenant()             | "520707" | ""              | "403"
+        "PUT"    | randomTenant()             | "520707" | ""              | "403"
+        "POST"   | randomTenant()             | "520707" | ""              | "403"
+        "PATCH"  | randomTenant()             | "520707" | ""              | "403"
+        "DELETE" | randomTenant()             | "520707" | ""              | "403"
+        "GET"    | randomTenant()             | "520707" | "shazbot_prod"  | "403"
+        "HEAD"   | randomTenant()             | "520707" | "prombol"       | "403"
+        "PUT"    | randomTenant()             | "520707" | "hezmol"        | "403"
+        "POST"   | randomTenant()             | "520707" | "_22_reimer"    | "403"
+        "PATCH"  | randomTenant()             | "520707" | "blah"          | "403"
+        "DELETE" | randomTenant()             | "520707" | "blah"          | "403"
+
+    }
+
+    def String randomTenant() {
+        "hybrid:" + random.nextInt()
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/urlextractortoheader/UrlExtractorToHeaderWValkyrieTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/urlextractortoheader/UrlExtractorToHeaderWValkyrieTest.groovy
@@ -1,3 +1,22 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
 package features.filters.urlextractortoheader
 
 import framework.ReposeValveTest


### PR DESCRIPTION
Added new filter that let's you extract part of the URL and put it in a header.  The header name is configurable, the header value is the first group in the configured regex, and a default value can be specified (or left out if the header shouldn't added) when the regex doesn't match the URL.