### PR TITLE
REP 3175 Add Header Filter config update

### DIFF
--- a/repose-aggregator/components/filters/add-header/src/main/resources/META-INF/schema/config/add-header.xsd
+++ b/repose-aggregator/components/filters/add-header/src/main/resources/META-INF/schema/config/add-header.xsd
@@ -30,8 +30,8 @@
 
     <xs:complexType name="AddHeadersConfig">
         <xs:all>
-            <xs:element name="request" type="HttpMessage"/>
-            <xs:element name="response" type="HttpMessage"/>
+            <xs:element name="request" type="HttpMessage" minOccurs="0"/>
+            <xs:element name="response" type="HttpMessage" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 

--- a/repose-aggregator/components/filters/add-header/src/main/resources/META-INF/schema/config/add-header.xsd
+++ b/repose-aggregator/components/filters/add-header/src/main/resources/META-INF/schema/config/add-header.xsd
@@ -22,6 +22,9 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:html="http://www.w3.org/1999/xhtml"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           xmlns:xerces="http://xerces.apache.org"
+           xmlns:saxon="http://saxon.sf.net/"
            targetNamespace="http://docs.openrepose.org/repose/add-header/v1.0"
            xmlns="http://docs.openrepose.org/repose/add-header/v1.0"
            elementFormDefault="qualified">
@@ -33,6 +36,10 @@
             <xs:element name="request" type="HttpMessage" minOccurs="0"/>
             <xs:element name="response" type="HttpMessage" minOccurs="0"/>
         </xs:all>
