### PR TITLE
REP-3167 - Tracing Header updates

### DIFF
--- a/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/KeystoneV2Filter.scala
+++ b/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/KeystoneV2Filter.scala
@@ -604,7 +604,7 @@ class KeystoneV2Filter @Inject()(configurationService: ConfigurationService,
     private var initialized = false
 
     override def configurationUpdated(configurationObject: SystemModel): Unit = {
-      sendTraceHeader = configurationObject.getTracingHeader == null || configurationObject.getTracingHeader.isEnabled
+      sendTraceHeader = Option(configurationObject.getTracingHeader).isEmpty || configurationObject.getTracingHeader.isEnabled
       initialized = true
     }
 

--- a/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/KeystoneV2Filter.scala
+++ b/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/KeystoneV2Filter.scala
@@ -604,7 +604,7 @@ class KeystoneV2Filter @Inject()(configurationService: ConfigurationService,
     private var initialized = false
 
     override def configurationUpdated(configurationObject: SystemModel): Unit = {
-      sendTraceHeader = configurationObject.isTracingHeader
+      sendTraceHeader = configurationObject.getTracingHeader == null || configurationObject.getTracingHeader.isEnabled
       initialized = true
     }
 

--- a/repose-aggregator/components/filters/keystone-v2-filter/src/test/scala/org/openrepose/filters/keystonev2/KeystoneV2FilterPrepTest.scala
+++ b/repose-aggregator/components/filters/keystone-v2-filter/src/test/scala/org/openrepose/filters/keystonev2/KeystoneV2FilterPrepTest.scala
@@ -32,7 +32,7 @@ import org.mockito.{ArgumentCaptor, Matchers => MockitoMatcher, Mockito}
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.core.services.datastore.{Datastore, DatastoreService}
 import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClient, AkkaServiceClientFactory}
-import org.openrepose.core.systemmodel.SystemModel
+import org.openrepose.core.systemmodel.{TracingHeaderConfig, SystemModel}
 import org.openrepose.filters.keystonev2.config.KeystoneV2Config
 import org.openrepose.nodeservice.atomfeed.{AtomFeedListener, AtomFeedService}
 import org.scalatest.junit.JUnitRunner
@@ -48,7 +48,9 @@ class KeystoneV2FilterPrepTest extends FunSpec with Matchers with MockitoSugar w
   private val mockDatastore = mock[Datastore]
   Mockito.when(mockDatastoreService.getDefaultDatastore).thenReturn(mockDatastore)
   private val mockSystemModel = mock[SystemModel]
-  Mockito.when(mockSystemModel.isTracingHeader).thenReturn(true, Nil: _*)
+  private val mockTracingHeader = mock[TracingHeaderConfig]
+  Mockito.when(mockSystemModel.getTracingHeader).thenReturn(mockTracingHeader)
+  Mockito.when(mockTracingHeader.isEnabled).thenReturn(true, Nil: _*)
 
   before {
     Mockito.reset(mockDatastore)

--- a/repose-aggregator/components/filters/keystone-v2-filter/src/test/scala/org/openrepose/filters/keystonev2/KeystoneV2FilterTest.scala
+++ b/repose-aggregator/components/filters/keystone-v2-filter/src/test/scala/org/openrepose/filters/keystonev2/KeystoneV2FilterTest.scala
@@ -42,7 +42,7 @@ import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.core.services.datastore.types.SetPatch
 import org.openrepose.core.services.datastore.{Datastore, DatastoreService}
 import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClient, AkkaServiceClientFactory}
-import org.openrepose.core.systemmodel.SystemModel
+import org.openrepose.core.systemmodel.{TracingHeaderConfig, SystemModel}
 import org.openrepose.filters.keystonev2.KeystoneRequestHandler._
 import org.openrepose.filters.keystonev2.config.{KeystoneV2Config, ServiceEndpointType}
 import org.openrepose.nodeservice.atomfeed.AtomFeedService
@@ -70,7 +70,9 @@ with HttpDelegationManager {
   private val mockConfigurationService = mock[ConfigurationService]
   when(mockDatastoreService.getDefaultDatastore).thenReturn(mockDatastore)
   private val mockSystemModel = mock[SystemModel]
-  when(mockSystemModel.isTracingHeader).thenReturn(true, Nil: _*)
+  private val mockTracingHeader = mock[TracingHeaderConfig]
+  when(mockSystemModel.getTracingHeader).thenReturn(mockTracingHeader)
+  when(mockTracingHeader.isEnabled).thenReturn(true, Nil: _*)
   private val mockFilterConfig = new MockFilterConfig
 
   before {
@@ -2213,7 +2215,9 @@ with HttpDelegationManager {
 
     it("should not forward the x-trans-id header if disabled") {
       val mockSystemModelNoTracing = mock[SystemModel]
-      when(mockSystemModelNoTracing.isTracingHeader).thenReturn(false)
+      val mockTracingHeaderConfig = mock[TracingHeaderConfig]
+      when(mockSystemModelNoTracing.getTracingHeader).thenReturn(mockTracingHeaderConfig)
+      when(mockTracingHeaderConfig.isEnabled).thenReturn(false)
       filter.SystemModelConfigListener.configurationUpdated(mockSystemModelNoTracing)
 
       val request = new MockHttpServletRequest()

--- a/repose-aggregator/components/services/phone-home-service/src/main/scala/org/openrepose/core/services/phonehome/PhoneHomeService.scala
+++ b/repose-aggregator/components/services/phone-home-service/src/main/scala/org/openrepose/core/services/phonehome/PhoneHomeService.scala
@@ -163,7 +163,7 @@ class PhoneHomeService @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_VERSI
       logger.trace("sendUpdateMessage method called")
 
       try {
-        val updateHeaders = if (staticSystemModel.isTracingHeader) {
+        val updateHeaders = if (staticSystemModel.getTracingHeader == null || staticSystemModel.getTracingHeader.isEnabled) {
           Map(CommonHttpHeader.TRACE_GUID.toString -> UUID.randomUUID().toString).asJava
         } else {
           Map.empty[String, String].asJava

--- a/repose-aggregator/components/services/phone-home-service/src/main/scala/org/openrepose/core/services/phonehome/PhoneHomeService.scala
+++ b/repose-aggregator/components/services/phone-home-service/src/main/scala/org/openrepose/core/services/phonehome/PhoneHomeService.scala
@@ -163,7 +163,7 @@ class PhoneHomeService @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_VERSI
       logger.trace("sendUpdateMessage method called")
 
       try {
-        val updateHeaders = if (staticSystemModel.getTracingHeader == null || staticSystemModel.getTracingHeader.isEnabled) {
+        val updateHeaders = if (Option(staticSystemModel.getTracingHeader).isEmpty || staticSystemModel.getTracingHeader.isEnabled) {
           Map(CommonHttpHeader.TRACE_GUID.toString -> UUID.randomUUID().toString).asJava
         } else {
           Map.empty[String, String].asJava

--- a/repose-aggregator/components/services/phone-home-service/src/test/scala/org/openrepose/core/services/phonehome/PhoneHomeServiceTest.scala
+++ b/repose-aggregator/components/services/phone-home-service/src/test/scala/org/openrepose/core/services/phonehome/PhoneHomeServiceTest.scala
@@ -317,7 +317,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       val servicesList = new ServicesList()
       val phoneHomeConfig = new PhoneHomeServiceConfig()
 
-      systemModel.setTracingHeader(true)
+      val tracingHeader = new TracingHeaderConfig
+      systemModel.setTracingHeader(tracingHeader)
+      tracingHeader.setEnabled(true)
       phoneHomeConfig.setEnabled(true)
 
       reposeCluster.setFilters(filterList)
@@ -366,7 +368,9 @@ class PhoneHomeServiceTest extends FunSpec with Matchers with MockitoSugar {
       val servicesList = new ServicesList()
       val phoneHomeConfig = new PhoneHomeServiceConfig()
 
-      systemModel.setTracingHeader(false)
+      val tracingHeader = new TracingHeaderConfig
+      systemModel.setTracingHeader(tracingHeader)
+      tracingHeader.setEnabled(false)
       phoneHomeConfig.setEnabled(true)
 
       reposeCluster.setFilters(filterList)

--- a/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilter.java
+++ b/repose-aggregator/core/core-lib/src/main/java/org/openrepose/powerfilter/PowerFilter.java
@@ -353,7 +353,7 @@ public class PowerFilter extends DelegatingFilterProxy {
         final MutableHttpServletRequest mutableHttpRequest = MutableHttpServletRequest.wrap((HttpServletRequest) request, streamLimit);
         final MutableHttpServletResponse mutableHttpResponse = MutableHttpServletResponse.wrap(mutableHttpRequest, (HttpServletResponse) response);
 
-        if (currentSystemModel.get().isRewriteTracingHeader()) {
+        if (currentSystemModel.get().getTracingHeader() != null && currentSystemModel.get().getTracingHeader().isRewriteHeader()) {
             mutableHttpRequest.removeHeader(CommonHttpHeader.TRACE_GUID.toString());
         }
 
@@ -378,7 +378,7 @@ public class PowerFilter extends DelegatingFilterProxy {
             new URI(mutableHttpRequest.getRequestURI());
             final PowerFilterChain requestFilterChain = getRequestFilterChain(mutableHttpResponse, chain);
             if (requestFilterChain != null) {
-                if (currentSystemModel.get().isTracingHeader()) {
+                if (currentSystemModel.get().getTracingHeader() == null || currentSystemModel.get().getTracingHeader().isEnabled()) {
                     if (StringUtilities.isBlank(mutableHttpRequest.getHeader(CommonHttpHeader.TRACE_GUID.toString()))) {
                         mutableHttpRequest.addHeader(CommonHttpHeader.TRACE_GUID.toString(),
                                 TracingHeaderHelper.createTracingHeader(traceGUID, mutableHttpRequest.getHeader(CommonHttpHeader.VIA.toString())));

--- a/repose-aggregator/core/core-lib/src/test/groovy/org/openrepose/nodeservice/httpcomponent/RequestProxyServiceImplTest.groovy
+++ b/repose-aggregator/core/core-lib/src/test/groovy/org/openrepose/nodeservice/httpcomponent/RequestProxyServiceImplTest.groovy
@@ -34,6 +34,7 @@ import org.openrepose.core.services.healthcheck.HealthCheckService
 import org.openrepose.core.services.httpclient.HttpClientResponse
 import org.openrepose.core.services.httpclient.HttpClientService
 import org.openrepose.core.systemmodel.SystemModel
+import org.openrepose.core.systemmodel.TracingHeaderConfig
 import spock.lang.Specification
 
 import static org.mockito.Mockito.mock
@@ -125,7 +126,9 @@ class RequestProxyServiceImplTest extends Specification {
     def "a request does not include the x-trans-id header for tracing when disabled"() {
         given:
         SystemModel systemModel = mock(SystemModel)
-        when(systemModel.isTracingHeader()).thenReturn(false)
+        TracingHeaderConfig tracingHeader = mock(TracingHeaderConfig)
+        when(systemModel.getTracingHeader()).thenReturn(tracingHeader)
+        when(tracingHeader.isEnabled()).thenReturn(false)
         StatusLine statusLine = mock(StatusLine)
         when(statusLine.getStatusCode()).thenReturn(418)
         HttpEntity httpEntity = mock(HttpEntity)

--- a/repose-aggregator/core/core-service-api/src/main/resources/META-INF/schema/system-model/system-model.xsd
+++ b/repose-aggregator/core/core-service-api/src/main/resources/META-INF/schema/system-model/system-model.xsd
@@ -44,10 +44,8 @@
             <xs:element name="repose-cluster" type="mod:ReposeCluster" minOccurs="1" maxOccurs="unbounded"/>
             <xs:element name="service-cluster" type="mod:Cluster" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="phone-home" type="mod:PhoneHomeServiceConfig" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="tracing-header" type="mod:TracingHeaderConfig" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
-
-        <xs:attribute name="tracing-header" type="xs:boolean" use="optional" default="true"/>
-        <xs:attribute name="rewrite-tracing-header" type="xs:boolean" use="optional" default="false"/>
     </xs:complexType>
 
     <xs:complexType name="Cluster">
@@ -127,6 +125,19 @@
         <xs:attribute name="collection-uri" type="xs:anyURI" use="optional" default="http://phone-home.openrepose.org"/>
         <xs:attribute name="origin-service-id" type="xs:string" use="optional"/>
         <xs:attribute name="contact-email" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="TracingHeaderConfig">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>
+                    Allows you to configure the tracing header.  If not present, feature will be enabled by default.
+                </html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rewrite-header" type="xs:boolean" use="optional" default="false"/>
     </xs:complexType>
 
     <xs:complexType name="NodeList">

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/tracing/rewritetransid/rewritefalse/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/tracing/rewritetransid/rewritefalse/system-model.cfg.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose-cluster">
+        <nodes>
+            <node id="node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+
+        <filters/>
+
+        <destinations>
+            <endpoint id="endpoint" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
+                      default="true"/>
+        </destinations>
+    </repose-cluster>
+    <tracing-header rewrite-header="false"/>
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/tracing/rewritetransid/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/tracing/rewritetransid/system-model.cfg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0" rewrite-tracing-header="true">
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
     <repose-cluster id="repose-cluster">
         <nodes>
             <node id="node" hostname="localhost" http-port="${reposePort}"/>
@@ -13,4 +13,5 @@
                       default="true"/>
         </destinations>
     </repose-cluster>
+    <tracing-header rewrite-header="true"/>
 </system-model>


### PR DESCRIPTION
I updated the tracing header config in the system model from being a pair of attributes to an element with those two attributes.  I also updated code to use the new generated source.

Previously, the tracing header attribute was set to true by default (i.e. if it wasn't explicitly configured, it would be turned on).  With these updates, if the element is not specified, it will default to being turned on.  If the element is specified, but the attribute is not, it will still default to true.  As before, the only way to turn it off is to specify the attribute with a value of false.  I was going to make the attribute required (because if you already have the element then why not?), but I kept it optional in case all you wanted to do was change the rewrite behavior.

The rewrite attribute pretty much acts the same way except it's in this new element now.