### PR TITLE
REP-3629 - Header Translation - configure quality

### DIFF
--- a/repose-aggregator/components/filters/header-translation-filter/src/main/resources/META-INF/schema/config/header-translation.xsd
+++ b/repose-aggregator/components/filters/header-translation-filter/src/main/resources/META-INF/schema/config/header-translation.xsd
@@ -95,14 +95,17 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="splittable" type="xs:boolean" use="optional" default="true">
+        <xs:attribute name="splittable" type="xs:boolean" use="optional" default="false">
             <xs:annotation>
                 <xs:documentation>
                     <html:p>
                         Whether or not the original header should be split.  If the value of the original header can
                         contain commas that are not meant to delimit individual header values (e.g. User-Agent), this
-                        should be set to false.  When set to false, each header entry will be treated as a single value
-                        when it comes to applying the configured quality (if applicable).
+                        should be set to false (or left out since the default is false).  When set to false, each
+                        header entry will be treated as a single value when it comes to applying the configured
+                        quality (if applicable).  It is important to set this attribute to true when configured
+                        to set a new header quality on a splittable header (otherwise, not all of the qualities will
+                        be correctly updated).
                     </html:p>
                 </xs:documentation>
             </xs:annotation>

--- a/repose-aggregator/components/filters/header-translation-filter/src/main/resources/META-INF/schema/config/header-translation.xsd
+++ b/repose-aggregator/components/filters/header-translation-filter/src/main/resources/META-INF/schema/config/header-translation.xsd
@@ -61,9 +61,52 @@
             </xs:documentation>
         </xs:annotation>
 
-        <xs:attribute type="xs:string" name="original-name" use="required"/>
-        <xs:attribute type="header-translation:StringList" name="new-name" use="required"/>
-        <xs:attribute type="xs:boolean" name="remove-original" use="optional" default="false"/>
+        <xs:attribute name="original-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>The name of the original header to look for in the request.</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="new-name" type="header-translation:StringList" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        The list of new headers this filter should create using the values of the original header.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="remove-original" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>Whether or not the original header should be removed in the request.</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="quality" type="header-translation:doubleBetweenZeroAndOne" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        Quality for the new headers. If no quality is specified, the original quality (if any) is used.
+                        When quality is specified, any specified quality in the original value will be removed before
+                        the new quality is added.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="splittable" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        Whether or not the original header should be split.  If the value of the original header can
+                        contain commas that are not meant to delimit individual header values (e.g. User-Agent), this
+                        should be set to false.  When set to false, each header entry will be treated as a single value
+                        when it comes to applying the configured quality (if applicable).
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
 
     </xs:complexType>
 
@@ -83,6 +126,13 @@
 
     <xs:simpleType name="StringList">
         <xs:list itemType="header-translation:header-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="doubleBetweenZeroAndOne">
+        <xs:restriction base="xs:double">
+            <xs:minInclusive value="0.0"/>
+            <xs:maxInclusive value="1.0"/>
+        </xs:restriction>
     </xs:simpleType>
 
 </xs:schema>

