### PR TITLE
REP-3280 - API Validation wrapper updates

### DIFF
--- a/repose-aggregator/components/filters/api-validator-filter/build.gradle
+++ b/repose-aggregator/components/filters/api-validator-filter/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(":repose-aggregator/core/core-service-api")
     compile project(":repose-aggregator/commons/commons-utilities")
-    compile project(":repose-aggregator/core/core-lib") //todo: remove this when the wrappers have been brought in
+    compile project(":repose-aggregator/core/core-lib")
     compile "com.rackspace.papi.components.api-checker:checker-core"
     compile "org.slf4j:slf4j-api"
     compile "org.springframework:spring-beans"
@@ -13,4 +13,6 @@ dependencies {
     testCompile "org.codehaus.groovy:groovy-all"
     testCompile "org.hamcrest:hamcrest-all"
     testCompile "org.mockito:mockito-all"
+    testCompile "org.springframework:spring-test"
+    testCompile "org.slf4j:jcl-over-slf4j"
 }

--- a/repose-aggregator/components/filters/api-validator-filter/pom.xml
+++ b/repose-aggregator/components/filters/api-validator-filter/pom.xml
@@ -57,6 +57,20 @@
             <groupId>com.rackspace.papi.components.api-checker</groupId>
             <artifactId>checker-core</artifactId>
         </dependency>
+
+        <!-- MockHttpServletRequest/Response -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- LogFactory, needed by MockHttpServletRequest/Response -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ApiValidatorFilter.java
+++ b/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ApiValidatorFilter.java
@@ -75,12 +75,12 @@ public class ApiValidatorFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
         ApiValidatorHandler handler = handlerFactory.buildHandler();
+
         if (handler == null) {
             LOG.error("API Validator filter has not yet initialized... Please check your configuration files and your artifacts directory.");
             ((HttpServletResponse) response).sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
         } else {
-            handler.setFilterChain(chain);
-            handler.handleRequest((HttpServletRequest) request, (HttpServletResponse) response);
+            handler.doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
         }
     }
 

--- a/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ApiValidatorHandler.java
+++ b/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ApiValidatorHandler.java
@@ -149,7 +149,6 @@ public class ApiValidatorHandler {
                     } else {
                         lastValidatorResult = validator.validate(wrappedRequest, response, chain);
                         isValid = lastValidatorResult.valid();
-                        response.setStatus(response.getStatus());
                         if (isValid) {
                             break;
                         }

--- a/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ApiValidatorHandler.java
+++ b/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ApiValidatorHandler.java
@@ -115,8 +115,9 @@ public class ApiValidatorHandler {
                 response.setStatus(error.code());
                 response.sendError(error.code(), error.message());
             }
-        } catch (Exception e) {
-            LOG.error("Some error", e);
+        } catch (Throwable t) {
+            // API Checker throws exceptions that extend Throwable
+            LOG.error("Some error", t);
             response.setStatus(HttpServletResponse.SC_BAD_GATEWAY);
         }
     }
@@ -162,8 +163,9 @@ public class ApiValidatorHandler {
             } else {
                 response.sendError(HttpServletResponse.SC_FORBIDDEN);
             }
-        } catch (Exception e) {
-            LOG.error("Error processing validation", e);
+        } catch (Throwable t) {
+            // API Checker throws exceptions that extend Throwable
+            LOG.error("Error processing validation", t);
             response.setStatus(HttpServletResponse.SC_BAD_GATEWAY);
         }
     }

--- a/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ValidatorInfo.java
+++ b/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ValidatorInfo.java
@@ -78,7 +78,6 @@ public class ValidatorInfo {
         throw new IllegalArgumentException("WADL Source Not Specified");
     }
 
