### PR TITLE
REP-3199 API-Validator filter is not splitting the X-Roles header.

### DIFF
--- a/repose-aggregator/extensions/api-validator/src/main/java/org/openrepose/filters/apivalidator/ApiValidatorHandler.java
+++ b/repose-aggregator/extensions/api-validator/src/main/java/org/openrepose/filters/apivalidator/ApiValidatorHandler.java
@@ -60,8 +60,8 @@ public class ApiValidatorHandler extends AbstractFilterLogicHandler {
 
     public ApiValidatorHandler(ValidatorInfo defaultValidator, List<ValidatorInfo> validators, boolean multiRoleMatch,
                                boolean delegatingMode, MetricsService metricsService) {
-        this.validators = new ArrayList<ValidatorInfo>(validators.size());
-        this.matchedRoles = new HashSet<String>();
+        this.validators = new ArrayList<>(validators.size());
+        this.matchedRoles = new HashSet<>();
         this.validators.addAll(validators);
         this.multiRoleMatch = multiRoleMatch;
         this.defaultValidator = defaultValidator;
@@ -80,10 +80,14 @@ public class ApiValidatorHandler extends AbstractFilterLogicHandler {
     }
 
     private Set<String> getRolesAsSet(List<? extends HeaderValue> listRoles) {
-        Set<String> roles = new HashSet();
+        Set<String> roles = new HashSet<>();
 
-        for (HeaderValue role : listRoles) {
-            roles.add(role.getValue());
+        for (HeaderValue headerValue : listRoles) {
+            String[] split = headerValue.getValue().split(",");
+            for (String role : split) {
+                String[] value = role.split(";");
+                roles.add(value[0]);
+            }
         }
 
         return roles;
@@ -105,7 +109,7 @@ public class ApiValidatorHandler extends AbstractFilterLogicHandler {
     }
 
     protected List<ValidatorInfo> getValidatorsForRole(List<? extends HeaderValue> listRoles) {
-        List<ValidatorInfo> validatorList = new ArrayList<ValidatorInfo>();
+        List<ValidatorInfo> validatorList = new ArrayList<>();
         Set<String> roles = getRolesAsSet(listRoles);
 
         for (ValidatorInfo validator : validators) {

--- a/repose-aggregator/extensions/api-validator/src/test/java/org/openrepose/filters/apivalidator/ApiValidatorHandlerTest.java
+++ b/repose-aggregator/extensions/api-validator/src/test/java/org/openrepose/filters/apivalidator/ApiValidatorHandlerTest.java
@@ -109,7 +109,7 @@ public class ApiValidatorHandlerTest {
         @Test
         public void shouldCallValidatorForRole() {
             List<HeaderValue> roles = new ArrayList<HeaderValue>();
-            roles.add(new HeaderValueImpl("role1"));
+            roles.add(new HeaderValueImpl("junk;q=0.9,role1;q=0.1,stuff;=0.8"));
 
             when(request.getPreferredHeaderValues(eq(OpenStackServiceHeader.ROLES.toString()), any(HeaderValueImpl.class))).thenReturn(roles);
             instance.handleRequest(request, response);


### PR DESCRIPTION
This is what came out of the Ninja task investigation for:
 * https://repose.atlassian.net/browse/REP-3177