### PR TITLE
Moved time bombs to July

### DIFF
--- a/repose-aggregator/components/filters/rate-limiting/src/test/java/org/openrepose/filters/ratelimiting/RateLimitingHandlerTest.java
+++ b/repose-aggregator/components/filters/rate-limiting/src/test/java/org/openrepose/filters/ratelimiting/RateLimitingHandlerTest.java
@@ -88,7 +88,7 @@ public class RateLimitingHandlerTest extends RateLimitingTestSupport {
 
     public static class WhenMakingValidRequests extends TestParent {
         private final ConfiguredRatelimit defaultConfig = new ConfiguredRatelimit();
-        private GregorianCalendar splodeDate = new GregorianCalendar(2016, Calendar.APRIL, 4);
+        private GregorianCalendar splodeDate = new GregorianCalendar(2016, Calendar.JULY, 5);
 
         @Before
         public void setup() {

--- a/repose-aggregator/components/filters/versioning/src/test/java/org/openrepose/filters/versioning/VersioningHandlerTest.java
+++ b/repose-aggregator/components/filters/versioning/src/test/java/org/openrepose/filters/versioning/VersioningHandlerTest.java
@@ -58,7 +58,7 @@ public class VersioningHandlerTest {
     Node localHost;
     DestinationEndpoint localEndpoint;
     HttpServletRequest request;
-    private GregorianCalendar splodeDate = new GregorianCalendar(2016, Calendar.APRIL, 4);
+    private GregorianCalendar splodeDate = new GregorianCalendar(2016, Calendar.JULY, 5);
 
     @Before
     public void setUp() {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/classloader/ClassLoaderTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/classloader/ClassLoaderTest.groovy
@@ -37,7 +37,7 @@ class ClassLoaderTest extends ReposeValveTest {
      * Unfortunately this tests requires the Servlet Filter Contract to actually be upheld,
      * Repose doesn't do this, so we're setting a timebomb that will make the tests fail at a later date
      */
-    def splodeDate = new GregorianCalendar(2016, Calendar.APRIL, 4)
+    def splodeDate = new GregorianCalendar(2016, Calendar.JULY, 5)
 
     /**
      * copy the bundle from /repose-aggregator/functional-tests/test-bundles/bundle-one/target/

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/experimental/servletContract/ServletContractFilterTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/filters/experimental/servletContract/ServletContractFilterTest.groovy
@@ -27,7 +27,7 @@ import org.rackspace.deproxy.Response
 
 class ServletContractFilterTest extends ReposeValveTest {
 
-    def splodeDate = new GregorianCalendar(2016, Calendar.APRIL, 4)
+    def splodeDate = new GregorianCalendar(2016, Calendar.JULY, 5)
 
     /**
      * This test fails because repose does not properly support the servlet filter contract.


### PR DESCRIPTION
Moved time bombs to July 5 (Tuesday).

Of note, one of these won't exist in Repose 8 and another one is fixed, but I updated anyway to get master working.