### PR TITLE
REP-3491 - Tightly Coupled filter wrapper updates

### DIFF
--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/experimental/tightlyCoupled/TightlyCoupledFilterTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/experimental/tightlyCoupled/TightlyCoupledFilterTest.groovy
@@ -29,44 +29,35 @@ class TightlyCoupledFilterTest extends ReposeValveTest {
     /**
      * This test proves that a custom filter, even though it's tightly coupled to repose
      * can modify the response body
-     * @return
      */
     def "Proving that a custom filter (although tightly coupled) does in fact work"() {
         setup:
-
         def params = properties.defaultTemplateParams
         repose.configurationProvider.applyConfigs("common", params)
         repose.configurationProvider.applyConfigs("features/filters/experimental/tightlycoupled", params)
 
         deproxy = new Deproxy()
         deproxy.addEndpoint(properties.targetPort)
-        def started = true
-        repose.start([waitOnJmxAfterStarting: false])
+        repose.start(waitOnJmxAfterStarting: false)
 
         waitUntilReadyToServiceRequests("200", false, true)
 
-        when:
-        MessageChain mc = null
-        mc = deproxy.makeRequest(
-                [
-                        method        : 'GET',
-                        url           : reposeEndpoint + "/get",
-                        defaultHandler: {
-                            new Response(200, null, null, "This should be the body")
-                        }
-                ])
+        def body = "This should be the body"
 
+        when:
+        MessageChain mc = deproxy.makeRequest(
+                method        : 'GET',
+                url           : "$reposeEndpoint/get",
+                defaultHandler: { new Response(200, null, null, body) })
 
         then:
         mc.receivedResponse.code == '200'
+        mc.receivedResponse.body.contains(body)
         mc.receivedResponse.body.contains("<extra> Added by TestFilter, should also see the rest of the content </extra>")
         println(mc.receivedResponse.body)
 
         cleanup:
-        if (started)
-            repose.stop()
-        if (deproxy != null)
-            deproxy.shutdown()
-
+        repose?.stop()
+        deproxy?.shutdown()
     }
 }


### PR DESCRIPTION
I updated the Tightly Coupled filter to use the new wrappers.  I removed the unnecessary request wrapping and a couple of odd logging statements (like asking the request for the response content type).  I also removed the "hasBody" check on the response as the new wrapper doesn't support that (and as I understand it the old wrapper barely did anyway).

I also had to set the Content-Length for the whole response to be read by Deproxy.

Also :panda_face: s.