### PR TITLE
Use entities for illegal angle brackets in RPM %pre scripts

### DIFF
--- a/repose-aggregator/installation/rpm/repose-valve/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-valve/pom.xml
@@ -320,7 +320,7 @@
                                     then
                                     # Detects if the Dist-Datastore filter is present in the system-model.cfg.xml file.
                                     # If the filter is an active component then this installation will fail.
-                                    if cat $SYSTEM_MODEL | sed '/<!--.*-->/d'| sed '/<!--/,/-->/d' | \ 
+                                    if cat $SYSTEM_MODEL | sed '/&lt;!--.*--&gt;/d'| sed '/&lt;!--/,/--&gt;/d' | \ 
                                       grep 'filter.*dist-datastore'
                                     then
                                     echo "Unable to upgrade. system-model.cfg.xml file contains the deprecated \

--- a/repose-aggregator/installation/rpm/repose-war/pom.xml
+++ b/repose-aggregator/installation/rpm/repose-war/pom.xml
@@ -266,7 +266,7 @@
                                     then
                                     # Detects if the Dist-Datastore filter is present in the system-model.cfg.xml file.
                                     # If the filter is an active component then this installation will fail.
-                                    if cat $SYSTEM_MODEL | sed '/<!--.*-->/d'| sed '/<!--/,/-->/d' | \
+                                    if cat $SYSTEM_MODEL | sed '/&lt;!--.*--&gt;/d'| sed '/&lt;!--/,/--&gt;/d' | \
                                     grep 'filter.*dist-datastore'
                                     then
                                     echo "Unable to upgrade. system-model.cfg.xml file contains the deprecated \


### PR DESCRIPTION
This fixes broken sed commands in the RPM %pre scripts, which have been causing installation failures in cases where /etc/repose is already populated with config files at install time.