### PR TITLE
REP-3168 - Update to default time format in SLF4J logging

### DIFF
--- a/repose-aggregator/commons/commons-utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TimeReceivedHandler.java
+++ b/repose-aggregator/commons/commons-utilities/src/main/java/org/openrepose/commons/utils/logging/apache/format/stock/TimeReceivedHandler.java
@@ -29,7 +29,7 @@ import java.util.Calendar;
 
 public class TimeReceivedHandler implements FormatterLogic {
 
-    private final static String DEFAULT_DATE_FORMAT = "dd-MM-yyyy-HH:mm:ss.SSS";
+    private final static String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
     private final String dateFormat;
 

--- a/repose-aggregator/commons/commons-utilities/src/test/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatterTest.java
+++ b/repose-aggregator/commons/commons-utilities/src/test/java/org/openrepose/commons/utils/logging/apache/HttpLogFormatterTest.java
@@ -103,7 +103,7 @@ public class HttpLogFormatterTest {
 
         @Test
         public void shouldParseSimpleTimeFormat() {
-            final String defaultDateFormatRegex = "\\d{2}-\\d{2}-\\d{4}-\\d{2}:\\d{2}:\\d{2}\\.\\d{3}";
+            final String defaultDateFormatRegex = "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}";
 
             final HttpLogFormatter formatter = new HttpLogFormatter("%t");
 

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/slf4jhttplogging/customdateformat/slf4j-http-logging.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/slf4jhttplogging/customdateformat/slf4j-http-logging.cfg.xml
@@ -7,7 +7,7 @@ it can then be used in log4j backend to determine which appender to go to -->
 found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->
     <slf4j-http-log
             id="my-special-log"
-            format="Remote User=%u\tURL Path Requested=%U\tRequest Protocol=%H\tServer Port=%p\tQuery String=%q\tResponse Time=%T seconds\tResponse Time=%D microseconds\tRequest Line=&quot;%r&quot;\tTime Request Received=%{yyyy-MM-dd HH:mm:ss}t\tStatus=%s\n"/>
+            format="Remote User=%u\tURL Path Requested=%U\tRequest Protocol=%H\tServer Port=%p\tQuery String=%q\tResponse Time=%T seconds\tResponse Time=%D microseconds\tRequest Line=&quot;%r&quot;\tTime Request Received=%{dd-MM-yyyy-HH:mm:ss.SSS}t\tStatus=%s\n"/>
     <slf4j-http-log id="my-test-log"
                     format="Remote IP=%a Local IP=%A Request Method=%m Response Code=%s Response Time=%D "/>
 </slf4j-http-logging>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingCustomDateFormatTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingCustomDateFormatTest.groovy
@@ -36,6 +36,7 @@ class Slf4jHttpLoggingCustomDateFormatTest extends ReposeValveTest {
         repose.start()
         deproxy = new Deproxy()
         deproxy.addEndpoint(properties.targetPort)
+        repose.waitForNon500FromUrl(reposeEndpoint)
     }
 
     def "Check slf4log for our custom date format"() {
@@ -46,6 +47,6 @@ class Slf4jHttpLoggingCustomDateFormatTest extends ReposeValveTest {
         deproxy.makeRequest(url: reposeEndpoint, method: 'GET')
 
         then:
-        logSearch.searchByString("Time Request Received=\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}").size() == 1
+        logSearch.searchByString("Time Request Received=\\d{2}-\\d{2}-\\d{4}-\\d{2}:\\d{2}:\\d{2}\\.\\d{3}").size() == 1
     }
 }

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/slf4jlogging/Slf4jHttpLoggingTest.groovy
@@ -54,7 +54,7 @@ class Slf4jHttpLoggingTest extends ReposeValveTest {
         then:
         logSearch.searchByString("Remote IP=127.0.0.1 Local IP=127.0.0.1 Request Method=$method").size() == 1
         logSearch.searchByString("Remote User=null\tURL Path Requested=http://localhost:${properties.targetPort}//\tRequest Protocol=HTTP/1.1").size() == 1
-        logSearch.searchByString("Time Request Received=\\d{2}-\\d{2}-\\d{4}-\\d{2}:\\d{2}:\\d{2}\\.\\d{3}").size() == 1 // default date format
+        logSearch.searchByString("Time Request Received=\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}").size() == 1 // default date format
 
         where:
         method << [


### PR DESCRIPTION
I updated the default time format used by the SLF4J logging filter from "dd-MM-yyyy-HH:mm:ss.SSS" to "yyyy-MM-dd HH:mm:ss".  I also updated the functional tests to use the new default time, and I updated the custom time format test to use the old default just for fun.