### PR TITLE
REP-3573 - Intra-filter logging wrapper updates

### DIFF
--- a/repose-aggregator/commons/commons-utilities/src/main/java/org/openrepose/commons/utils/io/buffer/CyclicByteBuffer.java
+++ b/repose-aggregator/commons/commons-utilities/src/main/java/org/openrepose/commons/utils/io/buffer/CyclicByteBuffer.java
@@ -159,6 +159,11 @@ public class CyclicByteBuffer implements ByteBuffer, Cloneable {
 
     @Override
     public int put(byte[] b, int off, int len) {
+        if (len == 0) {
+            // nothing to do - especially don't change "hasElements"
+            return 0;
+        }
+
         allocate();
         final int remaining = remaining();
 

--- a/repose-aggregator/commons/commons-utilities/src/test/java/org/openrepose/commons/utils/servlet/http/MutableHttpServletResponseTest.java
+++ b/repose-aggregator/commons/commons-utilities/src/test/java/org/openrepose/commons/utils/servlet/http/MutableHttpServletResponseTest.java
@@ -131,18 +131,6 @@ public class MutableHttpServletResponseTest {
 
             assertNotNull(actual.getWriter());
         }
-
-        @Test
-        public void shouldGetOutputQueue() {
-            HttpServletResponse response = mock(HttpServletResponse.class);
-            HttpServletRequest request = mock(HttpServletRequest.class);
-            MutableHttpServletResponse actual;
-
-            actual = MutableHttpServletResponse.wrap(request, response);
-            verify(request).getAttribute(eq("repose.response.output.queue"));
-            verify(request).setAttribute(eq("repose.response.output.queue"), anyObject());
-
-        }
     }
 
     public static class WhenGettingAndSettingInputStream {

--- a/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilter.java
+++ b/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilter.java
@@ -405,6 +405,7 @@ public class PowerFilter extends DelegatingFilterProxy {
             // In the case where we pass/route the request, there is a chance that
             // the response will be committed by an underlying service, outside of repose
             if (!mutableHttpResponse.isCommitted()) {
+                mutableHttpResponse.flushWriter();  // total hack because of the old wrapper; remove it when we go to the new wrapper
                 responseMessageService.handle(mutableHttpRequest, mutableHttpResponse);
                 responseHeaderService.setVia(mutableHttpRequest, mutableHttpResponse);
             }

--- a/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
+++ b/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
@@ -241,7 +241,8 @@ public class PowerFilterChain implements FilterChain {
 
     private String intrafilterResponseLog(
             HttpServletResponseWrapper wrappedServletResponse,
-            FilterContext filterContext, String uuid) throws IOException {
+            FilterContext filterContext,
+            String uuid) throws IOException {
 
         // if the response doesn't already have a UUID, give it the UUID passed to this method
         if (StringUtils.isEmpty(wrappedServletResponse.getHeader(INTRAFILTER_UUID))) {

--- a/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
+++ b/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
@@ -29,10 +29,7 @@ import org.openrepose.commons.utils.http.PowerApiHeader;
 import org.openrepose.commons.utils.http.header.HeaderFieldParser;
 import org.openrepose.commons.utils.http.header.HeaderValue;
 import org.openrepose.commons.utils.http.header.SplittableHeaderUtil;
-import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper;
-import org.openrepose.commons.utils.servlet.http.HttpServletResponseWrapper;
-import org.openrepose.commons.utils.servlet.http.MutableHttpServletRequest;
-import org.openrepose.commons.utils.servlet.http.MutableHttpServletResponse;
+import org.openrepose.commons.utils.servlet.http.*;
 import org.openrepose.core.FilterProcessingTime;
 import org.openrepose.core.services.reporting.metrics.MetricsService;
 import org.openrepose.core.services.reporting.metrics.TimerByCategory;
@@ -181,58 +178,61 @@ public class PowerFilterChain implements FilterChain {
         return response.getStatus() < HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
     }
 
-    private void doReposeFilter(MutableHttpServletRequest mutableHttpRequest, ServletResponse servletResponse,
-                                FilterContext filterContext) throws IOException, ServletException {
-        final MutableHttpServletResponse mutableHttpResponse =
-                MutableHttpServletResponse.wrap(mutableHttpRequest, (HttpServletResponse) servletResponse);
-
-        mutableHttpResponse.pushOutputStream();
+    private void doReposeFilter(
+            ServletRequest servletRequest,
+            ServletResponse servletResponse,
+            FilterContext filterContext) throws IOException, ServletException {
+        HttpServletRequestWrapper wrappedServletRequest = new HttpServletRequestWrapper((HttpServletRequest) servletRequest);
+        HttpServletResponse maybeWrappedServletResponse = (HttpServletResponse) servletResponse;
 
         try {
             if (INTRAFILTER_LOG.isTraceEnabled()) {
+                maybeWrappedServletResponse = new HttpServletResponseWrapper(
+                        maybeWrappedServletResponse, ResponseMode.PASSTHROUGH, ResponseMode.READONLY);
                 // log the request, and give it a new UUID if it doesn't already have one
-                UUID intrafilterUuid = UUID.randomUUID();
-                INTRAFILTER_LOG.trace(intrafilterRequestLog(mutableHttpRequest, filterContext, intrafilterUuid));
+                INTRAFILTER_LOG.trace(intrafilterRequestLog(wrappedServletRequest, filterContext));
             }
 
-            filterContext.getFilter().doFilter(mutableHttpRequest, mutableHttpResponse, this);
+            filterContext.getFilter().doFilter(wrappedServletRequest, maybeWrappedServletResponse, this);
 
             if (INTRAFILTER_LOG.isTraceEnabled()) {
                 // log the response, and give it the request's UUID if the response didn't already have one
-                INTRAFILTER_LOG.trace(intrafilterResponseLog(mutableHttpResponse, filterContext,
-                        mutableHttpRequest.getHeader(INTRAFILTER_UUID)));
+                INTRAFILTER_LOG.trace(intrafilterResponseLog(
+                        (HttpServletResponseWrapper) maybeWrappedServletResponse,
+                        filterContext,
+                        wrappedServletRequest.getHeader(INTRAFILTER_UUID)));
             }
         } catch (Exception ex) {
             String filterName = filterContext.getFilter().getClass().getSimpleName();
             LOG.error("Failure in filter: " + filterName + "  -  Reason: " + ex.getMessage(), ex);
-            mutableHttpResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        } finally {
-            mutableHttpResponse.popOutputStream();
+            maybeWrappedServletResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
     }
 
-    private String intrafilterRequestLog(MutableHttpServletRequest mutableHttpRequest,
-                                         FilterContext filterContext, UUID uuid) throws IOException {
+    private String intrafilterRequestLog(
+            HttpServletRequestWrapper wrappedServletRequest,
+            FilterContext filterContext) throws IOException {
 
-        // if the request doesn't already have a UUID, give it the UUID passed to this method
-        if (StringUtils.isEmpty(mutableHttpRequest.getHeader(INTRAFILTER_UUID))) {
-            mutableHttpRequest.addHeader(INTRAFILTER_UUID, uuid.toString());
+        // if the request doesn't already have a UUID, give it a new UUID
+        if (StringUtils.isEmpty(wrappedServletRequest.getHeader(INTRAFILTER_UUID))) {
+            wrappedServletRequest.addHeader(INTRAFILTER_UUID, UUID.randomUUID().toString());
         }
 
-        RequestLog requestLog = new RequestLog(mutableHttpRequest, filterContext);
+        RequestLog requestLog = new RequestLog(wrappedServletRequest, filterContext.getFilterConfig());
 
         return convertPojoToJsonString(requestLog);
     }
 
-    private String intrafilterResponseLog(MutableHttpServletResponse mutableHttpResponse,
-                                          FilterContext filterContext, String uuid) throws IOException {
+    private String intrafilterResponseLog(
+            HttpServletResponseWrapper wrappedServletResponse,
+            FilterContext filterContext, String uuid) throws IOException {
 
         // if the response doesn't already have a UUID, give it the UUID passed to this method
-        if (StringUtils.isEmpty(mutableHttpResponse.getHeader(INTRAFILTER_UUID))) {
-            mutableHttpResponse.addHeader(INTRAFILTER_UUID, uuid);
+        if (StringUtils.isEmpty(wrappedServletResponse.getHeader(INTRAFILTER_UUID))) {
+            wrappedServletResponse.addHeader(INTRAFILTER_UUID, uuid);
         }
 
-        ResponseLog responseLog = new ResponseLog(mutableHttpResponse, filterContext);
+        ResponseLog responseLog = new ResponseLog(wrappedServletResponse, filterContext.getFilterConfig());
 
         return convertPojoToJsonString(responseLog);
     }

--- a/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/intrafilterLogging/RequestLog.java
+++ b/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/intrafilterLogging/RequestLog.java
@@ -53,7 +53,7 @@ public class RequestLog {
             requestBody = IOUtils.toString(inputStream); //http://stackoverflow.com/a/309448
             inputStream.reset();
         } else {
-            throw new RuntimeException("Servlet input stream does not support mark/reset: " + inputStream);
+            throw new IllegalArgumentException("Servlet input stream does not support mark/reset: " + inputStream);
         }
     }
 

--- a/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/intrafilterLogging/RequestLog.java
+++ b/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/intrafilterLogging/RequestLog.java
@@ -53,7 +53,7 @@ public class RequestLog {
             requestBody = IOUtils.toString(inputStream); //http://stackoverflow.com/a/309448
             inputStream.reset();
         } else {
-            throw new RuntimeException("Servlet input stream does not support mark/reset.");
+            throw new RuntimeException("Servlet input stream does not support mark/reset: " + inputStream);
         }
     }
 

--- a/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/intrafilterLogging/RequestLog.java
+++ b/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/intrafilterLogging/RequestLog.java
@@ -22,11 +22,10 @@ package org.openrepose.powerfilter.intrafilterLogging;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
-import org.openrepose.commons.utils.servlet.http.MutableHttpServletRequest;
 import org.openrepose.core.systemmodel.Filter;
-import org.openrepose.powerfilter.filtercontext.FilterContext;
 
 import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.*;
 
@@ -38,41 +37,34 @@ public class RequestLog {
     String httpMethod;
     String requestURI;
     String requestBody;
-    HashMap<String, String> headers;
+    Map<String, String> headers;
 
-    public RequestLog(MutableHttpServletRequest mutableHttpServletRequest,
-                      FilterContext filterContext) throws IOException {
-
-        Filter filter = filterContext.getFilterConfig();
-
+    public RequestLog(HttpServletRequest httpServletRequest, Filter filter) throws IOException {
         preamble = "Intrafilter Request Log";
         timestamp = new DateTime().toString();
         currentFilter = StringUtils.isEmpty(filter.getId()) ? filter.getName() : filter.getId() + "-" + filter.getName();
-        httpMethod = mutableHttpServletRequest.getMethod();
-        requestURI = mutableHttpServletRequest.getRequestURI();
-        headers = convertRequestHeadersToMap(mutableHttpServletRequest);
+        httpMethod = httpServletRequest.getMethod();
+        requestURI = httpServletRequest.getRequestURI();
+        headers = convertRequestHeadersToMap(httpServletRequest);
 
-        //Have to wrap the input stream in something that can be buffered, as well as reset.
-        ServletInputStream bin = mutableHttpServletRequest.getInputStream();
-        bin.mark(Integer.MAX_VALUE); //Something doesn't support mark reset
-        requestBody = IOUtils.toString(bin); //http://stackoverflow.com/a/309448
-        bin.reset();
+        ServletInputStream inputStream = httpServletRequest.getInputStream();
+        if (inputStream.markSupported()) {
+            inputStream.mark(Integer.MAX_VALUE);
+            requestBody = IOUtils.toString(inputStream); //http://stackoverflow.com/a/309448
+            inputStream.reset();
+        } else {
+            throw new RuntimeException("Servlet input stream does not support mark/reset.");
+        }
     }
 
-    private HashMap<String, String> convertRequestHeadersToMap(
-            MutableHttpServletRequest mutableHttpServletRequest) {
-
-        HashMap<String, String> headerMap = new LinkedHashMap<>();
-        List<String> headerNames = Collections.list(mutableHttpServletRequest.getHeaderNames());
+    private Map<String, String> convertRequestHeadersToMap(HttpServletRequest httpServletRequest) {
+        Map<String, String> headerMap = new LinkedHashMap<>();
+        List<String> headerNames = Collections.list(httpServletRequest.getHeaderNames());
 
         for (String headerName : headerNames) {
-            StringBuilder allHeaderValues = new StringBuilder();
-            for (String value : Collections.list(mutableHttpServletRequest.getHeaders(headerName))) {
-                allHeaderValues.append(value).append(",");
-            }
-            //Clobber the last character
-            allHeaderValues.deleteCharAt(allHeaderValues.length() - 1);
-            headerMap.put(headerName, allHeaderValues.toString());
+            StringJoiner stringJoiner = new StringJoiner(",");
+            Collections.list(httpServletRequest.getHeaders(headerName)).forEach(stringJoiner::add);
+            headerMap.put(headerName, stringJoiner.toString());
         }
 
         return headerMap;

--- a/repose-aggregator/core/repose-core/src/test/scala/org/openrepose/powerfilter/intrafilterLogging/RequestLogTest.scala
+++ b/repose-aggregator/core/repose-core/src/test/scala/org/openrepose/powerfilter/intrafilterLogging/RequestLogTest.scala
@@ -23,9 +23,8 @@ import java.io.ByteArrayInputStream
 
 import org.junit.runner.RunWith
 import org.openrepose.commons.utils.io.BufferedServletInputStream
-import org.openrepose.commons.utils.servlet.http.MutableHttpServletRequest
+import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 import org.openrepose.core.systemmodel.Filter
-import org.openrepose.powerfilter.filtercontext.FilterContext
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
 import org.scalatest.junit.JUnitRunner
@@ -37,17 +36,15 @@ class RequestLogTest extends FunSpec with Matchers with MockitoSugar with Before
 
   import org.mockito.Mockito.when
 
-  var mutableHttpServletRequest: MutableHttpServletRequest = _
-  var filterContext: FilterContext = _
+  var httpServletRequestWrapper: HttpServletRequestWrapper = _
   val dummyInputStream = new BufferedServletInputStream(new ByteArrayInputStream(" ".getBytes))
 
   before {
-    mutableHttpServletRequest = mock[MutableHttpServletRequest]
-    filterContext = mock[FilterContext]
+    httpServletRequestWrapper = mock[HttpServletRequestWrapper]
 
     // the code under test makes some static method calls, so we gotta do this mess
-    when(mutableHttpServletRequest.getInputStream).thenReturn(dummyInputStream)
-    when(mutableHttpServletRequest.getHeaderNames).thenReturn(Iterator[String]().asJavaEnumeration)
+    when(httpServletRequestWrapper.getInputStream).thenReturn(dummyInputStream)
+    when(httpServletRequestWrapper.getHeaderNames).thenReturn(Iterator[String]().asJavaEnumeration)
   }
 
   describe("a request log") {
@@ -62,10 +59,8 @@ class RequestLogTest extends FunSpec with Matchers with MockitoSugar with Before
         filter.setId(filterId)
         filter.setName(filterName)
 
-        when(filterContext.getFilterConfig).thenReturn(filter)
-
         // when we create a new RequestLog
-        val requestLog = new RequestLog(mutableHttpServletRequest, filterContext)
+        val requestLog = new RequestLog(httpServletRequestWrapper, filter)
 
         // then the filter description includes both the ID and name
         s"$filterId-$filterName" shouldEqual requestLog.currentFilter
@@ -80,10 +75,8 @@ class RequestLogTest extends FunSpec with Matchers with MockitoSugar with Before
         filter.setId(filterId)
         filter.setName(filterName)
 
-        when(filterContext.getFilterConfig).thenReturn(filter)
-
         // when we create a new RequestLog
-        val requestLog = new RequestLog(mutableHttpServletRequest, filterContext)
+        val requestLog = new RequestLog(httpServletRequestWrapper, filter)
 
         // then the filter description includes just the filter name
         filterName shouldEqual requestLog.currentFilter
@@ -98,10 +91,8 @@ class RequestLogTest extends FunSpec with Matchers with MockitoSugar with Before
         filter.setId(filterId)
         filter.setName(filterName)
 
-        when(filterContext.getFilterConfig).thenReturn(filter)
-
         // when we create a new RequestLog
-        val requestLog = new RequestLog(mutableHttpServletRequest, filterContext)
+        val requestLog = new RequestLog(httpServletRequestWrapper, filter)
 
         // then the filter description includes just the filter name
         filterName shouldEqual requestLog.currentFilter

--- a/repose-aggregator/core/repose-core/src/test/scala/org/openrepose/powerfilter/intrafilterLogging/RequestLogTest.scala
+++ b/repose-aggregator/core/repose-core/src/test/scala/org/openrepose/powerfilter/intrafilterLogging/RequestLogTest.scala
@@ -123,7 +123,7 @@ class RequestLogTest extends FunSpec with Matchers with MockitoSugar with Before
         when(unsupportedInputStream.markSupported()).thenReturn(false)
         when(httpServletRequestWrapper.getInputStream).thenReturn(unsupportedInputStream)
 
-        a [RuntimeException] should be thrownBy new RequestLog(httpServletRequestWrapper, filter)
+        a [IllegalArgumentException] should be thrownBy new RequestLog(httpServletRequestWrapper, filter)
       }
     }
 

--- a/repose-aggregator/core/repose-core/src/test/scala/org/openrepose/powerfilter/intrafilterLogging/ResponseLogTest.scala
+++ b/repose-aggregator/core/repose-core/src/test/scala/org/openrepose/powerfilter/intrafilterLogging/ResponseLogTest.scala
@@ -22,9 +22,8 @@ package org.openrepose.powerfilter.intrafilterLogging
 import java.io.ByteArrayInputStream
 
 import org.junit.runner.RunWith
-import org.openrepose.commons.utils.servlet.http.MutableHttpServletResponse
+import org.openrepose.commons.utils.servlet.http.HttpServletResponseWrapper
 import org.openrepose.core.systemmodel.Filter
-import org.openrepose.powerfilter.filtercontext.FilterContext
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
@@ -34,16 +33,14 @@ class ResponseLogTest extends FunSpec with Matchers with MockitoSugar with Befor
 
   import org.mockito.Mockito.when
 
-  var mutableHttpServletResponse: MutableHttpServletResponse = _
-  var filterContext: FilterContext = _
+  var httpServletResponseWrapper: HttpServletResponseWrapper = _
   val dummyInputStream = new ByteArrayInputStream(" ".getBytes)
 
   before {
-    mutableHttpServletResponse = mock[MutableHttpServletResponse]
-    filterContext = mock[FilterContext]
+    httpServletResponseWrapper = mock[HttpServletResponseWrapper]
 
     // the code under test makes some static method calls, so we gotta do this mess
-    when(mutableHttpServletResponse.getBufferedOutputAsInputStream).thenReturn(dummyInputStream)
+    when(httpServletResponseWrapper.getOutputStreamAsInputStream).thenReturn(dummyInputStream)
   }
 
   describe("a response log") {
@@ -58,10 +55,8 @@ class ResponseLogTest extends FunSpec with Matchers with MockitoSugar with Befor
         filter.setId(filterId)
         filter.setName(filterName)
 
-        when(filterContext.getFilterConfig).thenReturn(filter)
-
         // when we create a new ResponseLog
-        val responseLog = new ResponseLog(mutableHttpServletResponse, filterContext)
+        val responseLog = new ResponseLog(httpServletResponseWrapper, filter)
 
         // then the filter description includes both the ID and name
         s"$filterId-$filterName" shouldEqual responseLog.currentFilter
@@ -76,10 +71,8 @@ class ResponseLogTest extends FunSpec with Matchers with MockitoSugar with Befor
         filter.setId(filterId)
         filter.setName(filterName)
 
-        when(filterContext.getFilterConfig).thenReturn(filter)
-
         // when we create a new ResponseLog
-        val responseLog = new ResponseLog(mutableHttpServletResponse, filterContext)
+        val responseLog = new ResponseLog(httpServletResponseWrapper, filter)
 
         // then the filter description includes just the filter name
         filterName shouldEqual responseLog.currentFilter
@@ -94,10 +87,8 @@ class ResponseLogTest extends FunSpec with Matchers with MockitoSugar with Befor
         filter.setId(filterId)
         filter.setName(filterName)
 
-        when(filterContext.getFilterConfig).thenReturn(filter)
-
         // when we create a new ResponseLog
-        val responseLog = new ResponseLog(mutableHttpServletResponse, filterContext)
+        val responseLog = new ResponseLog(httpServletResponseWrapper, filter)
 
         // then the filter description includes just the filter name
         filterName shouldEqual responseLog.currentFilter

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/header-normalization.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/header-normalization.cfg.xml
@@ -22,14 +22,6 @@
             </whitelist>
         </target>
 
-        <!-- applies to all POST and PUT requests -->
-        <target http-methods="POST PUT">
-            <whitelist id="modification">
-                <header id="X-THIRD-Filter"/>
-                <header id="x-auth-token"/>
-            </whitelist>
-        </target>
-
         <!-- this blacklist filter only applies if the request does not match one of the previous targets -->
         <!-- since uri-regex and http-methods are not specified in target the blacklist applies to all http requests
              that don't match the previous two targets -->

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/responsebody/system-model.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/responsebody/system-model.cfg.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+
+        <nodes>
+            <node id="simple-node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+
+        <filters>
+            <filter name="add-header" />
+            <filter name="ip-user" />
+            <filter name="content-type-stripper"/>
+            <filter name="header-user"/>
+            <filter name="header-normalization"/>
+            <filter name="header-translation"/>
+            <filter name="merge-header"/>
+            <filter name="slf4j-http-logging"/>
+            <filter name="uri-user"/>
+            <filter name="uri-normalization" uri-regex=".*"/>
+            <filter name="uri-stripper"/>
+            <filter name="compression"/>
+            <filter name="rate-limiting" />
+            <filter name="simple-rbac" />
+            <filter name="api-validator"/>
+            <filter name="herp" />
+            <filter name="derp" />
+        </filters>
+
+        <destinations>
+            <endpoint id="target" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
+                      default="true"/>
+        </destinations>
+
+    </repose-cluster>
+</system-model>

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/simple-rbac.cfg.xml
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/configs/features/core/intrafilterlogging/simple-rbac.cfg.xml
@@ -4,7 +4,7 @@
              roles-header-name="X-ROLES"
              mask-rax-roles-403="false">
     <resources>
-/test          GET       ANY
+/test          GET,POST  ANY
 /path/to/this  GET       super,useradmin,admin,user
 /path/to/this  PUT       super,useradmin,admin
 /path/to/this  POST      super,useradmin

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/intrafilterlogging/IntraFilterLoggingRequestResponseBodyTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/intrafilterlogging/IntraFilterLoggingRequestResponseBodyTest.groovy
@@ -30,7 +30,7 @@ import org.rackspace.deproxy.Response
  * Verifies that the response body sent from the origin service makes it to the client and is logged by the IntraFilter
  * Logger.  Also verifies that the request body from the client makes it to the origin service.
  */
-class IntraFilterLoggingResponseBodyTest extends ReposeValveTest {
+class IntraFilterLoggingRequestResponseBodyTest extends ReposeValveTest {
     def static String content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi pretium non mi ac " +
             "malesuada. Integer nec est turpis duis."
     def static logPreString = '"currentFilter":"'
@@ -56,11 +56,6 @@ class IntraFilterLoggingResponseBodyTest extends ReposeValveTest {
         deproxy.addEndpoint(properties.targetPort, 'origin service')
 
         repose.waitForNon500FromUrl(reposeEndpoint)
-    }
-
-    def cleanupSpec() {
-        deproxy?.shutdown()
-        repose?.stop()
     }
 
     def "verify client gets the response body from the origin and that it is properly logged"() {

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/intrafilterlogging/IntraFilterLoggingResponseBodyTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/intrafilterlogging/IntraFilterLoggingResponseBodyTest.groovy
@@ -1,0 +1,105 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.core.intrafilterlogging
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import org.rackspace.deproxy.Response
+
+/**
+ * Created by mari9064 on 3/29/16.
+ * Verifies that the response body sent from the origin service makes it to the client and is logged by the IntraFilter
+ * Logger.  Also verifies that the request body from the client makes it to the origin service.
+ */
+class IntraFilterLoggingResponseBodyTest extends ReposeValveTest {
+    def static String content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi pretium non mi ac " +
+            "malesuada. Integer nec est turpis duis."
+    def static logPreString = '"currentFilter":"'
+    def static logPostStringRequest = /".*"requestBody":"$content"/
+    def static logPostStringResponse = /","httpResponseCode":"200","responseBody":"$content"/
+    def static configuredFilters = ["derp", "herp", "api-validator", "simple-rbac", "rate-limiting", "compression",
+                                    "uri-stripper", "uri-normalization", "uri-user", "slf4j-http-logging", "merge-header",
+                                    "header-translation", "header-normalization", "header-user", "content-type-stripper",
+                                    "ip-user", "add-header"]
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        reposeLogSearch.cleanLog()
+
+        def params = properties.getDefaultTemplateParams()
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params);
+        repose.configurationProvider.applyConfigs("features/core/intrafilterlogging", params);
+        repose.configurationProvider.applyConfigs("features/core/intrafilterlogging/responsebody", params);
+
+        repose.start()
+
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
+
+        repose.waitForNon500FromUrl(reposeEndpoint)
+    }
+
+    def cleanupSpec() {
+        deproxy?.shutdown()
+        repose?.stop()
+    }
+
+    def "verify client gets the response body from the origin and that it is properly logged"() {
+        given:
+        def headers = ["x-roles": "raxRolesDisabled"]
+
+        when:
+        MessageChain mc = deproxy.makeRequest(
+                url: reposeEndpoint + "/test",
+                method: 'GET',
+                headers: headers,
+                defaultHandler: { new Response(200, "OK", [], content) })
+
+        then:
+        mc.receivedResponse.code == "200"
+        mc.orphanedHandlings.size() == 0
+        mc.receivedResponse.body == content
+        configuredFilters.each { filterName ->
+            assert reposeLogSearch.searchByString(logPreString + filterName + logPostStringResponse).size() > 0
+        }
+    }
+
+    def "verify origin receives request body from client and that it is properly logged"() {
+        given:
+        def headers = ["x-roles": "raxRolesDisabled"]
+
+        when:
+        MessageChain mc = deproxy.makeRequest(
+                url: reposeEndpoint + "/test",
+                method: 'POST',
+                headers: headers,
+                requestBody: content)
+
+        then:
+        mc.receivedResponse.code == "200"
+        mc.orphanedHandlings.size() == 0
+        mc.sentRequest.body == content
+        configuredFilters.each { filterName ->
+            assert reposeLogSearch.searchByString(logPreString + filterName + logPostStringRequest).size() > 0
+        }
+    }
+}

--- a/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/intrafilterlogging/IntraFilterLoggingResponseBodyTest.groovy
+++ b/repose-aggregator/functional-tests/spock-functional-test/src/test/groovy/features/core/intrafilterlogging/IntraFilterLoggingResponseBodyTest.groovy
@@ -77,10 +77,10 @@ class IntraFilterLoggingResponseBodyTest extends ReposeValveTest {
         then:
         mc.receivedResponse.code == "200"
         mc.orphanedHandlings.size() == 0
-        mc.receivedResponse.body == content
         configuredFilters.each { filterName ->
             assert reposeLogSearch.searchByString(logPreString + filterName + logPostStringResponse).size() > 0
         }
+        mc.receivedResponse.body == content
     }
 
     def "verify origin receives request body from client and that it is properly logged"() {


### PR DESCRIPTION
Instead of wrapping the request and response with the old mutable wrappers in the PowerFilterChain.doReposeFilter() method, I use what's passed in when intrafilter logging is turned off and wrap it using the new wrappers when it's set to trace.

I also check if the InputStream in the request supports mark/reset, and if it doesn't, I copy the data over to an InputStream that does (and use that when wrapping the request).

For the response, I wrap it using READONLY mode on the body so I can read the OutputStream.

I'm not a huge fan of the maybeWrapped stuff, but I expect the PowerFilterChain to be updated soon anyway.

I added a new functional test to verify:
- the origin service receives the request body sent from the client
- the client receives the response body sent from the origin service
- each intrafilter log line contains the full request and/or response body