### PR TITLE
REP-3281 - Simple RBAC wrapper updates

### DIFF
--- a/repose-aggregator/components/filters/simple-rbac-filter/pom.xml
+++ b/repose-aggregator/components/filters/simple-rbac-filter/pom.xml
@@ -22,11 +22,6 @@
     <dependencies>
         <dependency>
             <groupId>org.openrepose</groupId>
-            <artifactId>core-lib</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.openrepose</groupId>
             <artifactId>core-service-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -66,6 +61,11 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/repose-aggregator/components/filters/simple-rbac-filter/src/main/scala/org/openrepose/filters/simplerbac/SimpleRbacFilter.scala
+++ b/repose-aggregator/components/filters/simple-rbac-filter/src/main/scala/org/openrepose/filters/simplerbac/SimpleRbacFilter.scala
@@ -34,7 +34,6 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.apache.commons.lang3.StringUtils
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.StringUriUtilities
-import org.openrepose.commons.utils.servlet.http.{MutableHttpServletRequest, MutableHttpServletResponse}
 import org.openrepose.core.filter.FilterConfigHelper
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.core.spring.ReposeSpringProperties
@@ -83,11 +82,11 @@ class SimpleRbacFilter @Inject()(configurationService: ConfigurationService,
       logger.error("Simple RBAC filter has not yet initialized...")
       servletResponse.asInstanceOf[HttpServletResponse].sendError(500)
     } else {
-      val mutableHttpRequest = MutableHttpServletRequest.wrap(servletRequest.asInstanceOf[HttpServletRequest])
-      val mutableHttpResponse = MutableHttpServletResponse.wrap(mutableHttpRequest, servletResponse.asInstanceOf[HttpServletResponse])
-
       logger.trace("Simple RBAC filter processing request...")
-      validator.validate(mutableHttpRequest, mutableHttpResponse, filterChain)
+      validator.validate(
+        servletRequest.asInstanceOf[HttpServletRequest],
+        servletResponse.asInstanceOf[HttpServletResponse],
+        filterChain)
     }
     logger.trace("Simple RBAC filter returning response...")
   }


### PR DESCRIPTION
I removed the old wrapper usage in Simple RBAC.  I don't see why they were wrapped in the first place, so I didn't replace them with the new wrappers.  I also removed the core-lib dependency and had to add the jcl-over-slf4j dependency for the tests.

The gradle build worked without any updates.