### PR TITLE
REP-3577 - Configure request headers in HTTP connection pools

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>repose</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Build Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.openrepose</groupId>
     <artifactId>repose</artifactId>
-    <version>8.0.0.0-SNAPSHOT</version>
+    <version>7.3.3.0-SNAPSHOT</version>
 
 
     <name>Repose</name>

--- a/repose-aggregator/commons/configuration/pom.xml
+++ b/repose-aggregator/commons/configuration/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>commons-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Commons - Configuration Management</name>

--- a/repose-aggregator/commons/pom.xml
+++ b/repose-aggregator/commons/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Commons - Commons Support</name>

--- a/repose-aggregator/commons/utilities/pom.xml
+++ b/repose-aggregator/commons/utilities/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>commons-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Commons - Utilities</name>

--- a/repose-aggregator/components/cli-utils/pom.xml
+++ b/repose-aggregator/components/cli-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>components-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Command Line Utilities</name>

--- a/repose-aggregator/components/filters/add-header/pom.xml
+++ b/repose-aggregator/components/filters/add-header/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Add Header</name>

--- a/repose-aggregator/components/filters/client-auth/pom.xml
+++ b/repose-aggregator/components/filters/client-auth/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Client Authentication</name>

--- a/repose-aggregator/components/filters/client-authorization/pom.xml
+++ b/repose-aggregator/components/filters/client-authorization/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Client Authorization</name>

--- a/repose-aggregator/components/filters/client-ip-identity/pom.xml
+++ b/repose-aggregator/components/filters/client-ip-identity/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Client Identity By IP</name>

--- a/repose-aggregator/components/filters/compression/pom.xml
+++ b/repose-aggregator/components/filters/compression/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Compression</name>

--- a/repose-aggregator/components/filters/content-normalization/pom.xml
+++ b/repose-aggregator/components/filters/content-normalization/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Content Normalization</name>

--- a/repose-aggregator/components/filters/content-type-stripper/pom.xml
+++ b/repose-aggregator/components/filters/content-type-stripper/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Content Type Stripper</name>

--- a/repose-aggregator/components/filters/cors/pom.xml
+++ b/repose-aggregator/components/filters/cors/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - CORS</name>

--- a/repose-aggregator/components/filters/derp/pom.xml
+++ b/repose-aggregator/components/filters/derp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - DeRP</name>

--- a/repose-aggregator/components/filters/destination-router/pom.xml
+++ b/repose-aggregator/components/filters/destination-router/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Destination Router</name>

--- a/repose-aggregator/components/filters/echo/pom.xml
+++ b/repose-aggregator/components/filters/echo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Testing Echo Filter</name>

--- a/repose-aggregator/components/filters/filter-bundle/pom.xml
+++ b/repose-aggregator/components/filters/filter-bundle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - EAR Bundle</name>

--- a/repose-aggregator/components/filters/flush-output/pom.xml
+++ b/repose-aggregator/components/filters/flush-output/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Flush Output Stream</name>

--- a/repose-aggregator/components/filters/forwarded-proto/pom.xml
+++ b/repose-aggregator/components/filters/forwarded-proto/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Forwarded Protocol</name>

--- a/repose-aggregator/components/filters/header-id-mapping/pom.xml
+++ b/repose-aggregator/components/filters/header-id-mapping/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Client Header Identity Mapping</name>

--- a/repose-aggregator/components/filters/header-identity/pom.xml
+++ b/repose-aggregator/components/filters/header-identity/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Client Identity By Header</name>

--- a/repose-aggregator/components/filters/header-normalization/pom.xml
+++ b/repose-aggregator/components/filters/header-normalization/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Header Normalization</name>

--- a/repose-aggregator/components/filters/header-translation/pom.xml
+++ b/repose-aggregator/components/filters/header-translation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Header Translation</name>

--- a/repose-aggregator/components/filters/herp/pom.xml
+++ b/repose-aggregator/components/filters/herp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - HERP</name>

--- a/repose-aggregator/components/filters/ip-user/pom.xml
+++ b/repose-aggregator/components/filters/ip-user/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - IP Classification Filter</name>

--- a/repose-aggregator/components/filters/iri-validator/pom.xml
+++ b/repose-aggregator/components/filters/iri-validator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - IRI Validator</name>

