### PR TITLE
REP-3504 Rate Limiting default HTTP Methods fix.

### DIFF
--- a/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
@@ -84,7 +84,7 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
           val httpMethods = pathRegex.getHttpMethods
           httpMethods.isEmpty ||
             httpMethods.contains(HttpMethod.ALL) ||
-            httpMethods.contains(HttpMethod.fromValue(mutableHttpRequest.getMethod))
+            httpMethods.contains(HttpMethod.valueOf(mutableHttpRequest.getMethod.toUpperCase()))
         }
       })).getOrElse(Seq.empty[Resource])
     val translateAccountPermissions: Option[AnyRef] = Option(configuration.getTranslatePermissionsToRoles)

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/globalratelimit/rate-limiting.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/ratelimiting/globalratelimit/rate-limiting.cfg.xml
@@ -4,7 +4,8 @@
     <request-endpoint uri-regex="/service/limits/" include-absolute-limits="true"/>
 
     <global-limit-group>
-        <limit id="globallimit" uri="all" uri-regex="/service/.*" http-methods="ALL" value="5" unit="MINUTE"/>
+        <!-- The first one tests for the default http-methods of ALL. -->
+        <limit id="globallimit" uri="all" uri-regex="/service/.*" value="5" unit="MINUTE"/>
         <limit id="GlobalLimitGroup1" uri="all" uri-regex="/test1.*" http-methods="ALL" value="3" unit="MINUTE"/>
         <limit id="GlobalLimitGroup2" uri="all" uri-regex="/test2.*" http-methods="ALL" value="3" unit="MINUTE"/>
         <limit id="GlobalLimitGroup3" uri="all" uri-regex="/test3.*" http-methods="GET" value="3" unit="MINUTE"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/GlobalRateLimiting2NodesTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/GlobalRateLimiting2NodesTest.groovy
@@ -141,7 +141,7 @@ class GlobalRateLimiting2NodesTest extends ReposeValveTest {
         then: "the request is rate-limited, and passes to the origin service"
         messageChain.receivedResponse.code.equals("503")
 
-        when: "user1 hit the same resource, rate limitted"
+        when: "user2 hit the same resource, rate limitted"
         messageChain = deproxy.makeRequest(url: reposeEndpoint + "/service/test", method: "GET",
                 headers: headers2, defaultHandler: handler)
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/GlobalRateLimitingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/GlobalRateLimitingTest.groovy
@@ -121,7 +121,7 @@ class GlobalRateLimitingTest extends ReposeValveTest {
                 assertTrue(messageChain.handlings.size() == 1)
         }
 
-        when: "user2 hit the same resource, rate limitted"
+        when: "user1 hit the same resource, rate limitted"
         MessageChain messageChain = deproxy.makeRequest(url: reposeEndpoint + "/service/test", method: "GET",
                 headers: headers1, defaultHandler: handler)
 
@@ -145,7 +145,7 @@ class GlobalRateLimitingTest extends ReposeValveTest {
         when: "we make multiple requests"
         response = deproxy.makeRequest(method: method, url: reposeEndpoint + url, headers: headers)
 
-        then: "it should limit based off of the global rate limit"
+        then: "it should limit based off of the global rate limit group"
         response.receivedResponse.code == responseCode
 
         where:

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/GlobalRateLimitingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/ratelimiting/GlobalRateLimitingTest.groovy
@@ -69,12 +69,12 @@ class GlobalRateLimitingTest extends ReposeValveTest {
 
     def "When Repose config with Global Rate Limit, user limit should hit first"() {
         given: "the rate-limit has not been reached"
-        //waitForLimitReset()
+        def methods = ["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"]
 
         (1..5).each {
             i ->
                 when: "the user sends their request and the rate-limit has not been reached"
-                MessageChain messageChain = deproxy.makeRequest(url: reposeEndpoint + "/service/test", method: "GET",
+                MessageChain messageChain = deproxy.makeRequest(url: reposeEndpoint + "/service/test", method: methods[i],
                         headers: userHeaderDefault + ['X-PP-Groups': 'all-limits-small'], defaultHandler: handler)
 
                 then: "the request is not rate-limited, and passes to the origin service"

--- a/repose-aggregator/services/rate-limiting-service/src/main/java/org/openrepose/core/services/ratelimit/RateLimitingServiceImpl.java
+++ b/repose-aggregator/services/rate-limiting-service/src/main/java/org/openrepose/core/services/ratelimit/RateLimitingServiceImpl.java
@@ -135,7 +135,9 @@ public class RateLimitingServiceImpl implements RateLimitingService {
     }
 
     private boolean httpMethodMatches(List<HttpMethod> configMethods, String requestMethod) {
-        return configMethods.contains(HttpMethod.ALL) || configMethods.contains(HttpMethod.valueOf(requestMethod.toUpperCase()));
+        return configMethods.isEmpty() || // Indicates the current default of ALL is desired.
+                configMethods.contains(HttpMethod.ALL) ||
+                configMethods.contains(HttpMethod.valueOf(requestMethod.toUpperCase()));
     }
 
     private boolean queryParameterNameMatches(List<String> configuredQueryParams, Map<String, String[]> requestParameterMap) {


### PR DESCRIPTION
I also brought in the minor consistency update to the Valkyrie Authorization filter so it would behave exactly like the Rate Limiting filter in the future.