--- a/repose-aggregator/components/filters/header-translation-filter/src/main/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilter.scala
+++ b/repose-aggregator/components/filters/header-translation-filter/src/main/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilter.scala
@@ -65,10 +65,11 @@ class HeaderTranslationFilter @Inject()(configurationService: ConfigurationServi
 
       sourceHeaders foreach { sourceHeader =>
         val originalHeaderName = sourceHeader.getOriginalName
-        val originalHeaderValues = if (sourceHeader.isSplittable)
-          httpRequest.getSplittableHeaderScala(originalHeaderName) else
-          httpRequest.getHeadersScala(originalHeaderName)
         val quality = Option(sourceHeader.getQuality)
+        val originalHeaderValues = if (sourceHeader.isSplittable)
+          httpRequest.getSplittableHeaderScala(originalHeaderName)
+        else
+          httpRequest.getHeadersScala(originalHeaderName)
 
         if (originalHeaderValues.nonEmpty) {
           sourceHeader.getNewName foreach { newHeaderName =>
@@ -112,5 +113,5 @@ class HeaderTranslationFilter @Inject()(configurationService: ConfigurationServi
 object HeaderTranslationFilter {
   private final val DefaultConfig = "header-translation.cfg.xml"
   private final val SchemaFileName = "/META-INF/schema/config/header-translation.xsd"
-  private final val QualityReqex = ";q=\\d[^;]*".r
+  private final val QualityReqex = """;q=[^;]*""".r
 }

--- a/repose-aggregator/components/filters/header-translation-filter/src/main/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilter.scala
+++ b/repose-aggregator/components/filters/header-translation-filter/src/main/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilter.scala
@@ -36,17 +36,18 @@ import scala.collection.JavaConversions._
 class HeaderTranslationFilter @Inject()(configurationService: ConfigurationService)
   extends Filter with UpdateListener[HeaderTranslationType] with LazyLogging {
 
-  private final val DEFAULT_CONFIG = "header-translation.cfg.xml"
+  private final val DefaultConfig = "header-translation.cfg.xml"
+  private final val SchemaFileName = "/META-INF/schema/config/header-translation.xsd"
 
   private var configFilename: String = _
   private var initialized: Boolean = false
   private var sourceHeaders: List[Header] = List.empty
 
   override def init(filterConfig: FilterConfig): Unit = {
-    configFilename = new FilterConfigHelper(filterConfig).getFilterConfig(DEFAULT_CONFIG)
+    configFilename = new FilterConfigHelper(filterConfig).getFilterConfig(DefaultConfig)
     logger.info("Initializing filter using config " + configFilename)
 
-    val xsdURL = getClass.getResource("/META-INF/schema/config/header-translation.xsd")
+    val xsdURL = getClass.getResource(SchemaFileName)
     configurationService.subscribeTo(
       filterConfig.getFilterName,
       configFilename,
@@ -72,15 +73,15 @@ class HeaderTranslationFilter @Inject()(configurationService: ConfigurationServi
             originalHeaderValues foreach { originalHeaderValue =>
               httpRequest.addHeader(newHeaderName, originalHeaderValue)
             }
-            logger.trace("Header added: " + newHeaderName)
+            logger.trace("Header added: {}", newHeaderName)
           }
 
           if (sourceHeader.isRemoveOriginal) {
             httpRequest.removeHeader(originalHeaderName)
-            logger.trace("Header removed: " + originalHeaderName)
+            logger.trace("Header removed: {}", originalHeaderName)
           }
         } else {
-          logger.trace("Header for translation not found: " + originalHeaderName)
+          logger.trace("Header for translation not found: {}", originalHeaderName)
         }
       }
 
@@ -88,9 +89,7 @@ class HeaderTranslationFilter @Inject()(configurationService: ConfigurationServi
     }
   }
 
-  override def isInitialized: Boolean = {
-    initialized
-  }
+  override def isInitialized: Boolean = initialized
 
   override def destroy(): Unit = {
     configurationService.unsubscribeFrom(configFilename, this)

--- a/repose-aggregator/components/filters/header-translation-filter/src/test/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilterTest.scala
+++ b/repose-aggregator/components/filters/header-translation-filter/src/test/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilterTest.scala
@@ -72,10 +72,42 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
     headerFour.getNewName.add("X-New-Four-Two")
     headerFour.setRemoveOriginal(false)
 
+    val headerFive = new Header
+    headerFive.setOriginalName("X-Five")
+    headerFive.getNewName.add("X-New-Five-One")
+    headerFive.setRemoveOriginal(false)
+    headerFive.setQuality(null)
+    headerFive.setSplittable(true)
+
+    val headerSix = new Header
+    headerSix.setOriginalName("X-Six")
+    headerSix.getNewName.add("X-New-Six-One")
+    headerSix.setRemoveOriginal(false)
+    headerSix.setQuality(null)
+    headerSix.setSplittable(false)
+
+    val headerSeven = new Header
+    headerSeven.setOriginalName("X-Seven")
+    headerSeven.getNewName.add("X-New-Seven-One")
+    headerSeven.setRemoveOriginal(false)
+    headerSeven.setQuality(0.71)
+    headerSeven.setSplittable(true)
+
+    val headerEight = new Header
+    headerEight.setOriginalName("X-Eight")
+    headerEight.getNewName.add("X-New-Eight-One")
+    headerEight.setRemoveOriginal(false)
+    headerEight.setQuality(0.82)
+    headerEight.setSplittable(false)
+
     config.getHeader.add(headerOne)
     config.getHeader.add(headerTwo)
     config.getHeader.add(headerThree)
     config.getHeader.add(headerFour)
+    config.getHeader.add(headerFive)
+    config.getHeader.add(headerSix)
+    config.getHeader.add(headerSeven)
+    config.getHeader.add(headerEight)
 
     filter.configurationUpdated(config)
   }
@@ -109,40 +141,25 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
 
       filter.doFilter(request, null, mockFilterChain)
 
-      val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
-      verify(mockFilterChain).doFilter(requestCaptor.capture(), any[ServletResponse])
-
-      val capturedRequest = requestCaptor.getValue
-      capturedRequest.getHeaderNames.toSeq should contain theSameElementsAs request.getHeaderNames.toSeq
+      getCapturedRequest.getHeaderNames.toSeq should contain theSameElementsAs request.getHeaderNames.toSeq
     }
 
     it("should remove the original header") {
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
-      verify(mockFilterChain).doFilter(requestCaptor.capture(), any[ServletResponse])
-
-      val capturedRequest = requestCaptor.getValue
-      capturedRequest.getHeader("X-One") shouldBe null
+      getCapturedRequest.getHeader("X-One") shouldBe null
     }
 
     it("should add a new header with a single value") {
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
-      verify(mockFilterChain).doFilter(requestCaptor.capture(), any[ServletResponse])
-
-      val capturedRequest = requestCaptor.getValue
-      capturedRequest.getHeaders("X-New-One-One").toSeq should contain theSameElementsAs Seq("valueOne")
+      getCapturedRequest.getHeaders("X-New-One-One").toSeq should contain theSameElementsAs Seq("valueOne")
     }
 
     it("should add new headers with multiple values") {
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
-      verify(mockFilterChain).doFilter(requestCaptor.capture(), any[ServletResponse])
-
-      val capturedRequest = requestCaptor.getValue
+      val capturedRequest = getCapturedRequest
       capturedRequest.getHeaders("X-New-Two-One").toSeq should contain theSameElementsAs Seq("valueOne", "valueTwo")
       capturedRequest.getHeaders("X-New-Two-Two").toSeq should contain theSameElementsAs Seq("valueOne", "valueTwo")
     }
@@ -150,10 +167,7 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
     it("should preserve header value order") {
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
-      verify(mockFilterChain).doFilter(requestCaptor.capture(), any[ServletResponse])
-
-      val capturedRequest = requestCaptor.getValue
+      val capturedRequest = getCapturedRequest
       capturedRequest.getHeaders("X-New-One-One").toSeq should contain theSameElementsInOrderAs Seq("valueOne")
       capturedRequest.getHeaders("X-New-Two-One").toSeq should contain theSameElementsInOrderAs Seq("valueOne", "valueTwo")
       capturedRequest.getHeaders("X-New-Two-Two").toSeq should contain theSameElementsInOrderAs Seq("valueOne", "valueTwo")
@@ -174,22 +188,98 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
 
       filter.doFilter(request, null, mockFilterChain)
 
-      val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
-      verify(mockFilterChain).doFilter(requestCaptor.capture(), any[ServletResponse])
-
-      val capturedRequest = requestCaptor.getValue
-      capturedRequest.getHeaderNames.toSeq should contain theSameElementsAs request.getHeaderNames.toSeq
+      getCapturedRequest.getHeaderNames.toSeq should contain theSameElementsAs request.getHeaderNames.toSeq
     }
 
     it("should not remove the original headers") {
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
-      verify(mockFilterChain).doFilter(requestCaptor.capture(), any[ServletResponse])
-
-      val capturedRequest = requestCaptor.getValue
+      val capturedRequest = getCapturedRequest
       capturedRequest.getHeaders("X-Three").toSeq should contain theSameElementsAs Seq("valueOne")
       capturedRequest.getHeaders("X-Four").toSeq should contain theSameElementsAs Seq("valueOne", "valueTwo")
     }
+  }
+
+  describe("splittable header configuration") {
+    it("should not split the headers when NOT configured to do so") {
+      val mockRequest = new MockHttpServletRequest()
+      mockRequest.addHeader("X-Six", "mustard,ketchup,mayo;q=0.9,pickles;q=0.1")
+
+      filter.doFilter(mockRequest, null, mockFilterChain)
+
+      getCapturedRequest.getHeaders("X-New-Six-One").toSeq should contain theSameElementsAs Seq("mustard,ketchup,mayo;q=0.9,pickles;q=0.1")
+    }
+
+    it("should split the headers when configured") {
+      val mockRequest = new MockHttpServletRequest()
+      mockRequest.addHeader("X-Five", "mustard,ketchup,mayo;q=0.9,pickles;q=0.1")
+
+      filter.doFilter(mockRequest, null, mockFilterChain)
+
+      getCapturedRequest.getHeaders("X-New-Five-One").toSeq should contain theSameElementsInOrderAs Seq("mustard", "ketchup", "mayo;q=0.9", "pickles;q=0.1")
+    }
+
+    it("should correctly handle multiple splittable headers") {
+      val mockRequest = new MockHttpServletRequest()
+      mockRequest.addHeader("X-Five", "mustard,ketchup,mayo;q=0.9,pickles;q=0.1")
+      mockRequest.addHeader("X-Five", "bacon;q=1.0,cheese;q=0.8")
+
+      filter.doFilter(mockRequest, null, mockFilterChain)
+
+      getCapturedRequest.getHeaders("X-New-Five-One").toSeq should contain theSameElementsInOrderAs Seq("mustard", "ketchup", "mayo;q=0.9", "pickles;q=0.1", "bacon;q=1.0", "cheese;q=0.8")
+    }
+  }
+
+  describe("when configured to set the header quality") {
+    it("sets the configured quality on the new header") {
+      val mockRequest = new MockHttpServletRequest()
+      mockRequest.addHeader("X-Eight", "mustard")
+
+      filter.doFilter(mockRequest, null, mockFilterChain)
+
+      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain theSameElementsAs Seq("mustard;q=0.82")
+    }
+
+    it("removes the original quality before adding the new header") {
+      val mockRequest = new MockHttpServletRequest()
+      mockRequest.addHeader("X-Eight", "mayo;q=1.0")
+
+      filter.doFilter(mockRequest, null, mockFilterChain)
+
+      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain theSameElementsAs Seq("mayo;q=0.82")
+    }
+
+    it("correctly handles non-splittable headers") {
+      val mockRequest = new MockHttpServletRequest()
+      mockRequest.addHeader("X-Eight", "mustard,mayo,cheese")
+
+      filter.doFilter(mockRequest, null, mockFilterChain)
+
+      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain theSameElementsAs Seq("mustard,mayo,cheese;q=0.82")
+    }
+
+    it("correctly handles splittable headers") {
+      val mockRequest = new MockHttpServletRequest()
+      mockRequest.addHeader("X-Seven", "mustard,mayo,cheese")
+
+      filter.doFilter(mockRequest, null, mockFilterChain)
+
+      getCapturedRequest.getHeaders("X-New-Seven-One").toSeq should contain theSameElementsAs Seq("mustard;q=0.71", "mayo;q=0.71", "cheese;q=0.71")
+    }
+
+    it("removes the original quality on splittable headers before adding the new header") {
+      val mockRequest = new MockHttpServletRequest()
+      mockRequest.addHeader("X-Seven", "mustard,mayo;q=0.2,cheese")
+
+      filter.doFilter(mockRequest, null, mockFilterChain)
+
+      getCapturedRequest.getHeaders("X-New-Seven-One").toSeq should contain theSameElementsAs Seq("mustard;q=0.71", "mayo;q=0.71", "cheese;q=0.71")
+    }
+  }
+
+  def getCapturedRequest: HttpServletRequest = {
+    val requestCaptor = ArgumentCaptor.forClass(classOf[HttpServletRequest])
+    verify(mockFilterChain).doFilter(requestCaptor.capture(), any[ServletResponse])
+    requestCaptor.getValue
   }
 }

--- a/repose-aggregator/components/filters/header-translation-filter/src/test/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilterTest.scala
+++ b/repose-aggregator/components/filters/header-translation-filter/src/test/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilterTest.scala
@@ -153,7 +153,7 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
     it("should add a new header with a single value") {
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      getCapturedRequest.getHeaders("X-New-One-One").toSeq should contain theSameElementsAs Seq("valueOne")
+      getCapturedRequest.getHeaders("X-New-One-One").toSeq should contain ("valueOne")
     }
 
     it("should add new headers with multiple values") {
@@ -168,9 +168,9 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
       filter.doFilter(mockRequest, null, mockFilterChain)
 
       val capturedRequest = getCapturedRequest
-      capturedRequest.getHeaders("X-New-One-One").toSeq should contain theSameElementsInOrderAs Seq("valueOne")
-      capturedRequest.getHeaders("X-New-Two-One").toSeq should contain theSameElementsInOrderAs Seq("valueOne", "valueTwo")
-      capturedRequest.getHeaders("X-New-Two-Two").toSeq should contain theSameElementsInOrderAs Seq("valueOne", "valueTwo")
+      capturedRequest.getHeaders("X-New-One-One").toSeq should contain ("valueOne")
+      capturedRequest.getHeaders("X-New-Two-One").toSeq should contain inOrderOnly ("valueOne", "valueTwo")
+      capturedRequest.getHeaders("X-New-Two-Two").toSeq should contain inOrderOnly ("valueOne", "valueTwo")
     }
   }
 
@@ -195,7 +195,7 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
       filter.doFilter(mockRequest, null, mockFilterChain)
 
       val capturedRequest = getCapturedRequest
-      capturedRequest.getHeaders("X-Three").toSeq should contain theSameElementsAs Seq("valueOne")
+      capturedRequest.getHeaders("X-Three").toSeq should contain ("valueOne")
       capturedRequest.getHeaders("X-Four").toSeq should contain theSameElementsAs Seq("valueOne", "valueTwo")
     }
   }