--- a/repose-aggregator/components/filters/keystone-v2/pom.xml
+++ b/repose-aggregator/components/filters/keystone-v2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Keystone v2</name>

--- a/repose-aggregator/components/filters/merge-header/pom.xml
+++ b/repose-aggregator/components/filters/merge-header/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Merge Header Filter</name>

--- a/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
+++ b/repose-aggregator/components/filters/openstack-identity-v3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - OpenStack Identity V3</name>

--- a/repose-aggregator/components/filters/pom.xml
+++ b/repose-aggregator/components/filters/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>components-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>filters-support</name>

--- a/repose-aggregator/components/filters/rackspace-auth-user/pom.xml
+++ b/repose-aggregator/components/filters/rackspace-auth-user/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Rackspace Authentication User filter</name>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth/pom.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Rackspace Identity Basic Auth</name>

--- a/repose-aggregator/components/filters/rate-limiting/pom.xml
+++ b/repose-aggregator/components/filters/rate-limiting/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Rate Limiting</name>

--- a/repose-aggregator/components/filters/slf4j-http-logging/pom.xml
+++ b/repose-aggregator/components/filters/slf4j-http-logging/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - SLF4J HTTP Logging</name>

--- a/repose-aggregator/components/filters/translation/pom.xml
+++ b/repose-aggregator/components/filters/translation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Translation</name>

--- a/repose-aggregator/components/filters/uri-identity/pom.xml
+++ b/repose-aggregator/components/filters/uri-identity/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Client Identity By URI</name>

--- a/repose-aggregator/components/filters/uri-normalization/pom.xml
+++ b/repose-aggregator/components/filters/uri-normalization/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - URI Normalization</name>

--- a/repose-aggregator/components/filters/uri-stripper/pom.xml
+++ b/repose-aggregator/components/filters/uri-stripper/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - URI Stripper</name>

--- a/repose-aggregator/components/filters/url-extractor-to-header/pom.xml
+++ b/repose-aggregator/components/filters/url-extractor-to-header/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - URL Extractor to Header</name>

--- a/repose-aggregator/components/filters/valkyrie-authorization/pom.xml
+++ b/repose-aggregator/components/filters/valkyrie-authorization/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Valkyrie Authorization</name>

--- a/repose-aggregator/components/filters/versioning/pom.xml
+++ b/repose-aggregator/components/filters/versioning/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>filters-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Versioning</name>

--- a/repose-aggregator/components/pom.xml
+++ b/repose-aggregator/components/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Components Support</name>

--- a/repose-aggregator/components/repose-lint/pom.xml
+++ b/repose-aggregator/components/repose-lint/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>components-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Repose Lint</name>

--- a/repose-aggregator/core/core-lib/pom.xml
+++ b/repose-aggregator/core/core-lib/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>core-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Core - Power API Core Library</name>

--- a/repose-aggregator/core/core-service-api/pom.xml
+++ b/repose-aggregator/core/core-service-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>core-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Core Service APIs</name>

--- a/repose-aggregator/core/pom.xml
+++ b/repose-aggregator/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Core - Core Support</name>

--- a/repose-aggregator/core/valve/pom.xml
+++ b/repose-aggregator/core/valve/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>core-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Valve - Integration Proxy Container</name>

--- a/repose-aggregator/core/web-application/pom.xml
+++ b/repose-aggregator/core/web-application/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>core-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Core - Root Web Application</name>

--- a/repose-aggregator/experimental/exception-filter/pom.xml
+++ b/repose-aggregator/experimental/exception-filter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Exception Filter</name>

--- a/repose-aggregator/experimental/experimental-filter-bundle/pom.xml
+++ b/repose-aggregator/experimental/experimental-filter-bundle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Experimental EAR Bundle</name>

--- a/repose-aggregator/experimental/pom.xml
+++ b/repose-aggregator/experimental/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Experimental Support</name>

--- a/repose-aggregator/experimental/servlet-contract-filter/pom.xml
+++ b/repose-aggregator/experimental/servlet-contract-filter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Servlet Contract Filter</name>

--- a/repose-aggregator/experimental/tightly-coupled-filter/pom.xml
+++ b/repose-aggregator/experimental/tightly-coupled-filter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>experimental-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Tightly Coupled Filter</name>

