### PR TITLE
REP-3667 - URI Normalization config ordering

### DIFF
--- a/repose-aggregator/components/filters/uri-normalization-filter/src/main/scala/org/openrepose/filters/urinormalization/UriNormalizationFilter.scala
+++ b/repose-aggregator/components/filters/uri-normalization-filter/src/main/scala/org/openrepose/filters/urinormalization/UriNormalizationFilter.scala
@@ -92,7 +92,7 @@ class UriNormalizationFilter @Inject()(configurationService: ConfigurationServic
 
   override def configurationUpdated(configurationObject: UriNormalizationConfig): Unit = {
     synchronized {
-      val newNormalizers = mutable.Map.empty[String, QueryParameterNormalizer]
+      val newNormalizers = mutable.LinkedHashMap.empty[String, QueryParameterNormalizer]
 
       Option(configurationObject.getUriFilters).foreach(_.getTarget foreach { target =>
         val alphabetize = target.isAlphabetize


### PR DESCRIPTION
I added a unit test that consistently triggered the ordering issue when loading the URI Norm config, and I changed the scala HashMap to a scala LinkedHashMap in the filter which preserves the ordering of the config.