### PR TITLE
Adding rackspace basic auth password filter

### DIFF
--- a/repose-aggregator/components/filters/filter-bundle/pom.xml
+++ b/repose-aggregator/components/filters/filter-bundle/pom.xml
@@ -123,6 +123,11 @@
         </dependency>
         <dependency>
             <groupId>org.openrepose.rackspace</groupId>
+            <artifactId>rackspace-identity-basic-auth-password</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openrepose.rackspace</groupId>
             <artifactId>rackspace-auth-user</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/repose-aggregator/components/filters/filter-bundle/src/main/application/WEB-INF/web-fragment.xml
+++ b/repose-aggregator/components/filters/filter-bundle/src/main/application/WEB-INF/web-fragment.xml
@@ -93,6 +93,10 @@
         <filter-class>org.openrepose.filters.rackspaceidentitybasicauth.RackspaceIdentityBasicAuthFilter</filter-class>
     </filter>
     <filter>
+        <filter-name>rackspace-identity-basic-auth-password</filter-name>
+        <filter-class>org.openrepose.filters.rackspaceidentitybasicauthpassword.RackspaceIdentityBasicAuthPasswordFilter</filter-class>
+    </filter>
+    <filter>
         <filter-name>content-type-stripper</filter-name>
         <filter-class>org.openrepose.filters.contenttypestripper.ContentTypeStripperFilter</filter-class>
     </filter>

--- a/repose-aggregator/components/filters/pom.xml
+++ b/repose-aggregator/components/filters/pom.xml
@@ -41,6 +41,7 @@
         <module>merge-header</module>
         <module>openstack-identity-v3</module>
         <module>rackspace-identity-basic-auth</module>
+        <module>rackspace-identity-basic-auth-password</module>
         <module>content-type-stripper</module>
         <module>derp</module>
         <module>add-header</module>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/pom.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.openrepose</groupId>