--- a/repose-aggregator/extensions/api-validator/pom.xml
+++ b/repose-aggregator/extensions/api-validator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - API Validator</name>

--- a/repose-aggregator/extensions/extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/extensions/extensions-filter-bundle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Extensions EAR Bundle</name>

--- a/repose-aggregator/extensions/pom.xml
+++ b/repose-aggregator/extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Extensions Support</name>

--- a/repose-aggregator/extensions/simple-rbac/pom.xml
+++ b/repose-aggregator/extensions/simple-rbac/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>extensions-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Components - Simple RBAC</name>

--- a/repose-aggregator/external/jee6-schemas/pom.xml
+++ b/repose-aggregator/external/jee6-schemas/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>JavaEE 6 - XML Schema Library</name>

--- a/repose-aggregator/external/os-auth-schemas/pom.xml
+++ b/repose-aggregator/external/os-auth-schemas/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>OpenStack Auth XML Schemas</name>

--- a/repose-aggregator/external/pjl-compressingFilter/pom.xml
+++ b/repose-aggregator/external/pjl-compressingFilter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>PlanetJ CompressingFilter</name>

--- a/repose-aggregator/external/pom.xml
+++ b/repose-aggregator/external/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - External Library Support</name>

--- a/repose-aggregator/external/service-clients/auth/pom.xml
+++ b/repose-aggregator/external/service-clients/auth/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>service-clients-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Service Clients - Auth Service</name>

--- a/repose-aggregator/external/service-clients/pom.xml
+++ b/repose-aggregator/external/service-clients/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>external-lib-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Service Clients - Service Clients Support</name>

--- a/repose-aggregator/functional-tests/container-support/pom.xml
+++ b/repose-aggregator/functional-tests/container-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Test - Testing embedded support for Repose</name>

--- a/repose-aggregator/functional-tests/glassfish-support/pom.xml
+++ b/repose-aggregator/functional-tests/glassfish-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Test - Testing Repose with Embedded Glassfish</name>

--- a/repose-aggregator/functional-tests/mocks-servlet/pom.xml
+++ b/repose-aggregator/functional-tests/mocks-servlet/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Test - Testing Mocks Servlet</name>

--- a/repose-aggregator/functional-tests/mocks-util/pom.xml
+++ b/repose-aggregator/functional-tests/mocks-util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Test - Mocks Support</name>

--- a/repose-aggregator/functional-tests/pom.xml
+++ b/repose-aggregator/functional-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Functional Test Support</name>

--- a/repose-aggregator/functional-tests/spock-functional-test/pom.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Test - Spock Functional Tests</name>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/http-connection-pool.cfg.xml
@@ -23,5 +23,9 @@
           http.connection.max-header-count="100"
           http.connection.max-status-line-garbage="100"
           http.tcp.nodelay="true"
-          keepalive.timeout="0"/>
+          keepalive.timeout="0">
+       <headers>
+           <header name="auth-proxy" value="testing"/>
+       </headers>
+    </pool>
 </http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/connectionpooling/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/keystonev2/connectionpooling/http-connection-pool.cfg.xml
@@ -26,6 +26,10 @@
           http.connection.max-header-count="100"
           http.connection.max-status-line-garbage="100"
           http.tcp.nodelay="true"
-          keepalive.timeout="0"/>
+          keepalive.timeout="0">
+        <headers>
+            <header name="auth-proxy" value="testing"/>
+        </headers>
+    </pool>
 
 </http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/httpconnectionpool/headers/http-connection-pool.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/httpconnectionpool/headers/http-connection-pool.cfg.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+