+        <xs:assert vc:minVersion="1.1"
+                   test="count(*)>=1"
+                   xerces:message="At least one header must be defined."
+                   saxon:message="At least one header must be defined."/>
     </xs:complexType>
 
     <xs:complexType name="HttpMessage">

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/addheader/noheader/add-header.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/addheader/noheader/add-header.cfg.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<add-headers xmlns="http://docs.openrepose.org/repose/add-header/v1.0">
+</add-headers>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/addheader/requestonly/add-header.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/addheader/requestonly/add-header.cfg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  ~ Repose
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+<add-headers xmlns="http://docs.openrepose.org/repose/add-header/v1.0">
+    <request>
+        <header name="repose-test">this-is-a-test</header>
+    </request>
+</add-headers>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/addheader/responseonly/add-header.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/addheader/responseonly/add-header.cfg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  ~ Repose
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+<add-headers xmlns="http://docs.openrepose.org/repose/add-header/v1.0">
+    <response>
+        <header name="response-header" quality="0.9">foooo</header>
+    </response>
+</add-headers>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderOverwriteTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderOverwriteTest.groovy
@@ -59,9 +59,11 @@ class AddHeaderOverwriteTest extends ReposeValveTest {
         reposehandling.request.headers.contains("x-rax-groups")
         reposehandling.request.headers.getFirstValue("x-rax-groups") == "reposegroup1"
         reposehandling.request.headers.contains("repose-test")
-        reposehandling.request.headers.getFirstValue("repose-test") == "no-overwrite"
+        reposehandling.request.headers.findAll("repose-test").contains("no-overwrite")
+        reposehandling.request.headers.findAll("repose-test").contains("this-is-a-test;q=0.5")
         reposehandling.request.headers.contains("overwrite-test")
         reposehandling.request.headers.getFirstValue("overwrite-test") == "this-is-overwrite-value;q=0.5"
+        !reposehandling.request.headers.findAll("overwrite-test").contains("will-be-overwrite")
         mc.receivedResponse.headers.contains("response-header")
         mc.receivedResponse.headers.getFirstValue("response-header") == "foooo;q=0.9"
     }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderRequestOnlyTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderRequestOnlyTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.addheader
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import org.rackspace.deproxy.Response
+
+class AddHeaderRequestOnlyTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort)
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/addheader", params)
+        repose.configurationProvider.applyConfigs("features/filters/addheader/requestonly", params)
+        repose.start()
+    }
+
+    def cleanupSpec() {
+        deproxy.shutdown()
+        repose.stop()
+    }
+
+    def "When using add-header filter the expect header(s) in config is added to request"() {
+        given:
+        def Map headers = ["x-rax-user": "test-user", "x-rax-groups": "reposegroup1"]
+
+        when: "Request contains value(s) of the target header"
+        def mc = deproxy.makeRequest([url: reposeEndpoint, headers: headers])
+        def sentRequest = ((MessageChain) mc).getHandlings()[0]
+
+        then: "The request/response should contain additional header from add-header config"
+        sentRequest.request.headers.contains("x-rax-user")
+        sentRequest.request.headers.getFirstValue("x-rax-user") == "test-user"
+        sentRequest.request.headers.contains("x-rax-groups")
+        sentRequest.request.headers.getFirstValue("x-rax-groups") == "reposegroup1"
+        sentRequest.request.headers.contains("repose-test")
+        sentRequest.request.headers.getFirstValue("repose-test") == "this-is-a-test"
+        !mc.getReceivedResponse().headers.contains("response-header")
+    }
+
+    def "When using add-header filter the expected origin service response code should not change"() {
+        given:
+        def Map headers = ["x-rax-user": "test-user", "x-rax-groups": "reposegroup1"]
+
+        when: "Request contains value(s) of the target header"
+        def mc = deproxy.makeRequest([url: reposeEndpoint, headers: headers,
+                                      defaultHandler: { return new Response(302, "Redirect") }])
+        def sentRequest = ((MessageChain) mc).getHandlings()[0]
+
+        then: "The request/response should contain additional header from add-header config"
+        sentRequest.request.headers.contains("x-rax-user")
+        sentRequest.request.headers.getFirstValue("x-rax-user") == "test-user"
+        sentRequest.request.headers.contains("x-rax-groups")
+        sentRequest.request.headers.getFirstValue("x-rax-groups") == "reposegroup1"
+        sentRequest.request.headers.contains("repose-test")
+        sentRequest.request.headers.getFirstValue("repose-test") == "this-is-a-test"
+        mc.getReceivedResponse().headers.contains("response-header")
+        mc.getReceivedResponse().headers.getFirstValue("response-header") == "foooo;q=0.9"
+        mc.receivedResponse.code == "302"
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderRequestOnlyTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderRequestOnlyTest.groovy
@@ -36,6 +36,7 @@ class AddHeaderRequestOnlyTest extends ReposeValveTest {
         repose.configurationProvider.applyConfigs("features/filters/addheader", params)
         repose.configurationProvider.applyConfigs("features/filters/addheader/requestonly", params)
         repose.start()
+        repose.waitForNon500FromUrl(reposeEndpoint)
     }
 
     def cleanupSpec() {
@@ -43,7 +44,7 @@ class AddHeaderRequestOnlyTest extends ReposeValveTest {
         repose.stop()
     }
 
-    def "When using add-header filter the expect header(s) in config is added to request"() {
+    def "When using add-header filter the expected header in config is added to request"() {
         given:
         def Map headers = ["x-rax-user": "test-user", "x-rax-groups": "reposegroup1"]
 
@@ -77,8 +78,7 @@ class AddHeaderRequestOnlyTest extends ReposeValveTest {
         sentRequest.request.headers.getFirstValue("x-rax-groups") == "reposegroup1"
         sentRequest.request.headers.contains("repose-test")
         sentRequest.request.headers.getFirstValue("repose-test") == "this-is-a-test"
-        mc.getReceivedResponse().headers.contains("response-header")
-        mc.getReceivedResponse().headers.getFirstValue("response-header") == "foooo;q=0.9"
+        !mc.getReceivedResponse().headers.contains("response-header")
         mc.receivedResponse.code == "302"
     }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderResponseOnlyTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderResponseOnlyTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.addheader
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import org.rackspace.deproxy.Response
+
+class AddHeaderResponseOnlyTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort)
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/addheader", params)
+        repose.configurationProvider.applyConfigs("features/filters/addheader/responseonly", params)
+        repose.start()
+    }
+
+    def cleanupSpec() {
+        deproxy.shutdown()
+        repose.stop()
+    }
+
+    def "When using add-header filter the expect header(s) in config is added to response"() {
+        given:
+        def Map headers = ["x-rax-user": "test-user", "x-rax-groups": "reposegroup1"]
+
+        when: "Request contains value(s) of the target header"
+        def mc = deproxy.makeRequest([url: reposeEndpoint, headers: headers])
+        def sentRequest = ((MessageChain) mc).getHandlings()[0]
+
+        then: "The request/response should contain additional header from add-header config"
+        sentRequest.request.headers.contains("x-rax-user")
+        sentRequest.request.headers.getFirstValue("x-rax-user") == "test-user"
+        sentRequest.request.headers.contains("x-rax-groups")
+        sentRequest.request.headers.getFirstValue("x-rax-groups") == "reposegroup1"
+        !sentRequest.request.headers.contains("repose-test")
+        mc.getReceivedResponse().headers.contains("response-header")
+        mc.getReceivedResponse().headers.getFirstValue("response-header") == "foooo;q=0.9"
+    }
+
+    def "When using add-header filter the expected origin service response code should not change"() {
+        given:
+        def Map headers = ["x-rax-user": "test-user", "x-rax-groups": "reposegroup1"]
+
+        when: "Request contains value(s) of the target header"
+        def mc = deproxy.makeRequest([url: reposeEndpoint, headers: headers,
+                                      defaultHandler: { return new Response(302, "Redirect") }])
+        def sentRequest = ((MessageChain) mc).getHandlings()[0]
+
+        then: "The request/response should contain additional header from add-header config"
+        sentRequest.request.headers.contains("x-rax-user")
+        sentRequest.request.headers.getFirstValue("x-rax-user") == "test-user"
+        sentRequest.request.headers.contains("x-rax-groups")
+        sentRequest.request.headers.getFirstValue("x-rax-groups") == "reposegroup1"
+        sentRequest.request.headers.contains("repose-test")
+        sentRequest.request.headers.getFirstValue("repose-test") == "this-is-a-test"
+        mc.getReceivedResponse().headers.contains("response-header")
+        mc.getReceivedResponse().headers.getFirstValue("response-header") == "foooo;q=0.9"
+        mc.receivedResponse.code == "302"
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/addheader/AddHeaderTest.groovy
@@ -37,6 +37,7 @@ class AddHeaderTest extends ReposeValveTest {
         repose.configurationProvider.applyConfigs("common", params)
         repose.configurationProvider.applyConfigs("features/filters/addheader", params)
         repose.start()
+        repose.waitForNon500FromUrl(reposeEndpoint)
     }
 
     def cleanupSpec() {
@@ -49,7 +50,7 @@ class AddHeaderTest extends ReposeValveTest {
         def Map headers = ["x-rax-user": "test-user", "x-rax-groups": "reposegroup1"]
 
         when: "Request contains value(s) of the target header"
-        def mc = deproxy.makeRequest([url: reposeEndpoint, headers: headers])
+        def mc = deproxy.makeRequest(url: reposeEndpoint, headers: headers)
         def sentRequest = ((MessageChain) mc).getHandlings()[0]
 
         then: "The request/response should contain additional header from add-header config"
@@ -68,8 +69,8 @@ class AddHeaderTest extends ReposeValveTest {
         def Map headers = ["x-rax-user": "test-user", "x-rax-groups": "reposegroup1"]
 
         when: "Request contains value(s) of the target header"
-        def mc = deproxy.makeRequest([url: reposeEndpoint, headers: headers,
-                                      defaultHandler: { return new Response(302, "Redirect") }])
+        def mc = deproxy.makeRequest(url: reposeEndpoint, headers: headers,
+                                      defaultHandler: { new Response(302, "Redirect") })
         def sentRequest = ((MessageChain) mc).getHandlings()[0]
 
         then: "The request/response should contain additional header from add-header config"


### PR DESCRIPTION
Previously the Add Header filter required you to configure headers for both the request and the response.  I updated the XSD to allow a user to configure just one of them if they wanted to.  The code already handles having just one of them configured.

There's an existing functional test with both configured.  I added two additional tests with just the request and just the response to ensure it worked.