### PR TITLE
Upgrading JaCoCo to fix Java8 compatibility

### DIFF
--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -875,7 +875,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.6.4.201312101107</version>
+                <version>0.7.5.201505241946</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
To address the following issue:
https://github.com/jacoco/jacoco/issues/74