@@ -216,7 +216,7 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
 
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      getCapturedRequest.getHeaders("X-New-Five-One").toSeq should contain theSameElementsInOrderAs Seq("mustard", "ketchup", "mayo;q=0.9", "pickles;q=0.1")
+      getCapturedRequest.getHeaders("X-New-Five-One").toSeq should contain inOrderOnly ("mustard", "ketchup", "mayo;q=0.9", "pickles;q=0.1")
     }
 
     it("should correctly handle multiple splittable headers") {
@@ -226,7 +226,7 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
 
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      getCapturedRequest.getHeaders("X-New-Five-One").toSeq should contain theSameElementsInOrderAs Seq("mustard", "ketchup", "mayo;q=0.9", "pickles;q=0.1", "bacon;q=1.0", "cheese;q=0.8")
+      getCapturedRequest.getHeaders("X-New-Five-One").toSeq should contain inOrderOnly ("mustard", "ketchup", "mayo;q=0.9", "pickles;q=0.1", "bacon;q=1.0", "cheese;q=0.8")
     }
   }
 
@@ -237,7 +237,7 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
 
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain theSameElementsAs Seq("mustard;q=0.82")
+      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain ("mustard;q=0.82")
     }
 
     it("removes the original quality before adding the new header") {
@@ -246,7 +246,7 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
 
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain theSameElementsAs Seq("mayo;q=0.82")
+      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain ("mayo;q=0.82")
     }
 
     it("correctly handles non-splittable headers") {
@@ -255,7 +255,7 @@ class HeaderTranslationFilterTest extends FunSpec with BeforeAndAfter with Match
 
       filter.doFilter(mockRequest, null, mockFilterChain)
 
-      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain theSameElementsAs Seq("mustard,mayo,cheese;q=0.82")
+      getCapturedRequest.getHeaders("X-New-Eight-One").toSeq should contain ("mustard,mayo,cheese;q=0.82")
     }
 
     it("correctly handles splittable headers") {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
@@ -1,30 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<header-translation xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
+<header-translation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://docs.openrepose.org/repose/header-translation/v1.0 ../config/header-translation.xsd"
+                    xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
 
-    <header original-name="X-OneToOne-A" new-name="X-OneToOne-C" remove-original="false"/>
-    <header original-name="X-OneToOneRemoval-A" new-name="X-OneToOneRemoval-C" remove-original="true"/>
-    <header original-name="X-OneToMany-A" new-name="X-OneToMany-C X-OneToMany-D" remove-original="false"/>
-    <header original-name="X-OneToManyRemoval-A" new-name="X-OneToManyRemoval-C X-OneToManyRemoval-D"
-            remove-original="true"/>
-
-    <header original-name="X-StripHeader-A" new-name="" remove-original="true"/>
-
-    <header original-name="X-ManyToMany-A" new-name="X-ManyToMany-D" remove-original="false"/>
-    <header original-name="X-ManyToMany-B" new-name="X-ManyToMany-E" remove-original="false"/>
-    <header original-name="X-ManyToMany-C" new-name="X-ManyToMany-F" remove-original="false"/>
-
-    <header original-name="X-ManyToOne-A" new-name="X-ManyToOne-D" remove-original="true"/>
-    <header original-name="X-ManyToOne-B" new-name="X-ManyToOne-D" remove-original="true"/>
-    <header original-name="X-ManyToOne-C" new-name="X-ManyToOne-D" remove-original="true"/>
-
-    <header original-name="X-ToExisting-A" new-name="X-Header-Existing" remove-original="false"/>
-
-    <header original-name="X-mixedcase-A" new-name="X-MIXEDCASE-D" remove-original="false"/>
-    <header original-name="X-Mixedcase-b" new-name="X-Mixedcase-e" remove-original="false"/>
-    <header original-name="X-MIXEDCASE-C" new-name="x-MIXEDCASE-E" remove-original="false"/>
-
-    <!-- CSL headers -->
     <header original-name="x-pp-user" new-name="x-rax-username" quality=".5"/>
     <header original-name="x-tenant-name" new-name="x-rax-tenants"/>
     <header original-name="x-roles" new-name="x-rax-roles" quality=".2"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
@@ -5,6 +5,6 @@
                     xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
 
     <header original-name="x-pp-user" new-name="x-rax-username" quality=".5"/>
-    <header original-name="x-tenant-name" new-name="x-rax-tenants"/>
+    <header original-name="x-tenant-name" new-name="x-rax-tenants" remove-original="true"/>
     <header original-name="x-roles" new-name="x-rax-roles" quality=".2"/>
 </header-translation>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
@@ -25,7 +25,7 @@
     <header original-name="X-MIXEDCASE-C" new-name="x-MIXEDCASE-E" remove-original="false"/>
 
     <!-- CSL headers -->
-    <header original-name="x-pp-user" new-name="x-rax-username"/>
+    <header original-name="x-pp-user" new-name="x-rax-username" quality=".5"/>
     <header original-name="x-tenant-name" new-name="x-rax-tenants"/>
-    <header original-name="x-roles" new-name="x-rax-roles" />
+    <header original-name="x-roles" new-name="x-rax-roles" quality=".2"/>
 </header-translation>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
@@ -7,4 +7,6 @@
     <header original-name="x-pp-user" new-name="x-rax-username" quality=".5"/>
     <header original-name="x-tenant-name" new-name="x-rax-tenants" remove-original="true"/>
     <header original-name="x-roles" new-name="x-rax-roles" quality=".2"/>
+    <header original-name="test-headers" new-name="repose-headers" quality=".3" splittable="true"/>
+    <header original-name="nonsplit-headers" new-name="repose-nonsplit" quality=".2" splittable="false"/>
 </header-translation>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/headertranslation/wquality/header-translation.cfg.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<header-translation xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
+
+    <header original-name="X-OneToOne-A" new-name="X-OneToOne-C" remove-original="false"/>
+    <header original-name="X-OneToOneRemoval-A" new-name="X-OneToOneRemoval-C" remove-original="true"/>
+    <header original-name="X-OneToMany-A" new-name="X-OneToMany-C X-OneToMany-D" remove-original="false"/>
+    <header original-name="X-OneToManyRemoval-A" new-name="X-OneToManyRemoval-C X-OneToManyRemoval-D"
+            remove-original="true"/>
+
+    <header original-name="X-StripHeader-A" new-name="" remove-original="true"/>
+
+    <header original-name="X-ManyToMany-A" new-name="X-ManyToMany-D" remove-original="false"/>
+    <header original-name="X-ManyToMany-B" new-name="X-ManyToMany-E" remove-original="false"/>
+    <header original-name="X-ManyToMany-C" new-name="X-ManyToMany-F" remove-original="false"/>
+
+    <header original-name="X-ManyToOne-A" new-name="X-ManyToOne-D" remove-original="true"/>
+    <header original-name="X-ManyToOne-B" new-name="X-ManyToOne-D" remove-original="true"/>
+    <header original-name="X-ManyToOne-C" new-name="X-ManyToOne-D" remove-original="true"/>
+
+    <header original-name="X-ToExisting-A" new-name="X-Header-Existing" remove-original="false"/>
+
+    <header original-name="X-mixedcase-A" new-name="X-MIXEDCASE-D" remove-original="false"/>
+    <header original-name="X-Mixedcase-b" new-name="X-Mixedcase-e" remove-original="false"/>
+    <header original-name="X-MIXEDCASE-C" new-name="x-MIXEDCASE-E" remove-original="false"/>
+
+    <!-- CSL headers -->
+    <header original-name="x-pp-user" new-name="x-rax-username"/>
+    <header original-name="x-tenant-name" new-name="x-rax-tenants"/>
+    <header original-name="x-roles" new-name="x-rax-roles" />
+</header-translation>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationWQualityTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationWQualityTest.groovy
@@ -27,11 +27,11 @@ import org.rackspace.deproxy.MessageChain
  * Created by jennyvo on 3/22/16.
  *  Header Translation With Quality
  */
-class HeaderTranslationWQualityTest extends ReposeValveTest{
+class HeaderTranslationWQualityTest extends ReposeValveTest {
     def static Map params = [:]
     def static originEndpoint
 
-    def setupSpec () {
+    def setupSpec() {
         deproxy = new Deproxy()
         originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
 
@@ -52,7 +52,7 @@ class HeaderTranslationWQualityTest extends ReposeValveTest{
         }
     }
 
-    def "When translate header with quality" () {
+    def "When translate header with quality"() {
 
         when: "Send request with headers to translate"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: "GET", headers:
@@ -71,7 +71,7 @@ class HeaderTranslationWQualityTest extends ReposeValveTest{
         reposehandling.request.headers.getFirstValue("x-pp-user") == "a"
     }
 
-    def "the original header is splittable by default, all new translated headers will be added with quality" () {
+    def "the original header is splittable by default, all new translated headers will be added with quality"() {
         when: "client passes a request through repose with headers to be translated"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: "GET",
                 headers: ["x-pp-user"    : "test, repose",
@@ -88,7 +88,7 @@ class HeaderTranslationWQualityTest extends ReposeValveTest{
         reposehandling.request.getHeaders().getFirstValue("x-roles") == "test"
     }
 
-    def "when translation header quality in config should override quality from header" () {
+    def "when translation header quality in config should override quality from header"() {
 
         when: "client passes a request through repose with headers to be translated"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: "GET",
@@ -110,7 +110,7 @@ class HeaderTranslationWQualityTest extends ReposeValveTest{
         reposehandling.request.getHeaders().getFirstValue("x-roles") == "c;q=0.3"
     }
 
-    def "when translation header with different quality header" () {
+    def "when translation header with different quality header"() {
 
         when: "client passes a request through repose with headers to be translated"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: "GET",
@@ -134,10 +134,10 @@ class HeaderTranslationWQualityTest extends ReposeValveTest{
         reposehandling.request.getHeaders().getFirstValue("x-roles") == "test"
     }
 
-    def "Verify splittable option with non split by default header, all new translated headers will be added with quality" () {
+    def "Verify splittable option with non split by default header, all new translated headers will be added with quality"() {
         when: "client passes a request through repose with headers to be translated"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: "GET",
-                headers: ["test-headers" : "test, repose",
+                headers: ["test-headers"    : "test, repose",
                           "nonsplit-headers": "a, b, c",]
         )
         def reposehandling = mc.getHandlings()[0]

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationWQualityTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationWQualityTest.groovy
@@ -1,0 +1,51 @@
+package features.filters.headertranslation
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import spock.lang.Unroll
+
+/**
+ * Created by jennyvo on 3/21/16.
+ */
+class HeaderTranslationWQualityTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort)
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/headertranslation/common", params)
+        repose.configurationProvider.applyConfigs("features/filters/headertranslation/wquality", params)
+        repose.start()
+    }
+
+    def cleanupSpec() {
+        deproxy.shutdown()
+        repose.stop()
+    }
+    @Unroll("Request Verb: #method Headers: #reqHeaders")
+    def "when translating CSL request headers"() {
+
+        when: "client passes a request through repose with headers to be translated"
+        def respFromOrigin = deproxy.makeRequest(url: (String) reposeEndpoint, method: method, headers: reqHeaders)
+        def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
+
+        then: "origin receives translated headers"
+        sentRequest.request.getHeaders().contains("x-rax-username")
+        sentRequest.request.getHeaders().getFirstValue("x-rax-username") == "a;q=0.5"
+        sentRequest.request.getHeaders().contains("x-rax-tenants")
+        sentRequest.request.getHeaders().getFirstValue("x-rax-tenants") == "b"
+        sentRequest.request.getHeaders().contains("x-rax-roles")
+        sentRequest.request.getHeaders().getFirstValue("x-rax-roles") == "c;q=0.2"
+        sentRequest.request.getHeaders().contains("x-pp-user")
+        sentRequest.request.getHeaders().contains("x-tenant-name")
+        sentRequest.request.getHeaders().contains("x-roles")
+
+        where:
+        method | reqHeaders
+        "POST" | ["x-pp-user": "a", "x-tenant-name": "b", "x-roles": "c"]
+        "GET"  | ["x-pp-user": "a", "x-tenant-name": "b", "x-roles": "c"]
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationWQualityTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationWQualityTest.groovy
@@ -26,30 +26,85 @@ import spock.lang.Unroll
 
 /**
  * Created by jennyvo on 3/21/16.
+ *  Header translation with quality test
  */
 class HeaderTranslationWQualityTest extends ReposeValveTest {
+    def static Map params = [:]
+    def static originEndpoint
 
     def setupSpec() {
         deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.targetPort)
+        originEndpoint = deproxy.addEndpoint(properties.targetPort, 'origin service')
 
-        def params = properties.defaultTemplateParams
-        repose.configurationProvider.applyConfigs("common", params)
-        repose.configurationProvider.applyConfigs("features/filters/headertranslation/common", params)
-        repose.configurationProvider.applyConfigs("features/filters/headertranslation/wquality", params)
+        params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/filters/headertranslation/common", params);
+        repose.configurationProvider.applyConfigs("features/filters/headertranslation/wquality", params);
         repose.start()
     }
 
     def cleanupSpec() {
-        deproxy.shutdown()
-        repose.stop()
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+
+        if (repose) {
+            repose.stop()
+        }
     }
-    @Unroll("Request Verb: #method Headers: #reqHeaders")
-    def "when translating CSL request headers"() {
+
+    def "when translation header quality in config should override quality from header" () {
 
         when: "client passes a request through repose with headers to be translated"
-        def respFromOrigin = deproxy.makeRequest(url: (String) reposeEndpoint, method: method, headers: reqHeaders)
-        def sentRequest = ((MessageChain) respFromOrigin).getHandlings()[0]
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: "GET",
+                headers: ["x-pp-user"    : "a",
+                          "x-tenant-name": "b",
+                          "x-roles"      : "c;q=0.3"]
+        )
+
+        def sentRequest = mc.getHandlings()[0]
+
+        then: "origin receives translated headers"
+        sentRequest.request.getHeaders().contains("x-rax-username")
+        sentRequest.request.getHeaders().contains("x-rax-tenants")
+        sentRequest.request.getHeaders().contains("x-rax-roles")
+        sentRequest.request.getHeaders().getFirstValue("x-rax-roles") == "c;q=0.2"
+        sentRequest.request.getHeaders().contains("x-pp-user")
+        sentRequest.request.getHeaders().contains("x-tenant-name")
+        sentRequest.request.getHeaders().contains("x-roles")
+        sentRequest.request.getHeaders().getFirstValue("x-roles") == "c;q=0.3"
+    }
+
+    def "when translation header with different quality header" () {
+
+        when: "client passes a request through repose with headers to be translated"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: "GET",
+                headers: ["x-pp-user"    : "a",
+                          "x-tenant-name": "b",
+                          "x-roles"      : "test",
+                          "x-rax-roles"  : "test;q=0.5"]
+        )
+
+        def sentRequest = mc.getHandlings()[0]
+
+        then: "origin receives translated headers"
+        sentRequest.request.getHeaders().contains("x-rax-username")
+        sentRequest.request.getHeaders().contains("x-rax-tenants")
+        sentRequest.request.getHeaders().contains("x-rax-roles")
+        sentRequest.request.getHeaders().findAll("x-rax-roles").contains("test;q=0.2")
+        sentRequest.request.getHeaders().findAll("x-rax-roles").contains("test;q=0.5")
+        sentRequest.request.getHeaders().contains("x-pp-user")
+        sentRequest.request.getHeaders().contains("x-tenant-name")
+        sentRequest.request.getHeaders().contains("x-roles")
+        sentRequest.request.getHeaders().getFirstValue("x-roles") == "test"
+    }
+
+    @Unroll("Request with: #method Headers: #reqHeaders")
+    def "when translating request headers with quality"() {
+
+        when: "client passes a request through repose with headers to be translated"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: method, headers: reqHeaders)
+        def sentRequest = mc.getHandlings()[0]
 
         then: "origin receives translated headers"
         sentRequest.request.getHeaders().contains("x-rax-username")

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationWQualityTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/headertranslation/HeaderTranslationWQualityTest.groovy
@@ -1,3 +1,22 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
 package features.filters.headertranslation
 
 import framework.ReposeValveTest


### PR DESCRIPTION
I added "quality" and "splittable" attributes to the header config item for the Header Translation filter.  The filter now supports adding a quality parameter to the headers it creates (while not carrying over any quality parameter that was on the original header value).  If no "quality" attribute is specified, none is added (i.e. the quality parameter on the original header will be used if it exists).

In case the header is splittable, a config item was added to have the filter split the header values before applying a new quality when creating the new headers.