### PR TITLE
Removing dependencies on mocks-util module

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/pom.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/pom.xml
@@ -113,7 +113,6 @@
             <artifactId>org.linkedin.util-groovy</artifactId>
             <version>1.8.0</version>
             <scope>test</scope>
-
         </dependency>
 
         <dependency>
@@ -145,13 +144,6 @@
             <groupId>xerces</groupId>
             <artifactId>xerces-xsd11</artifactId>
             <version>2.12.0-rax</version>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.openrepose</groupId>
-            <artifactId>mocks-util</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/embedded/EmbeddedTomcatProxyTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/embedded/EmbeddedTomcatProxyTest.groovy
@@ -97,7 +97,7 @@ class EmbeddedTomcatProxyTest extends Specification {
         xmlData.headers.header.findAll { it.@name == 'passheader' }.size() == 2
 
         and: "Repose should have passed query params"
-        info.getQueryParams().get("a").get(0).equals("[b]")
-        info.getQueryParams().size() == 2
+        xmlData."query-params".parameter.find { it.@name == "a" }.@value.text() == "[b]"
+        xmlData."query-params".parameter.size() == 2
     }
 }

--- a/repose-aggregator/functional-tests/tomcat-support/pom.xml
+++ b/repose-aggregator/functional-tests/tomcat-support/pom.xml
@@ -60,11 +60,6 @@
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>
         </dependency>
-        <dependency>
-            <groupId>org.openrepose</groupId>
-            <artifactId>mocks-util</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <!--For SLF4J/Log4J 2.x logging support-->
         <dependency>

--- a/repose-aggregator/functional-tests/tomcat-support/src/main/java/org/openrepose/commons/utils/test/tomcat/ReposeTomcatContainer.java
+++ b/repose-aggregator/functional-tests/tomcat-support/src/main/java/org/openrepose/commons/utils/test/tomcat/ReposeTomcatContainer.java
@@ -24,7 +24,6 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.startup.Tomcat;
 import org.openrepose.commons.utils.test.ReposeContainer;
 import org.openrepose.commons.utils.test.ReposeContainerProps;
-import org.openrepose.commons.utils.test.mocks.util.MocksUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,9 +54,13 @@ public class ReposeTomcatContainer extends ReposeContainer {
 
         if (props.getOriginServiceWars() != null && props.getOriginServiceWars().length != 0) {
             for (String originService : props.getOriginServiceWars()) {
-                tomcat.addWebapp("/" + MocksUtil.getServletPath(originService), originService);
+                tomcat.addWebapp("/" + getServletPath(originService), originService);
             }
         }
+    }
+
+    private static String getServletPath(String filePath) {
+        return filePath.substring(filePath.lastIndexOf('/') + 1, filePath.lastIndexOf('.'));
     }
 
     @Override


### PR DESCRIPTION
I updated three spots that were using the mocks-util module.  Two were easy to replace.  The third involved using XmlSlurper to do some unmarshalling.  There's still a dependency in mocks-servlet on mocks-util, but that's going away I hear.  Of note, EmbeddedTomcatProxyTest uses the WAR generated by mocks-servlet, so additional updates will be needed in EmbeddedTomcatProxyTest before mocks-servlet and thus mocks-util can be removed.