+    <!-- Configuration for the default pool.  Any users of the service will by default, retrieve HTTP connections
+        using this default pool configuration.
+    -->
+    <pool id="default"
+          default="true"
+          chunked-encoding="true"
+          http.conn-manager.max-total="10"
+          http.conn-manager.max-per-route="2"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+
+    <pool id="identity-pool"
+          default="false"
+          chunked-encoding="true"
+          http.conn-manager.max-total="10"
+          http.conn-manager.max-per-route="2"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0">
+        <headers>
+            <header name="butts" value="pandas"/>
+        </headers>
+    </pool>
+
+</http-connection-pools>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/httpconnectionpool/headers/keystone-v2.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/httpconnectionpool/headers/keystone-v2.cfg.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<keystone-v2 xmlns="http://docs.openrepose.org/repose/keystone-v2/v1.0">
+    <identity-service
+            username="admin_username"
+            password="password"
+            uri="http://localhost:${identityPort}"
+            set-groups-in-header="true"
+            set-catalog-in-header="false"
+            connection-pool-id="identity-pool"/>
+</keystone-v2>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/httpconnectionpool/headers/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/services/httpconnectionpool/headers/system-model.cfg.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+        <nodes>
+            <node id="config-test" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+
+        <filters>
+            <filter name="keystone-v2"/>
+        </filters>
+
+        <destinations>
+            <endpoint id="service" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
+                      default="true"/>
+        </destinations>
+    </repose-cluster>
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingConnPoolTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/identitybasicauth/akkatimeout/BasicAuthAkkatimeoutUsingConnPoolTest.groovy
@@ -97,6 +97,10 @@ class BasicAuthAkkatimeoutUsingConnPoolTest extends ReposeValveTest {
         mc.handlings.size() == 1
         mc.handlings[0].request.headers.getCountByName("X-Auth-Token") == 1
         mc.handlings[0].request.headers.getFirstValue("X-Auth-Token").equals(fakeIdentityService.client_token)
+        // REP-3577 - add header using connection pool
+        mc.orphanedHandlings.get(0).request.headers.contains("auth-proxy")
+        mc.orphanedHandlings.get(0).request.headers.getFirstValue("auth-proxy") == "testing"
+        !mc.handlings[0].request.headers.contains("auth-proxy")
     }
 
     def "akka timeout test, auth response time out is greater than socket connection time out"() {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/connectionpooling/KeystoneV2ConnectionPoolingTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/keystonev2/connectionpooling/KeystoneV2ConnectionPoolingTest.groovy
@@ -117,6 +117,9 @@ class KeystoneV2ConnectionPoolingTest extends Specification {
         identityHandlings.size() > 0
         // there should be no requests to auth with a different connection id
         diff.size() == 0
+        // REP-3577 - add header using connection pool
+        mc1.orphanedHandlings.get(0).request.headers.contains("auth-proxy")
+        mc1.orphanedHandlings.get(0).request.headers.getFirstValue("auth-proxy") == "testing"
     }
 
     def cleanup() {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/httpconnectionpool/HttpClientHeaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/services/httpconnectionpool/HttpClientHeaderTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.services.httpconnectionpool
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+
+/**
+ * Test to verify that headers are added to requests made using an HTTP connection pool configured to do so.
+ */
+class HttpClientHeaderTest extends ReposeValveTest {
+
+    def static originEndpoint
+    def static identityEndpoint
+
+    def static MockIdentityV2Service fakeIdentityService
+
+    def setupSpec() {
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/services/httpconnectionpool/headers", params)
+
+        deproxy = new Deproxy()
+        repose.start(waitOnJmxAfterStarting: false)
+
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
+        fakeIdentityService = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        identityEndpoint = deproxy.addEndpoint(
+                properties.identityPort, 'identity service', null, fakeIdentityService.handler)
+
+        waitUntilReadyToServiceRequests("200", false, true)
+    }
+
+    def cleanupSpec() {
+        repose?.stop()
+        deproxy?.shutdown()
+    }
+
+    def "configured connection pool headers are added to requests using that pool"() {
+        when:
+        MessageChain mc = deproxy.makeRequest(
+                method : 'GET',
+                url    : "$reposeEndpoint/get",
+                headers: ['X-Auth-Token': fakeIdentityService.client_token, fancy: 'pants'])
+
+        then: 'request to identity has the configured connection pool headers'
+        mc.receivedResponse.code == '200'
+        mc.orphanedHandlings[0].request.headers.getFirstValue('butts') == 'pandas'
+        !mc.orphanedHandlings[0].request.headers.getFirstValue('fancy')
+
+        and: 'origin service received the correct headers'
+        mc.handlings.size() == 1
+        mc.handlings[0].request.headers.getFirstValue('fancy') == 'pants'
+        !mc.handlings[0].request.headers.getFirstValue('butts')
+    }
+}

--- a/repose-aggregator/functional-tests/test-support/pom.xml
+++ b/repose-aggregator/functional-tests/test-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Test - Testing Service and Mocks</name>

--- a/repose-aggregator/functional-tests/tomcat-support/pom.xml
+++ b/repose-aggregator/functional-tests/tomcat-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>functional-test-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Test - Testing Repose with Embedded Tomcat</name>

--- a/repose-aggregator/installation/deb/pom.xml
+++ b/repose-aggregator/installation/deb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>installation</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation DEB</name>

--- a/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/deb/repose-cli-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>deb</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Cloud Integration CLI-Utilities DEB</name>

--- a/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-extensions-filter-bundle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>deb</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Extension Filter Bundle DEB</name>

--- a/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/deb/repose-filter-bundle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>deb</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Filter Bundle DEB</name>

--- a/repose-aggregator/installation/deb/repose-lint/pom.xml
+++ b/repose-aggregator/installation/deb/repose-lint/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>deb</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Repose Lint DEB</name>

--- a/repose-aggregator/installation/deb/repose-valve/pom.xml
+++ b/repose-aggregator/installation/deb/repose-valve/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>deb</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Valve DEB</name>

--- a/repose-aggregator/installation/deb/repose-war/pom.xml
+++ b/repose-aggregator/installation/deb/repose-war/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>deb</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation ROOT.WAR DEB</name>

--- a/repose-aggregator/installation/pom.xml
+++ b/repose-aggregator/installation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation</name>

--- a/repose-aggregator/installation/rpm/pom.xml
+++ b/repose-aggregator/installation/rpm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>installation</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation RPM</name>

--- a/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-cli-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>rpm</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Cloud Integration CLI-Utilities RPM</name>

--- a/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-extensions-filter-bundle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>rpm</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Extension Filters RPM</name>

--- a/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-filter-bundle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>rpm</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Filter Bundle RPM</name>

--- a/repose-aggregator/installation/rpm/repose-lint/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-lint/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>rpm</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Repose Lint RPM</name>

--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>rpm</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation Valve RPM</name>

--- a/repose-aggregator/installation/rpm/repose-war/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-war/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>rpm</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Installation ROOT.WAR RPM</name>

--- a/repose-aggregator/pom.xml
+++ b/repose-aggregator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>repose</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose - Build Support Profiles</name>

--- a/repose-aggregator/services/atom-feed/api/pom.xml
+++ b/repose-aggregator/services/atom-feed/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>atom-feed-service-support</artifactId>
         <groupId>org.openrepose</groupId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Atom Feed Service API</name>

--- a/repose-aggregator/services/atom-feed/impl/pom.xml
+++ b/repose-aggregator/services/atom-feed/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>atom-feed-service-support</artifactId>
         <groupId>org.openrepose</groupId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Atom Feed Service Impl</name>

--- a/repose-aggregator/services/atom-feed/pom.xml
+++ b/repose-aggregator/services/atom-feed/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>services-pom</artifactId>
         <groupId>org.openrepose</groupId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Atom Feed Service</name>

--- a/repose-aggregator/services/datastore/api/pom.xml
+++ b/repose-aggregator/services/datastore/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>datastore-service-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Datastore Service API</name>

--- a/repose-aggregator/services/datastore/impl/pom.xml
+++ b/repose-aggregator/services/datastore/impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>datastore-service-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Datastore Service Impl</name>

--- a/repose-aggregator/services/datastore/pom.xml
+++ b/repose-aggregator/services/datastore/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>services-pom</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Datastore POM</name>

--- a/repose-aggregator/services/health-check/api/pom.xml
+++ b/repose-aggregator/services/health-check/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>health-check-service-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Health Check API</name>

--- a/repose-aggregator/services/health-check/impl/pom.xml
+++ b/repose-aggregator/services/health-check/impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>health-check-service-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Health Check Impl</name>

--- a/repose-aggregator/services/health-check/pom.xml
+++ b/repose-aggregator/services/health-check/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>services-pom</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Health Check Service</name>

--- a/repose-aggregator/services/httpclient/api/pom.xml
+++ b/repose-aggregator/services/httpclient/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>httpclient-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - HttpClient API</name>

--- a/repose-aggregator/services/httpclient/impl/pom.xml
+++ b/repose-aggregator/services/httpclient/impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>httpclient-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - HttpClient Connection Pool Impl</name>

--- a/repose-aggregator/services/httpclient/impl/src/main/java/org/openrepose/core/services/httpclient/impl/HttpConnectionPoolProvider.java
+++ b/repose-aggregator/services/httpclient/impl/src/main/java/org/openrepose/core/services/httpclient/impl/HttpConnectionPoolProvider.java
@@ -19,6 +19,7 @@
  */
 package org.openrepose.core.services.httpclient.impl;
 
+import org.apache.http.Header;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.params.ClientPNames;
 import org.apache.http.client.params.CookiePolicy;
@@ -27,14 +28,19 @@ import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.params.HttpParams;
+import org.openrepose.core.service.httpclient.config.HeaderType;
 import org.openrepose.core.service.httpclient.config.PoolType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 public final class HttpConnectionPoolProvider {
@@ -66,6 +72,10 @@ public final class HttpConnectionPoolProvider {
         params.setParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE, poolConf.getHttpSocketBufferSize());
         params.setBooleanParameter(CHUNKED_ENCODING_PARAM, poolConf.isChunkedEncoding());
 
+        if (poolConf.getHeaders() != null) {
+            params.setParameter(ClientPNames.DEFAULT_HEADERS, createHeaders(poolConf.getHeaders().getHeader()));
+        }
+
         final String uuid = UUID.randomUUID().toString();
         params.setParameter(CLIENT_INSTANCE_ID, uuid);
 
@@ -83,5 +93,15 @@ public final class HttpConnectionPoolProvider {
         LOG.info("HTTP connection pool {} with instance id {} has been created", poolConf.getId(), uuid);
 
         return client;
+    }
+
+    private static Collection<Header> createHeaders(List<HeaderType> configHeaders) {
+        Collection<Header> headers = new ArrayList<>();
+
+        for (HeaderType configHeader : configHeaders) {
+            headers.add(new BasicHeader(configHeader.getName(), configHeader.getValue()));
+        }
+
+        return headers;
     }
 }

--- a/repose-aggregator/services/httpclient/impl/src/main/resources/META-INF/schema/config/http-connection-pool.xsd
+++ b/repose-aggregator/services/httpclient/impl/src/main/resources/META-INF/schema/config/http-connection-pool.xsd
@@ -77,6 +77,9 @@
 
 
     <xs:complexType name="poolType">
+        <xs:sequence>
+            <xs:element type="cp:headerListType" name="headers" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
 
         <xs:attribute name="http.conn-manager.max-total" type="cp:PositiveInt" use="optional" default="400">
             <xs:annotation>
@@ -247,12 +250,34 @@
             </xs:annotation>
         </xs:attribute>
 
-
         <xs:assert vc:minVersion="1.1"
                    test="(@http.conn-manager.max-per-route) &lt;= (@http.conn-manager.max-total)"
                    xerces:message="Max connections per route must be less than or equal to total max connections"
                    saxon:message="Max connections per route must be less than or equal to total max connections"/>
 
+    </xs:complexType>
+
+    <xs:complexType name="headerListType">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>List of headers to add to each request made using this connection pool.</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:sequence>
+            <xs:element type="cp:headerType" name="header" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="headerType">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>Header with a name and a value.</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="required"/>
     </xs:complexType>
 
 </xs:schema>

--- a/repose-aggregator/services/httpclient/impl/src/test/groovy/org/openrepose/core/services/httpclient/impl/HttpConnectionPoolProviderTest.groovy
+++ b/repose-aggregator/services/httpclient/impl/src/test/groovy/org/openrepose/core/services/httpclient/impl/HttpConnectionPoolProviderTest.groovy
@@ -19,68 +19,96 @@
  */
 package org.openrepose.core.services.httpclient.impl
 
+import org.apache.http.Header
+import org.apache.http.client.params.ClientPNames
 import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.params.CoreConnectionPNames
 import org.junit.Before
 import org.junit.Test
+import org.openrepose.core.service.httpclient.config.HeaderListType
+import org.openrepose.core.service.httpclient.config.HeaderType
 import org.openrepose.core.service.httpclient.config.PoolType
-
-import static junit.framework.Assert.assertNotNull
-import static org.junit.Assert.assertEquals
 
 class HttpConnectionPoolProviderTest {
 
-    private PoolType poolType;
-    private final static int CONN_TIMEOUT = 30000;
-    private final static int MAX_HEADERS = 100;
-    private final static int MAX_LINE = 50;
-    private final static int SOC_TIMEOUT = 40000;
-    private final static boolean TCP_NODELAY = false;
-    private final static int SOC_BUFF_SZ = 1023;
-    private final static int MAX_PER_ROUTE = 50;
-    private final static int MAX_TOTAL = 300;
+    private final static int CONN_TIMEOUT = 30000
+    private final static int MAX_HEADERS = 100
+    private final static int MAX_LINE = 50
+    private final static int SOC_TIMEOUT = 40000
+    private final static boolean TCP_NODELAY = false
+    private final static int SOC_BUFF_SZ = 1023
+    private final static int MAX_PER_ROUTE = 50
+    private final static int MAX_TOTAL = 300
+
+    private PoolType poolType
 
     @Before
     public final void beforeAll() {
+        poolType = new PoolType()
 
-        poolType = new PoolType();
-
-        poolType.setHttpConnectionMaxHeaderCount(MAX_HEADERS);
-        poolType.setHttpConnectionMaxLineLength(MAX_LINE);
-        poolType.setHttpConnectionMaxStatusLineGarbage(10);
-        poolType.setHttpConnectionTimeout(CONN_TIMEOUT);
-        poolType.setHttpConnManagerMaxPerRoute(MAX_PER_ROUTE);
-        poolType.setHttpConnManagerMaxTotal(MAX_TOTAL);
-        poolType.setHttpSocketBufferSize(SOC_BUFF_SZ);
-        poolType.setHttpSocketTimeout(SOC_TIMEOUT);
-        poolType.setHttpTcpNodelay(TCP_NODELAY);
-        poolType.setKeepaliveTimeout(6000);
-        poolType.setId("testPool");
-
-    }
-
-
-    @Test
-    public void shouldCreateClientWithPassedConfigurationObject() {
-
-        DefaultHttpClient client = HttpConnectionPoolProvider.genClient(poolType);
-
-        Map props = client.connectionManager.properties;
-        assertEquals(client.getParams().getParameter(CoreConnectionPNames.MAX_LINE_LENGTH), MAX_LINE);
-        assertEquals(client.getParams().getParameter(CoreConnectionPNames.CONNECTION_TIMEOUT), CONN_TIMEOUT)
-        assertEquals(client.getParams().getParameter(CoreConnectionPNames.MAX_HEADER_COUNT), MAX_HEADERS);
-        assertEquals(client.getParams().getParameter(CoreConnectionPNames.TCP_NODELAY), TCP_NODELAY);
-        assertEquals(client.getParams().getParameter(CoreConnectionPNames.SO_TIMEOUT), SOC_TIMEOUT);
-        assertEquals(client.getParams().getParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE), SOC_BUFF_SZ);
-        assertEquals(props.get("defaultMaxPerRoute"), MAX_PER_ROUTE);
-        assertEquals(props.get("maxTotal"), MAX_TOTAL);
-        assertEquals(client.getConnectionKeepAliveStrategy().timeout, 6000);
-
+        poolType.setHttpConnectionMaxHeaderCount(MAX_HEADERS)
+        poolType.setHttpConnectionMaxLineLength(MAX_LINE)
+        poolType.setHttpConnectionMaxStatusLineGarbage(10)
+        poolType.setHttpConnectionTimeout(CONN_TIMEOUT)
+        poolType.setHttpConnManagerMaxPerRoute(MAX_PER_ROUTE)
+        poolType.setHttpConnManagerMaxTotal(MAX_TOTAL)
+        poolType.setHttpSocketBufferSize(SOC_BUFF_SZ)
+        poolType.setHttpSocketTimeout(SOC_TIMEOUT)
+        poolType.setHttpTcpNodelay(TCP_NODELAY)
+        poolType.setKeepaliveTimeout(6000)
+        poolType.setId("testPool")
     }
 
     @Test
-    public void shouldGetTestCoverageWithSillyTestTo100() {
+    public void "should create client with passed-in configuration object"() {
+        DefaultHttpClient client = HttpConnectionPoolProvider.genClient(poolType) as DefaultHttpClient
+
+        Map props = client.connectionManager.properties
+        assert client.getParams().getParameter(CoreConnectionPNames.MAX_LINE_LENGTH) == MAX_LINE
+        assert client.getParams().getParameter(CoreConnectionPNames.CONNECTION_TIMEOUT) == CONN_TIMEOUT
+        assert client.getParams().getParameter(CoreConnectionPNames.MAX_HEADER_COUNT) == MAX_HEADERS
+        assert client.getParams().getParameter(CoreConnectionPNames.TCP_NODELAY) == TCP_NODELAY
+        assert client.getParams().getParameter(CoreConnectionPNames.SO_TIMEOUT) == SOC_TIMEOUT
+        assert client.getParams().getParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE) == SOC_BUFF_SZ
+        assert props.get("defaultMaxPerRoute") == MAX_PER_ROUTE
+        assert props.get("maxTotal") == MAX_TOTAL
+        assert client.getConnectionKeepAliveStrategy().timeout == 6000
+    }
+
+    @Test
+    public void "should get test coverage with silly test to 100"() {
         HttpConnectionPoolProvider provider = new HttpConnectionPoolProvider()
-        assertNotNull(provider)
+        assert provider
+    }
+
+    @Test
+    public void "should add header parameter when configured"() {
+        def headerListType = new HeaderListType()
+        headerListType.getHeader().addAll(
+                [new HeaderType(name: "lol", value: "potatoes"),
+                 new HeaderType(name: "serious-business", value: "tomatoes")])
+        poolType.setHeaders(headerListType)
+
+        DefaultHttpClient client = HttpConnectionPoolProvider.genClient(poolType) as DefaultHttpClient
+
+        def parameter = client.getParams().getParameter(ClientPNames.DEFAULT_HEADERS)
+        assert parameter
+        assert parameter in Collection
+        parameter = parameter as Collection<?>
+        assert parameter.size() == 2
+        assert parameter[0] in Header
+        assert parameter[0].name == "lol"
+        assert parameter[0].value == "potatoes"
+        assert parameter[1].name == "serious-business"
+        assert parameter[1].value == "tomatoes"
+    }
+
+    @Test
+    public void "should not add header parameter when not configured"() {
+        poolType.setHeaders(null)
+
+        DefaultHttpClient client = HttpConnectionPoolProvider.genClient(poolType) as DefaultHttpClient
+
+        assert !client.getParams().getParameter(ClientPNames.DEFAULT_HEADERS)
     }
 }

--- a/repose-aggregator/services/httpclient/pom.xml
+++ b/repose-aggregator/services/httpclient/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>services-pom</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - HttpClient Support</name>

--- a/repose-aggregator/services/phone-home/pom.xml
+++ b/repose-aggregator/services/phone-home/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>services-pom</artifactId>
         <groupId>org.openrepose</groupId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/repose-aggregator/services/pom.xml
+++ b/repose-aggregator/services/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>profile-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services</name>

--- a/repose-aggregator/services/rate-limiting-service/pom.xml
+++ b/repose-aggregator/services/rate-limiting-service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>services-pom</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - Rate Limiting</name>

--- a/repose-aggregator/services/service-client/api/pom.xml
+++ b/repose-aggregator/services/service-client/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>service-client-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - AuthClient API</name>

--- a/repose-aggregator/services/service-client/impl/pom.xml
+++ b/repose-aggregator/services/service-client/impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>service-client-support</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - AuthClient Akka Impl</name>

--- a/repose-aggregator/services/service-client/pom.xml
+++ b/repose-aggregator/services/service-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openrepose</groupId>
         <artifactId>services-pom</artifactId>
-        <version>8.0.0.0-SNAPSHOT</version>
+        <version>7.3.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Repose Services - ServiceClient Support</name>


### PR DESCRIPTION
I updated the HTTP Connection Pool configuration to allow a list of headers to be configured for a connection pool.  I also updated the HttpConnectionPoolProvider to set the configured headers as default headers in the HttpClient.

I added a functional test (with the v2v2 filter configured to use a connection pool with a configured header) to verify that the call to identity contained the configured header and that the origin service (which used the default connection pool) did not receive said header.