+        <artifactId>filters-support</artifactId>
+        <version>7.3.1.0-SNAPSHOT</version>
+    </parent>
+
+    <name>Repose Components - Rackspace Identity Basic Auth Password</name>
+    <groupId>org.openrepose.rackspace</groupId>
+    <artifactId>rackspace-identity-basic-auth-password</artifactId>
+    <packaging>jar</packaging>
+
+    <description>
+        This filter translates user/password requests from Basic Auth to the Rackspace Identity.
+    </description>
+
+    <properties>
+        <sonar.jacoco.itReportPath>${project.basedir}/../../../target/jacoco-it.exec</sonar.jacoco.itReportPath>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.10</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>http-delegation</artifactId>
+        </dependency>
+
+        <!-- Lazy logging -->
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging-slf4j_2.10</artifactId>
+        </dependency>
+
+        <!-- These three are required because of our coupling between filters and core -->
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>core-lib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>core-service-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics-runtime</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>datastoreservice-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>httpclient-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>service-client-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrepose</groupId>
+            <artifactId>utilities</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- The plugin that cleans up our XSD to conform to XML 1.0 -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <configuration>
+                    <transformationSets>
+                        <transformationSet>
+                            <dir>src/main/resources/META-INF/schema/config</dir>
+                            <stylesheet>../xsl/remove-1.1-elements.xsl</stylesheet>
+                            <outputDir>${project.build.directory}/generated-resources/xml/xslt/config</outputDir>
+                        </transformationSet>
+                    </transformationSets>
+                </configuration>
+            </plugin>
+
+            <!-- The plugin that compiles and binds our clean XSD to a Java object -->
+            <plugin>
+                <groupId>org.jvnet.jaxb2.maven2</groupId>
+                <artifactId>maven-jaxb2-plugin</artifactId>
+                <configuration>
+                    <specVersion>2.2</specVersion>
+                    <schemaDirectory>${project.build.directory}/generated-resources/xml/xslt</schemaDirectory>
+
+                    <schemaIncludes>
+                        <include>**/*.xsd</include>
+                    </schemaIncludes>
+                    <bindingIncludes>
+                        <include>**/*.xjb</include>
+                    </bindingIncludes>
+
+                    <strict>true</strict>
+                    <verbose>false</verbose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/resources/META-INF/schema/config/bindings.xjb
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/resources/META-INF/schema/config/bindings.xjb
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  Repose
+  _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+
+<bindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          version="2.0"
+          xmlns="http://java.sun.com/xml/ns/jaxb"
+          xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+          schemaLocation="rackspace-identity-basic-auth-password.xsd">
+
+    <schemaBindings>
+        <package name="org.openrepose.filters.rackspaceidentitybasicauthpassword.config"/>
+    </schemaBindings>
+</bindings>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/resources/META-INF/schema/config/rackspace-identity-basic-auth-password.xsd
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/resources/META-INF/schema/config/rackspace-identity-basic-auth-password.xsd
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  Repose
+  _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:html="http://www.w3.org/1999/xhtml"
+           xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth-password/v1.0"
+           targetNamespace="http://docs.openrepose.org/repose/rackspace-identity-basic-auth-password/v1.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <!-- Elements -->
+    <xs:element name="rackspace-identity-basic-auth-password" type="RackspaceIdentityBasicAuthPasswordConfig"/>
+
+    <!-- Types -->
+    <xs:complexType name="RackspaceIdentityBasicAuthPasswordConfig">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>The root config type for the Rackspace Identity Basic Auth Password filter
+                    configuration file.</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:sequence>
+            <xs:element name="delegating" type="DelegatingType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="rackspace-identity-service-uri" type="xs:anyURI" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>The target Rackspace Identity endpoint URI for credential requests including host, port, and
+                        path to service.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="token-cache-timeout-millis" type="ZeroOrPositiveInteger" use="optional" default="600000">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Time in milliseconds to cache auth token. The default is 10 minutes. A value of Zero (0) is
+                        disabled.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connection-pool-id" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Http Connection pool ID to use when talking to Keystone v2 Identity</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="DelegatingType">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>Whether or not you would like this filter to populate the delegation headers. Inclusion means
+                    you do.
+                </html:p>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="quality" type="QualityType" use="optional" default="0.9">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        What quality you want any output headers to be.
+                        When setting up a chain of delegating filters the highest quality number will be the one that is
+                        eventually output.
+                        Default is 0.9
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="QualityType">
+        <xs:restriction base="xs:double">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="1.0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="ZeroOrPositiveInteger">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/resources/META-INF/schema/examples/rackspace-identity-basic-auth-password.cfg.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/resources/META-INF/schema/examples/rackspace-identity-basic-auth-password.cfg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rackspace-identity-basic-auth-password
+        xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth-password/v1.0"
+        rackspace-identity-service-uri="http://identity.example.com:8080/v2.0/tokens"
+        token-cache-timeout-millis="600000"
+        connection-pool-id="basic-auth-pool"/>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauthpassword/BasicAuthUtils.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauthpassword/BasicAuthUtils.scala
@@ -1,0 +1,55 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package org.openrepose.filters.rackspaceidentitybasicauthpassword
+
+import org.apache.commons.codec.binary.Base64
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+trait BasicAuthUtils {
+  /**
+   * Returns a tuple of the (username, password) retrieved from an HTTP Basic authentication header (Authorization) that
+   * has already been stripped of the "Basic " auth method identifier.
+   * @param authValue the cleaned header value to be decoded and split
+   * @return a tuple of the (username, password)
+   */
+  def extractCredentials(authValue: String): (String, String) = {
+    def getUsername(decodedCredentials: String): Try[String] = {
+      Try(decodedCredentials.split(":").head)
+    }
+
+    val decodedString = new String(Base64.decodeBase64(authValue))
+    getUsername(decodedString) match {
+      case Success(username) => (username, decodedString.replace(s"$username:", ""))
+      case Failure(_) => ("", "")
+    }
+  }
+
+  /**
+   * Returns an Iterator of the Authentication header values that match the desired auth method.
+   * @param headers the Authentication header values to search
+   * @param method the auth method to search for
+   * @return an Iterator of the Authentication header values that match the desired auth method
+   */
+  def getBasicAuthHeaders(headers: java.util.Enumeration[String], method: String): Iterator[String] = {
+    headers.asScala.filter(_.toUpperCase.startsWith(method.toUpperCase))
+  }
+}

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauthpassword/RackspaceIdentityBasicAuthPasswordFilter.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauthpassword/RackspaceIdentityBasicAuthPasswordFilter.scala
@@ -1,0 +1,298 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package org.openrepose.filters.rackspaceidentitybasicauthpassword
+
+import java.net.URL
+import java.util.concurrent.TimeUnit
+import java.util.{Calendar, GregorianCalendar}
+import javax.inject.{Inject, Named}
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import javax.ws.rs.core.MediaType
+
+import com.rackspace.httpdelegation.HttpDelegationManager
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.apache.commons.lang3.StringUtils
+import org.openrepose.commons.config.manager.UpdateListener
+import org.openrepose.commons.utils.http.{CommonHttpHeader, HttpDate}
+import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse
+import org.openrepose.core.filter.FilterConfigHelper
+import org.openrepose.core.filter.logic.common.AbstractFilterLogicHandler
+import org.openrepose.core.filter.logic.impl.{FilterDirectorImpl, FilterLogicHandlerDelegate}
+import org.openrepose.core.filter.logic.{FilterAction, FilterDirector}
+import org.openrepose.core.services.config.ConfigurationService
+import org.openrepose.core.services.datastore.DatastoreService
+import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClientFactory, AkkaServiceClient}
+import org.openrepose.filters.rackspaceidentitybasicauthpassword.config.RackspaceIdentityBasicAuthPasswordConfig
+import org.springframework.http.HttpHeaders
+
+import scala.collection.JavaConverters._
+import scala.io.Source
+import scala.xml.XML
+
+@Named
+class RackspaceIdentityBasicAuthPasswordFilter @Inject()(configurationService: ConfigurationService,
+                                                         akkaServiceClientFactory: AkkaServiceClientFactory,
+                                                         datastoreService: DatastoreService)
+  extends AbstractFilterLogicHandler
+  with Filter
+  with UpdateListener[RackspaceIdentityBasicAuthPasswordConfig]
+  with HttpDelegationManager
+  with BasicAuthUtils
+  with LazyLogging {
+
+  private final val DEFAULT_CONFIG = "rackspace-identity-basic-auth-password.cfg.xml"
+  private final val TOKEN_KEY_PREFIX = "TOKEN:"
+  private final val X_AUTH_TOKEN = "X-Auth-Token"
+  private val datastore = datastoreService.getDefaultDatastore
+  private var initialized = false
+  private var config: String = _
+  private var identityServiceUri: String = _
+  private var tokenCacheTtlMillis: Int = _
+  private var delegationWithQuality: Option[Double] = _
+  private var akkaServiceClient: AkkaServiceClient = _
+
+  override def init(filterConfig: FilterConfig) {
+    config = new FilterConfigHelper(filterConfig).getFilterConfig(DEFAULT_CONFIG)
+    logger.info("Initializing filter using config " + config)
+    val xsdURL: URL = getClass.getResource("/META-INF/config/schema/rackspace-identity-basic-auth-password.xsd")
+    configurationService.subscribeTo(
+      filterConfig.getFilterName,
+      config,
+      xsdURL,
+      this,
+      classOf[RackspaceIdentityBasicAuthPasswordConfig]
+    )
+    logger.warn("WARNING: This filter cannot be used alone, it requires an AuthFilter after it.")
+  }
+
+  override def configurationUpdated(config: RackspaceIdentityBasicAuthPasswordConfig) {
+    identityServiceUri = config.getRackspaceIdentityServiceUri
+    tokenCacheTtlMillis = config.getTokenCacheTimeoutMillis
+    delegationWithQuality = Option(config.getDelegating).map(_.getQuality)
+
+    val akkaServiceClientOld = Option(akkaServiceClient)
+    akkaServiceClient = akkaServiceClientFactory.newAkkaServiceClient(config.getConnectionPoolId)
+    akkaServiceClientOld.foreach(_.destroy())
+
+    initialized = true
+  }
+
+  override def isInitialized = {
+    initialized
+  }
+
+  override def doFilter(servletRequest: ServletRequest, servletResponse: ServletResponse, filterChain: FilterChain) {
+    new FilterLogicHandlerDelegate(servletRequest, servletResponse, filterChain).doFilter(this)
+  }
+
+  override def handleRequest(httpServletRequest: HttpServletRequest, httpServletResponse: ReadableHttpServletResponse): FilterDirector = {
+    logger.debug("Handling HTTP Request")
+    val filterDirector: FilterDirector = new FilterDirectorImpl()
+
+    def delegateOrElse(responseCode: Int, message: String)(f: => Any) = {
+      delegationWithQuality match {
+        case Some(quality) =>
+          buildDelegationHeaders(responseCode, "Rackspace Identity Basic Auth", message, quality) foreach { case (key, values) =>
+            filterDirector.requestHeaderManager.appendHeader(key, values: _*)
+            filterDirector.setFilterAction(FilterAction.PROCESS_RESPONSE)
+          }
+        case None =>
+          f
+      }
+    }
+
+    def processFailedToken(tokenResponseInfo: TokenCreationInfo, encodedCredentials: String): Unit = {
+      import HttpServletResponse._
+      tokenResponseInfo match {
+        case TokenCreationInfo(SC_UNAUTHORIZED, _, userName, _, _) =>
+          delegateOrElse(SC_UNAUTHORIZED, s"Failed to authenticate user: $userName") {
+            filterDirector.setResponseStatusCode(SC_UNAUTHORIZED) // (401)
+            filterDirector.responseHeaderManager().appendHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"RAX-KEY\"")
+            datastore.remove(TOKEN_KEY_PREFIX + encodedCredentials)
+          }
+        case TokenCreationInfo((SC_REQUEST_ENTITY_TOO_LARGE | FilterDirector.SC_TOO_MANY_REQUESTS), _, userName, Some(retry), _) => // (413 | 429)
+          delegateOrElse(SC_SERVICE_UNAVAILABLE, "Rate limited by identity service") {
+            filterDirector.setResponseStatusCode(SC_SERVICE_UNAVAILABLE) // (503)
+            filterDirector.responseHeaderManager().appendHeader(HttpHeaders.RETRY_AFTER, retry)
+          }
+        case TokenCreationInfo(SC_BAD_REQUEST, _, userName, _, identityResponseBody) =>
+          identityResponseBody.foreach { responseContent =>
+            logger.warn(s"Bad Request received from identity for $userName. Identity Response: $responseContent")
+          }
+          delegateOrElse(SC_UNAUTHORIZED, s"Bad Request received from identity service for $userName") {
+            filterDirector.setResponseStatusCode(SC_UNAUTHORIZED)
+            filterDirector.responseHeaderManager().appendHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"RAX-KEY\"")
+            datastore.remove(TOKEN_KEY_PREFIX + encodedCredentials)
+          }
+        case TokenCreationInfo(SC_FORBIDDEN, _, userName, _, _) =>
+          delegateOrElse(SC_FORBIDDEN, s"$userName is forbidden") {
+            filterDirector.setResponseStatusCode(SC_FORBIDDEN) // (401)
+            //Not removing it from the datastore, they're forbidden, cache is legit
+          }
+        case TokenCreationInfo(SC_NOT_FOUND, _, userName, _, _) =>
+          logger.warn(s"404 Received from identity attempting to authenticate $userName")
+
+          delegateOrElse(SC_UNAUTHORIZED, s"Failed to authenticate user: $userName") {
+            filterDirector.setResponseStatusCode(SC_UNAUTHORIZED) // (401)
+            filterDirector.responseHeaderManager().appendHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"RAX-KEY\"")
+            datastore.remove(TOKEN_KEY_PREFIX + encodedCredentials)
+          }
+        case (_) =>
+          delegateOrElse(SC_INTERNAL_SERVER_ERROR, "Failed with internal server error") {
+            filterDirector.setResponseStatusCode(SC_INTERNAL_SERVER_ERROR) // (500)
+          }
+      }
+      if (delegationWithQuality.isEmpty) filterDirector.setFilterAction(FilterAction.RETURN)
+    }
+
+    def getUserToken(authValue: String): TokenCreationInfo = {
+      val (userName, password) = extractCredentials(authValue)
+
+      def createAuthRequest(encoded: String) = {
+        // Base64 Decode and split the userName/apiKey
+        // Scala's standard XML syntax does not support the XML declaration w/o a lot of hoops
+        //<?xml version="1.0" encoding="UTF-8"?>
+        <auth xmlns="http://docs.openstack.org/identity/api/v2.0">
+          <passwordCredentials
+          xmlns="http://docs.openstack.org/identity/api/v2.0"
+          username={userName}
+          password={password}/>
+        </auth>
+      }
+
+      if (StringUtils.isEmpty(userName) || StringUtils.isEmpty(password)) {
+        TokenCreationInfo(HttpServletResponse.SC_UNAUTHORIZED, None, userName)
+      } else {
+        // Request a User Token based on the extracted User Name/API Key.
+        val requestTracingHeader = Option(httpServletRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString))
+          .map(guid => Map(CommonHttpHeader.TRACE_GUID.toString -> guid)).getOrElse(Map())
+        val authTokenResponse = Option(akkaServiceClient.post(authValue,
+          identityServiceUri,
+          Map[String, String]().++(requestTracingHeader).asJava,
+          createAuthRequest(authValue).toString(),
+          MediaType.APPLICATION_XML_TYPE))
+
+        authTokenResponse.map { tokenResponse =>
+          val statusCode = tokenResponse.getStatus
+          if (statusCode == HttpServletResponse.SC_OK) {
+            val xmlString = XML.loadString(Source.fromInputStream(tokenResponse.getData).mkString)
+            val idString = (xmlString \\ "access" \ "token" \ "@id").text
+            TokenCreationInfo(statusCode, Option(idString), userName)
+          } else {
+            val responseBody = Some(Source.fromInputStream(tokenResponse.getData).mkString)
+            //Figure out what our Retry Headers are, if identity returned us a rate limited response.
+            val retryHeaders: Option[String] = if (statusCode == HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE | statusCode == FilterDirector.SC_TOO_MANY_REQUESTS) {
+              // (413 | 429)
+              val identityRetryHeader = tokenResponse.getHeaders.filter { header => header.getName.equals(HttpHeaders.RETRY_AFTER) }
+              if (identityRetryHeader.isEmpty) {
+                logger.info(s"Missing ${HttpHeaders.RETRY_AFTER} header on Auth Response status code: $statusCode")
+                val retryCalendar = new GregorianCalendar()
+                retryCalendar.add(Calendar.SECOND, 5)
+                val retryString = new HttpDate(retryCalendar.getTime).toRFC1123
+                Some(retryString)
+              } else {
+                Some(identityRetryHeader.head.getValue)
+              }
+            } else {
+              //Retry headers are only set for 413 or 429
+              None
+            }
+            TokenCreationInfo(statusCode, None, userName, retryHeaders, responseBody)
+          }
+        } getOrElse {
+          TokenCreationInfo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, None, userName)
+        }
+      }
+    }
+
+    def processNoCachedToken(encodedCredentials: String): Unit = {
+      // request a token
+      getUserToken(encodedCredentials) match {
+        case TokenCreationInfo(_, Some(token), _, _, _) =>
+          val tokenStr = token.toString
+          if (tokenCacheTtlMillis > 0) {
+            datastore.put(TOKEN_KEY_PREFIX + encodedCredentials, tokenStr, tokenCacheTtlMillis, TimeUnit.MILLISECONDS)
+          }
+          filterDirector.requestHeaderManager().appendHeader(X_AUTH_TOKEN, tokenStr)
+        case failure: TokenCreationInfo =>
+          processFailedToken(failure, encodedCredentials)
+      }
+    }
+
+    // We need to process the Response unless a couple of specific conditions occur.
+    filterDirector.setFilterAction(FilterAction.PROCESS_RESPONSE)
+    if (!httpServletRequest.getHeaderNames.asScala.toList.contains(X_AUTH_TOKEN)) {
+      withEncodedCredentials(httpServletRequest) { encodedCredentials =>
+        Option(datastore.get(TOKEN_KEY_PREFIX + encodedCredentials)) match {
+          case Some(token) =>
+            val tokenString = token.toString
+            filterDirector.requestHeaderManager().appendHeader(X_AUTH_TOKEN, tokenString)
+          case None =>
+            processNoCachedToken(encodedCredentials)
+        }
+      }
+    }
+    filterDirector
+  }
+
+  override def handleResponse(httpServletRequest: HttpServletRequest, httpServletResponse: ReadableHttpServletResponse): FilterDirector = {
+    val responseStatus = httpServletResponse.getStatus
+    logger.debug("Handling HTTP Response. Incoming status code: " + responseStatus)
+    val filterDirector: FilterDirector = new FilterDirectorImpl()
+    filterDirector.setResponseStatusCode(responseStatus)
+    filterDirector.setFilterAction(FilterAction.PASS)
+    if (responseStatus == HttpServletResponse.SC_UNAUTHORIZED ||
+      responseStatus == HttpServletResponse.SC_FORBIDDEN) {
+      filterDirector.responseHeaderManager().appendHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"RAX-KEY\"")
+      withEncodedCredentials(httpServletRequest) { encodedCredentials =>
+        datastore.remove(TOKEN_KEY_PREFIX + encodedCredentials)
+      }
+    }
+    logger.debug("Rackspace Identity Basic Auth Password Response. Outgoing status code: " + filterDirector.getResponseStatusCode)
+    filterDirector
+  }
+
+  private def withEncodedCredentials(request: HttpServletRequest)(f: String => Unit): Unit = {
+    Option(request.getHeaders(HttpHeaders.AUTHORIZATION)).map { authHeader =>
+      val authMethodBasicHeaders = getBasicAuthHeaders(authHeader, "Basic")
+      if (authMethodBasicHeaders.nonEmpty) {
+        val firstHeader = authMethodBasicHeaders.next()
+        f(firstHeader.replace("Basic", "").trim)
+      }
+    }
+  }
+
+  override def destroy() {
+    Option(akkaServiceClient).foreach(_.destroy())
+    configurationService.unsubscribeFrom(config, this.asInstanceOf[UpdateListener[_]])
+  }
+
+  /**
+   * Token creation info encapsulates the response from identity.
+   * @param responseCode Response code received from identity
+   * @param responseBody Optional Response body from identity if it's not successful
+   * @param userId The user ID parsed from a successful response (if any)
+   * @param userName
+   * @param retry
+   */
+  case class TokenCreationInfo(responseCode: Int, userId: Option[String], userName: String, retry: Option[String] = None, responseBody: Option[String] = None)
+
+}

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/test/resources/log4j2-test.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/test/resources/log4j2-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT">
+            <PatternLayout pattern="%d %-4r [%t] %-5p %c - %m%n"/>
+        </Console>
+        <List name="List0"/>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="STDOUT"/>
+            <AppenderRef ref="List0"/>
+        </Root>
+        <Logger name="com.sun.jersey" level="off"/>
+        <Logger name="net.sf.ehcache" level="error"/>
+        <Logger name="org.apache" level="warn"/>
+        <Logger name="org.eclipse.jetty" level="off"/>
+        <Logger name="org.openrepose" level="debug"/>
+        <Logger name="org.springframework" level="warn"/>
+        <Logger name="intrafilter-logging" level="info"/>
+    </Loggers>
+</Configuration>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/test/scala/org/openrepose/filters/rackspaceidentitybasicauthpassword/BasicAuthUtilsTest.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/test/scala/org/openrepose/filters/rackspaceidentitybasicauthpassword/BasicAuthUtilsTest.scala
@@ -1,0 +1,51 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package org.openrepose.filters.rackspaceidentitybasicauthpassword
+
+import org.apache.commons.codec.binary.Base64
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FunSpec, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class BasicAuthUtilsTest extends FunSpec with Matchers with BasicAuthUtils {
+
+  describe("decoding username and Password credentials") {
+    val cases = List(
+      "userName:password" ->("userName", "password"), // No extra colons
+      "userName:::password" ->("userName", "::password"), // Extra leading colons
+      "userName:pass:::word" ->("userName", "pass:::word"), // Extra embedded colons
+      "userName:password::" ->("userName", "password::"), // Extra trailing colons
+      "userName::p:a:s:s:w:o:r:d:" ->("userName", ":p:a:s:s:w:o:r:d:"), // Just crazy
+      ":" ->("", ""), // Empty username, password
+      "username:" ->("username", "") // Empty password
+    )
+    cases.foreach { case (decoded, (expectedUsername, expectedPassword)) =>
+      it(s"decodes $decoded into $expectedUsername and $expectedPassword") {
+        val authValue = new String(Base64.encodeBase64URLSafeString(decoded.getBytes))
+
+        val (extractedUsername, extractedPassword) = extractCredentials(authValue)
+
+        extractedUsername shouldBe expectedUsername
+        extractedPassword shouldBe expectedPassword
+      }
+    }
+  }
+}

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/test/scala/org/openrepose/filters/rackspaceidentitybasicauthpassword/RackspaceIdentityBasicAuthPasswordFilterTest.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-password/src/test/scala/org/openrepose/filters/rackspaceidentitybasicauthpassword/RackspaceIdentityBasicAuthPasswordFilterTest.scala
@@ -1,0 +1,183 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package org.openrepose.filters.rackspaceidentitybasicauthpassword
+
+import javax.servlet.http.HttpServletResponse
+
+import com.mockrunner.mock.web.{MockFilterChain, MockFilterConfig, MockHttpServletRequest, MockHttpServletResponse}
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.test.appender.ListAppender
+import org.eclipse.jetty.server.Server
+import org.junit.runner.RunWith
+import org.mockito.AdditionalMatchers._
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.openrepose.commons.utils.servlet.http.ReadableHttpServletResponse
+import org.openrepose.core.filter.logic.FilterAction
+import org.openrepose.core.services.config.ConfigurationService
+import org.openrepose.core.services.datastore.{Datastore, DatastoreService}
+import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClientFactory, AkkaServiceClient}
+import org.openrepose.filters.rackspaceidentitybasicauthpassword.config.RackspaceIdentityBasicAuthPasswordConfig
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.mock.MockitoSugar
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class RackspaceIdentityBasicAuthPasswordFilterTest extends FunSpec with BeforeAndAfter with Matchers with MockitoSugar with LazyLogging {
+
+  val identityServer = new Server(0)
+  var listAppender: ListAppender = _
+  var filterChain: MockFilterChain = _
+  var mockDatastore: Datastore = _
+  var mockDatastoreService: DatastoreService = _
+  var mockAkkaServiceClient: AkkaServiceClient = _
+  var mockAkkaServiceClientFactory: AkkaServiceClientFactory = _
+  var mockConfigService: ConfigurationService = _
+  var config: RackspaceIdentityBasicAuthPasswordConfig = _
+  var filter: RackspaceIdentityBasicAuthPasswordFilter = _
+
+  before {
+    val ctx = LogManager.getContext(false).asInstanceOf[LoggerContext]
+    listAppender = ctx.getConfiguration.getAppender("List0").asInstanceOf[ListAppender].clear
+    filterChain = new MockFilterChain
+    mockDatastore = mock[Datastore]
+    mockDatastoreService = mock[DatastoreService]
+    mockAkkaServiceClient = mock[AkkaServiceClient]
+    mockAkkaServiceClientFactory = mock[AkkaServiceClientFactory]
+    mockConfigService = mock[ConfigurationService]
+    config = new RackspaceIdentityBasicAuthPasswordConfig
+    filter = new RackspaceIdentityBasicAuthPasswordFilter(mockConfigService, mockAkkaServiceClientFactory, mockDatastoreService)
+
+    when(mockDatastore.get(anyString)).thenReturn(null, Nil: _*)
+    when(mockDatastoreService.getDefaultDatastore).thenReturn(mockDatastore)
+    when(mockAkkaServiceClientFactory.newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String]))).thenReturn(mockAkkaServiceClient)
+  }
+
+  describe("the init method") {
+    it("should be loud") {
+      //val mockServletContext = new MockServletContext()
+      val mockFilterConfig = new MockFilterConfig()
+
+      // when:
+      filter.init(mockFilterConfig)
+
+      // then:
+      val events = listAppender.getEvents.toList.map(_.getMessage.getFormattedMessage)
+      events.count(_.contains("WARNING: This filter cannot be used alone, it requires an AuthFilter after it.")) shouldBe 1
+    }
+  }
+
+  describe("the configurationUpdated method") {
+    it("should be empty if field data is not present") {
+      // when:
+      filter.configurationUpdated(config)
+
+      // then:
+      assert(filter.isInitialized)
+    }
+
+    it("should destroy the previous akka service client") {
+      // given: two different clients will be returned on subsequent calls to the factory to create new instances
+      val firstAkkaServiceClient = mock[AkkaServiceClient]
+      val secondAkkaServiceClient = mock[AkkaServiceClient]
+      when(mockAkkaServiceClientFactory.newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String])))
+        .thenReturn(firstAkkaServiceClient)
+        .thenReturn(secondAkkaServiceClient)
+
+      // when: configuration is updated twice
+      filter.configurationUpdated(config)
+      filter.configurationUpdated(config)
+
+      // then: the factory is used twice, and the previous client is destroyed
+      verify(mockAkkaServiceClientFactory, times(2)).newAkkaServiceClient(or(anyString(), isNull.asInstanceOf[String]))
+      verify(firstAkkaServiceClient, times(1)).destroy()
+      verify(secondAkkaServiceClient, never()).destroy()
+    }
+  }
+
+  // Due to a limitation of the current mock environment,
+  // this test was moved to a Spock functional test.
+  ignore("the doFilter method") {
+    it("should be empty if field data is not present") {
+      // given: "a mock'd ServletRequest and ServletResponse"
+      val mockServletRequest = new MockHttpServletRequest
+      val mockServletResponse = new MockHttpServletResponse
+      //when(mockServletResponse.getHeaderNames).thenReturn(new java.util.ArrayList[String])
+      //when(mockServletResponse.extractHeaderValues).thenReturn(new util.ArrayList[String])//util.HashMap[HeaderName, List[HeaderValue]])
+
+      // when:
+      filter.configurationUpdated(config)
+      filter.doFilter(mockServletRequest, mockServletResponse, filterChain)
+
+      // then:
+      val events = listAppender.getEvents.toList.map(_.getMessage.getFormattedMessage)
+      events.count(_.contains("TEST")) shouldBe 1
+    }
+  }
+
+  describe("handleRequest") {
+    it("should simply pass if there is not an HTTP Basic authentication header") {
+      // given: "a mock'd ServletRequest and ServletResponse"
+      val mockServletRequest = new MockHttpServletRequest
+      val mockServletResponse = mock[ReadableHttpServletResponse]
+
+      // when: "the filter's handleRequest() is called without an HTTP Basic authentication header"
+      val filterDirector = filter.handleRequest(mockServletRequest, mockServletResponse)
+
+      // then: "the filter's response status code would only be processed if it were set to UNAUTHORIZED (401) by another filter/service."
+      filterDirector.getFilterAction equals FilterAction.PROCESS_RESPONSE
+    }
+  }
+
+  // Due to a limitation of the current mock environment,
+  // this test was moved to a Spock functional test.
+  ignore("handleResponse") {
+    it("should pass filter") {
+      // given: "a mock'd ServletRequest and ServletResponse"
+      val mockServletRequest = new MockHttpServletRequest
+      val mockServletResponse = mock[ReadableHttpServletResponse]
+      //when(mockServletResponse.getStatus).thenReturn(HttpServletResponse.SC_OK)
+
+      // when: "the filter's/handler's handleResponse() is called"
+      val filterDirector = filter.handleResponse(mockServletRequest, mockServletResponse)
+
+      // then: "the filter's response status code should be No Content (204)"
+      filterDirector.getFilterAction should not be (FilterAction.NOT_SET)
+      filterDirector.getResponseStatusCode should be(HttpServletResponse.SC_NO_CONTENT)
+    }
+  }
+
+  describe("when destroying the filter") {
+    it("should destroy the akka service client") {
+      // given: the akka service client exists
+      filter.configurationUpdated(config)
+
+      // when: the filter is destroyed
+      filter.destroy()
+
+      // then: the akka service client is destroyed, too
+      verify(mockAkkaServiceClient).destroy()
+    }
+  }
+}


### PR DESCRIPTION
Really just a CP of the Rackspace basic auth filter. Could probably have been done in one, but this allows a user to submit username and password to retrieve a token. 

This may not be specific to rackspace and could potentially be renamed. 

The use case for this is:

I have a user that only has a username and password, usually the admin. The admin needs to be validated against the auth service in order to use a service behind repose, but must retrieve an auth token first. This filter allows the user to submit an Authorization header in the basic auth format to securely authenticate with only a username and a password. . 