-    // Until API Validator is updated to not throw the generic Throwable, this method will need to catch it.
     public boolean initValidator() {
         LOG.debug("CALL TO ValidatorInfo#initValidator. Validator is {}. From thread {}", validator, Thread.currentThread().getName());
 
@@ -94,7 +93,7 @@ public class ValidatorInfo {
                 LOG.debug("Calling the validator creation method for {}", name);
                 validator = Validator.apply(name + System.currentTimeMillis(), getSource(), config);
                 return true;
-            } catch (Throwable ex) {
+            } catch (Exception ex) {
                 LOG.warn("Error loading validator for WADL: " + uri, ex);
                 return false;
             }

--- a/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ValidatorInfo.java
+++ b/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ValidatorInfo.java
@@ -54,12 +54,7 @@ public class ValidatorInfo {
         this.config = config;
         this.wadl = null;
         this.systemId = null;
-
-        if (StringUtilities.isEmpty(name) && !roles.isEmpty() && !roles.isEmpty()) {
-            this.name = getNameFromRoles(roles);
-        } else {
-            this.name = name;
-        }
+        this.name = (StringUtilities.isEmpty(name) && !roles.isEmpty()) ? getNameFromRoles(roles) : name;
     }
 
     public ValidatorInfo(List<String> roles, Node wadl, String systemId, Config config, String name) {
@@ -68,11 +63,7 @@ public class ValidatorInfo {
         this.wadl = wadl;
         this.systemId = systemId;
         this.uri = null;
-        if (StringUtilities.isEmpty(name) && !roles.isEmpty() && !roles.isEmpty()) {
-            this.name = getNameFromRoles(roles);
-        } else {
-            this.name = name;
-        }
+        this.name = (StringUtilities.isEmpty(name) && !roles.isEmpty()) ? getNameFromRoles(roles) : name;
     }
 
     private Source getSource() {

--- a/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ValidatorInfo.java
+++ b/repose-aggregator/components/filters/api-validator-filter/src/main/java/org/openrepose/filters/apivalidator/ValidatorInfo.java
@@ -93,8 +93,10 @@ public class ValidatorInfo {
                 LOG.debug("Calling the validator creation method for {}", name);
                 validator = Validator.apply(name + System.currentTimeMillis(), getSource(), config);
                 return true;
-            } catch (Exception ex) {
-                LOG.warn("Error loading validator for WADL: " + uri, ex);
+            } catch (Throwable t) {
+                // we need to be able to catch WADLException which extends Throwable, and in its infinite wisdom, the
+                // Java compiler doesn't let us catch it directly, so we have to catch Throwable.
+                LOG.warn("Error loading validator for WADL: " + uri, t);
                 return false;
             }
         }

--- a/repose-aggregator/components/filters/api-validator-filter/src/main/resources/META-INF/schema/config/validator-configuration.xsd
+++ b/repose-aggregator/components/filters/api-validator-filter/src/main/resources/META-INF/schema/config/validator-configuration.xsd
@@ -66,6 +66,10 @@
         <xs:annotation>
             <xs:documentation>
                 <html:p>
+                    <html:strong>Deprecation warning:</html:strong> Multiple validators will not be supported in
+                    Repose 9.  In Repose 9, only a single validator will be allowed in config.
+                </html:p>
+                <html:p>
                     The validator.cfg.xml will contain a list of validator elements.
                     A validator element will specify the WADL to be used in order to
                     validate a request for a user of a given role/group.
@@ -82,11 +86,15 @@
             <xs:annotation>
                 <xs:documentation>
                     <html:p>
-                        set to true will match validators to header 'x-roles' and all matches are
-                        validated until one of them is valid. In the event that all matches are invalid, the response
+                        <html:strong>Deprecation warning:</html:strong> Multiple validators will not be supported
+                        in Repose 9 making this attribute moot. This attribute will not be available in Repose 9.
+                    </html:p>
+                    <html:p>
+                        When set to true, filter will match validators to header 'x-roles' and all matches are
+                        validated until one of them is valid. If a default validator is configured, it will be
+                        the first validator to be checked. In the event that all matches are invalid, the response
                         returned will be that of the last matched validator. If set to false, or not set at all, the
-                        filer
-                        will use the first validator which matches the 'x-roles' header.
+                        filter will use the first validator which matches the 'x-roles' header.
                     </html:p>
                 </xs:documentation>
             </xs:annotation>
@@ -110,14 +118,31 @@
 
     <!-- The Validator Type -->
     <xs:complexType name="ValidatorItem">
+        <xs:annotation>
+            <xs:documentation>
+                <html:p>
+                    <html:strong>Deprecation warning:</html:strong> Embedding a WADL inside of a validator
+                    element will no longer be supported in Repose 9.  The WADL will need to be in its own
+                    file and referenced in this config.
+                </html:p>
+                <html:p>Creates a new validator.</html:p>
+            </xs:documentation>
+        </xs:annotation>
+
         <xs:sequence>
+            <!-- Allow embedding a WADL - deprecated in Repose 8, to be removed in Repose 9 -->
             <xs:any minOccurs="0" namespace="##any" processContents="skip"/>
         </xs:sequence>
 
         <xs:attribute name="role" type="scr:StringList" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    <html:p>List of roles that are applied on single validator. Triggers off of 'x-roles' header.
+                    <html:p>
+                        <html:strong>Deprecation warning:</html:strong> Starting in Repose 9, roles will need to
+                        be specified inside of the WADL.  This attribute will not be available in Repose 9.
+                    </html:p>
+                    <html:p>
+                        List of roles that are applied on single validator. Triggers off of 'x-roles' header.
                     </html:p>
                 </xs:documentation>
             </xs:annotation>
@@ -139,9 +164,13 @@
             <xs:annotation>
                 <xs:documentation>
                     <html:p>
+                        <html:strong>Deprecation warning:</html:strong> Multiple validators will not be supported
+                        in Repose 9 making this attribute moot. This attribute will not be available in Repose 9.
+                    </html:p>
+                    <html:p>
                         Set to use this validator if no 'x-roles' header is passed.
-                        If the api-validator config 'multi-match' is set to true then thh default validator
-                        will be the first validator to process the incoming request. If multimatch is set to
+                        If the api-validator config 'multi-match' is set to true then the default validator
+                        will be the first validator to process the incoming request. If multi-match is set to
                         false and if no validator is matched to the users' roles, then the filter will use
                         the default validator.
                     </html:p>
@@ -158,6 +187,7 @@
                         Can be located within the file system or pointed to a remote file.
                         Can use absolute or relative path.
                     </html:p>
+                    <html:p>Note: This will be a required attribute in Repose 9.</html:p>
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/repose-aggregator/components/filters/api-validator-filter/src/test/groovy/org/openrepose/filters/apivalidator/ApiValidatorHandlerFactoryTest.groovy
+++ b/repose-aggregator/components/filters/api-validator-filter/src/test/groovy/org/openrepose/filters/apivalidator/ApiValidatorHandlerFactoryTest.groovy
@@ -84,7 +84,7 @@ public class ApiValidatorHandlerFactoryTest {
             ApiValidatorHandler handler = instance.buildHandler();
             assertNotNull("Should build handler", handler);
 
-            List<ValidatorInfo> validatorsForRole = handler.getValidatorsForRole(roles);
+            List<ValidatorInfo> validatorsForRole = handler.getValidatorsForRoles(roles);
             assertNotNull(validatorsForRole);
 
             for (ValidatorInfo validatorForRole : validatorsForRole) {
@@ -99,7 +99,7 @@ public class ApiValidatorHandlerFactoryTest {
         public void shouldSetDefaultValidator() {
             ApiValidatorHandler handler = instance.buildHandler();
             assertNotNull("Should build handler", handler);
-            List<ValidatorInfo> validatorsForRole = handler.getValidatorsForRole(new ArrayList<String>());
+            List<ValidatorInfo> validatorsForRole = handler.getValidatorsForRoles(new ArrayList<String>());
             assertNotNull(validatorsForRole);
             assertEquals("Should get validator for default role", defaultRole, validatorsForRole.get(0).getRoles().get(0));
         }

--- a/repose-aggregator/components/filters/api-validator-filter/src/test/groovy/org/openrepose/filters/apivalidator/ApiValidatorHandlerFactoryTest.groovy
+++ b/repose-aggregator/components/filters/api-validator-filter/src/test/groovy/org/openrepose/filters/apivalidator/ApiValidatorHandlerFactoryTest.groovy
@@ -25,8 +25,6 @@ import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import org.openrepose.commons.config.parser.generic.GenericResourceConfigurationParser
 import org.openrepose.commons.config.resource.ConfigurationResource
-import org.openrepose.commons.utils.http.header.HeaderValue
-import org.openrepose.commons.utils.http.header.HeaderValueImpl
 import org.openrepose.components.apivalidator.servlet.config.DelegatingType
 import org.openrepose.components.apivalidator.servlet.config.ValidatorConfiguration
 import org.openrepose.components.apivalidator.servlet.config.ValidatorItem
@@ -50,7 +48,7 @@ public class ApiValidatorHandlerFactoryTest {
         private final String defaultRole = "defaultRole";
         private ConfigurationService configService;
         private ApiValidatorHandlerFactory instance;
-        private List<HeaderValue> roles;
+        private List<String> roles;
         private ValidatorConfiguration config;
 
         @Before
@@ -77,8 +75,7 @@ public class ApiValidatorHandlerFactoryTest {
 
             instance.configurationUpdated(config);
 
-            roles = new ArrayList<HeaderValue>();
-            roles.add(new HeaderValueImpl(role));
+            roles = [role];
 
         }
 
@@ -102,7 +99,7 @@ public class ApiValidatorHandlerFactoryTest {
         public void shouldSetDefaultValidator() {
             ApiValidatorHandler handler = instance.buildHandler();
             assertNotNull("Should build handler", handler);
-            List<ValidatorInfo> validatorsForRole = handler.getValidatorsForRole(new ArrayList<HeaderValue>());
+            List<ValidatorInfo> validatorsForRole = handler.getValidatorsForRole(new ArrayList<String>());
             assertNotNull(validatorsForRole);
             assertEquals("Should get validator for default role", defaultRole, validatorsForRole.get(0).getRoles().get(0));
         }

--- a/repose-aggregator/components/filters/api-validator-filter/src/test/java/org/openrepose/filters/apivalidator/ApiValidatorHandlerTest.java
+++ b/repose-aggregator/components/filters/api-validator-filter/src/test/java/org/openrepose/filters/apivalidator/ApiValidatorHandlerTest.java
@@ -92,14 +92,13 @@ public class ApiValidatorHandlerTest {
             validators.add(blowupValidatorInfo);
 
             instance = new ApiValidatorHandler(defaultValidatorInfo, validators, false, false, null);
-            instance.setFilterChain(chain);
 
             request.setRequestURI("/path/to/resource");
         }
 
         @Test
         public void shouldCallDefaultValidatorWhenNoRoleMatch() {
-            instance.handleRequest(request, response);
+            instance.doFilter(request, response, chain);
             verify(defaultValidator).validate(any(HttpServletRequestWrapper.class), eq(response), eq(chain));
         }
 
@@ -107,7 +106,7 @@ public class ApiValidatorHandlerTest {
         public void shouldCallValidatorForRole() {
             request.addHeader(OpenStackServiceHeader.ROLES.toString(), "junk;q=0.8,role1;q=0.9,bbq;q=0.9,stuff;q=0.7");
 
-            instance.handleRequest(request, response);
+            instance.doFilter(request, response, chain);
             verify(role1Validator).validate(any(HttpServletRequestWrapper.class), eq(response), eq(chain));
         }
 
@@ -115,7 +114,7 @@ public class ApiValidatorHandlerTest {
         public void shouldHandleNullValidators() {
             request.addHeader(OpenStackServiceHeader.ROLES.toString(), "nullValidator");
 
-            instance.handleRequest(request, response);
+            instance.doFilter(request, response, chain);
             verify(nullValidatorInfo).getValidator();
             assertEquals(HttpServletResponse.SC_BAD_GATEWAY, response.getStatus());
         }
@@ -124,7 +123,7 @@ public class ApiValidatorHandlerTest {
         public void shouldHandleExceptionsInValidators() {
             request.addHeader(OpenStackServiceHeader.ROLES.toString(), "blowupValidator");
 
-            instance.handleRequest(request, response);
+            instance.doFilter(request, response, chain);
             verify(blowupValidator).validate(any(HttpServletRequestWrapper.class), eq(response), eq(chain));
             assertEquals(HttpServletResponse.SC_BAD_GATEWAY, response.getStatus());
         }
@@ -138,7 +137,7 @@ public class ApiValidatorHandlerTest {
             validators.add(role2ValidatorInfo);
 
             instance = new ApiValidatorHandler(defaultValidatorInfo, validators, true, false, null);
-            List<ValidatorInfo> validatorsForRole = instance.getValidatorsForRole(roles);
+            List<ValidatorInfo> validatorsForRole = instance.getValidatorsForRoles(roles);
             assertEquals(validatorsForRole.get(0), defaultValidatorInfo);
             assertEquals(validatorsForRole.get(1), role1ValidatorInfo);
         }
@@ -154,7 +153,7 @@ public class ApiValidatorHandlerTest {
 
             instance = new ApiValidatorHandler(defaultValidatorInfo, validators, true, false, null);
 
-            List<ValidatorInfo> validatorsForRole = instance.getValidatorsForRole(roles);
+            List<ValidatorInfo> validatorsForRole = instance.getValidatorsForRoles(roles);
 
             assertEquals(validatorsForRole.get(0), role1ValidatorInfo);
             assertEquals(validatorsForRole.get(1), defaultValidatorInfo);

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/apivalidator/ApiValidatorJMXTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/apivalidator/ApiValidatorJMXTest.groovy
@@ -51,6 +51,7 @@ class ApiValidatorJMXTest extends ReposeValveTest {
         repose.start()
         deproxy = new Deproxy()
         deproxy.addEndpoint(properties.targetPort)
+        repose.waitForNon500FromUrl(properties.reposeEndpoint)
     }
 
     static def params


### PR DESCRIPTION
Our typical update pattern wasn't going to work for this filter, so I kept the existing structure and just removed all of the FilterDirector/FilterLogicHandlerDelegate/old wrapper stuff.  I also cleaned up the code a bit (mostly renaming stuff) since I had the context in my brain.