### PR TITLE
REP-3393 Make our identity URLs in config consistent

### DIFF
--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-filter/src/main/resources/META-INF/schema/config/rackspace-identity-basic-auth.xsd
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-filter/src/main/resources/META-INF/schema/config/rackspace-identity-basic-auth.xsd
@@ -44,8 +44,9 @@
         <xs:attribute name="rackspace-identity-service-uri" type="xs:anyURI" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    <html:p>The target Rackspace Identity endpoint URI for credential requests including host, port, and
-                        path to service.
+                    <html:p>
+                        The target Rackspace Identity endpoint URI for credential requests including scheme, host,
+                        and port to service.
                     </html:p>
                 </xs:documentation>
             </xs:annotation>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-filter/src/main/resources/META-INF/schema/examples/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-filter/src/main/resources/META-INF/schema/examples/rackspace-identity-basic-auth.cfg.xml
@@ -2,7 +2,7 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://identity.example.com:8080/v2.0/tokens"
+        rackspace-identity-service-uri="http://identity.example.com:8080"
         token-cache-timeout-millis="600000"
         connection-pool-id="basic-auth-pool"
         secret-type="api-key"/>

--- a/repose-aggregator/components/filters/rackspace-identity-basic-auth-filter/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauth/RackspaceIdentityBasicAuthFilter.scala
+++ b/repose-aggregator/components/filters/rackspace-identity-basic-auth-filter/src/main/scala/org/openrepose/filters/rackspaceidentitybasicauth/RackspaceIdentityBasicAuthFilter.scala
@@ -56,6 +56,7 @@ class RackspaceIdentityBasicAuthFilter @Inject()(configurationService: Configura
     with LazyLogging {
 
   private final val DEFAULT_CONFIG = "rackspace-identity-basic-auth.cfg.xml"
+  private final val TOKEN_ENDPOINT = "/v2.0/tokens"
   private final val TOKEN_KEY_PREFIX = "TOKEN:"
   private final val X_AUTH_TOKEN = "X-Auth-Token"
   private final val SC_TOO_MANY_REQUESTS = 429
@@ -208,7 +209,7 @@ class RackspaceIdentityBasicAuthFilter @Inject()(configurationService: Configura
         val requestTracingHeader = Option(httpServletRequestWrapper.getHeader(CommonHttpHeader.TRACE_GUID.toString))
           .map(guid => Map(CommonHttpHeader.TRACE_GUID.toString -> guid)).getOrElse(Map())
         val authTokenResponse = Option(akkaServiceClient.post(authValue,
-          identityServiceUri,
+          identityServiceUri + TOKEN_ENDPOINT,
           requestTracingHeader.asJava,
           createAuthRequest(authValue).toString(),
           MediaType.APPLICATION_XML_TYPE))

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/rackspace-identity-basic-auth.cfg.xml
@@ -2,5 +2,5 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="0"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/apivalidatormultimatch/wauthpreference/wbasicauth/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/herp/apivalidatormultimatch/wauthpreference/wbasicauth/rackspace-identity-basic-auth.cfg.xml
@@ -2,7 +2,7 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="0">
     <delegating quality=".7"/>
 </rackspace-identity-basic-auth>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/diffpool/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/diffpool/rackspace-identity-basic-auth.cfg.xml
@@ -2,6 +2,6 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="0"
         connection-pool-id="basicauth"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/nopool/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/nopool/rackspace-identity-basic-auth.cfg.xml
@@ -2,5 +2,5 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="0"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/akkatimeout/rackspace-identity-basic-auth.cfg.xml
@@ -2,6 +2,6 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="0"
         connection-pool-id="basicauth-pool"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/cache/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/cache/rackspace-identity-basic-auth.cfg.xml
@@ -2,5 +2,5 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="2000"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/delegating/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/delegating/rackspace-identity-basic-auth.cfg.xml
@@ -2,7 +2,7 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="0">
     <delegating quality="0.2"/>
 </rackspace-identity-basic-auth>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/rackspace-identity-basic-auth.cfg.xml
@@ -2,5 +2,5 @@
 
 <rackspace-identity-basic-auth
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="0"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/wpassword/rackspace-identity-basic-auth.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/filters/identitybasicauth/wpassword/rackspace-identity-basic-auth.cfg.xml
@@ -2,5 +2,5 @@
 
 <rackspace-identity-basic-auth secret-type="password"
         xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
-        rackspace-identity-service-uri="http://localhost:${identityPort}/tokens"
+        rackspace-identity-service-uri="http://localhost:${identityPort}"
         token-cache-timeout-millis="0"/>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/framework/mocks/MockIdentityV2Service.groovy
@@ -288,7 +288,7 @@ class MockIdentityV2Service {
             query = null
             nonQueryPath = path
         }
-        if (isGenerateTokenCallPath(nonQueryPath) || isBasicAuthTokenCallPath(nonQueryPath)) {
+        if (isGenerateTokenCallPath(nonQueryPath)) {
             if (method == "POST") {
                 _generateTokenCount.incrementAndGet()
                 return generateTokenHandler(request, xml);
@@ -412,9 +412,10 @@ class MockIdentityV2Service {
      * @param nonQueryPath
      * @return true/false
      */
-    public static boolean isBasicAuthTokenCallPath(String nonQueryPath) {
-        return nonQueryPath == "/tokens"
-    }
+    //We fix uri for identity call
+    //public static boolean isBasicAuthTokenCallPath(String nonQueryPath) {
+    //    return nonQueryPath == "/v2.0/tokens"
+    //}
 
     /**
      * Check Path start with /v2.0/tokens


### PR DESCRIPTION
Only the rackspace-identity-basic-auth filter needed to be updated. All of the others expected just scheme, host, and port -- not the path.

Before this gets merged, the task to talk to users to make sure we aren't breaking their proxies should be completed.