### PR TITLE
Moved time bombs (repose-8-staging branch)

### DIFF
--- a/repose-aggregator/components/filters/rate-limiting-filter/src/test/java/org/openrepose/filters/ratelimiting/RateLimitingHandlerTest.java
+++ b/repose-aggregator/components/filters/rate-limiting-filter/src/test/java/org/openrepose/filters/ratelimiting/RateLimitingHandlerTest.java
@@ -75,7 +75,7 @@ public class RateLimitingHandlerTest extends RateLimitingTestSupport {
 
     public static class WhenMakingValidRequests extends TestParent {
         private final ConfiguredRatelimit defaultConfig = new ConfiguredRatelimit();
-        private GregorianCalendar splodeDate = new GregorianCalendar(2016, Calendar.APRIL, 4);
+        private GregorianCalendar splodeDate = new GregorianCalendar(2016, Calendar.JULY, 5);
 
         @Before
         public void setup() {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/classloader/ClassLoaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/classloader/ClassLoaderTest.groovy
@@ -37,7 +37,7 @@ class ClassLoaderTest extends ReposeValveTest {
      * Unfortunately this tests requires the Servlet Filter Contract to actually be upheld,
      * Repose doesn't do this, so we're setting a timebomb that will make the tests fail at a later date
      */
-    def splodeDate = new GregorianCalendar(2016, Calendar.APRIL, 4)
+    def splodeDate = new GregorianCalendar(2016, Calendar.JULY, 5)
 
     /**
      * copy the bundle from /repose-aggregator/functional-tests/test-bundles/bundle-one/target/

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/experimental/servletContract/ServletContractFilterTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/experimental/servletContract/ServletContractFilterTest.groovy
@@ -27,8 +27,6 @@ import org.rackspace.deproxy.Response
 
 class ServletContractFilterTest extends ReposeValveTest {
 
-    def splodeDate = new GregorianCalendar(2016, Calendar.APRIL, 4)
-
     /**
      * This test fails because repose does not properly support the servlet filter contract.
      * It should not fail.
@@ -40,8 +38,6 @@ class ServletContractFilterTest extends ReposeValveTest {
      */
     def "Proving that a custom filter (although tightly coupled) does in fact work"() {
         setup:
-        Assume.assumeTrue(new Date() > splodeDate.getTime())
-
         def params = properties.defaultTemplateParams
         repose.configurationProvider.applyConfigs("common", params)
         repose.configurationProvider.applyConfigs("features/filters/experimental/servletcontract", params)


### PR DESCRIPTION
I moved the time bombs for:
- RateLimitingHandlerTest
- ClassLoaderTest

Time bombs no longer needed (and thus removed on this branch):
- ServletContractFilterTest

Time bombs no longer existed for:
- VersioningHandlerTest