### PR TITLE
REP-3838 - IP User filter should check X-Forwarded-For header first

### DIFF
--- a/repose-aggregator/components/filters/ip-user-filter/build.gradle
+++ b/repose-aggregator/components/filters/ip-user-filter/build.gradle
@@ -12,4 +12,6 @@ dependencies {
     testCompile "org.mockito:mockito-all"
     testCompile project(":repose-aggregator:commons:commons-configuration")
     testCompile "xerces:xerces-xsd11"
+    testCompile "org.springframework:spring-test"
+    testCompile "org.slf4j:jcl-over-slf4j"
 }

--- a/repose-aggregator/components/filters/ip-user-filter/src/main/scala/org/openrepose/filters/ipuser/IpUserFilter.scala
+++ b/repose-aggregator/components/filters/ip-user-filter/src/main/scala/org/openrepose/filters/ipuser/IpUserFilter.scala
@@ -28,6 +28,7 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import edazdarevic.commons.net.CIDRUtils
 import org.openrepose.commons.config.manager.UpdateListener
+import org.openrepose.commons.utils.http.CommonHttpHeader
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 import org.openrepose.core.filter.FilterConfigHelper
 import org.openrepose.core.services.config.ConfigurationService
@@ -78,7 +79,9 @@ class IpUserFilter @Inject()(configurationService: ConfigurationService) extends
       }
 
       //Always set the user header name to the current IP address
-      request.addHeader(userHeaderName, servletRequest.getRemoteAddr, userHeaderQuality)
+      val clientIpAddress = request.getSplittableHeaderScala(CommonHttpHeader.X_FORWARDED_FOR.toString)
+        .headOption.getOrElse(servletRequest.getRemoteAddr)
+      request.addHeader(userHeaderName, clientIpAddress, userHeaderQuality)
 
       logger.trace("IP User filter passing request...")
       filterChain.doFilter(request, servletResponse)

--- a/repose-aggregator/components/filters/ip-user-filter/src/test/scala/org/openrepose/filters/ipuser/IpUserFilterTest.scala
+++ b/repose-aggregator/components/filters/ip-user-filter/src/test/scala/org/openrepose/filters/ipuser/IpUserFilterTest.scala
@@ -42,11 +42,12 @@ class IpUserFilterTest extends FunSpec with BeforeAndAfter with Matchers {
     servletRequest = new MockHttpServletRequest
     servletResponse = new MockHttpServletResponse
     filterChain = new MockFilterChain
+
+    ipUserFilter.configurationUpdated(createConfig())
   }
 
   describe("setting the request x-pp-user header") {
     it("should use the value of the remote IP address of the request when no X-Forwarded-For header is included") {
-      ipUserFilter.configurationUpdated(createConfig())
       servletRequest.setRemoteAddr("10.1.2.3")
 
       ipUserFilter.doFilter(servletRequest, servletResponse, filterChain)
@@ -55,7 +56,6 @@ class IpUserFilterTest extends FunSpec with BeforeAndAfter with Matchers {
     }
 
     it("should use the value of the X-Forwarded-For header when it is included") {
-      ipUserFilter.configurationUpdated(createConfig())
       servletRequest.setRemoteAddr("10.1.2.3")
       servletRequest.addHeader("X-Forwarded-For", "10.55.66.77")
 
@@ -65,7 +65,6 @@ class IpUserFilterTest extends FunSpec with BeforeAndAfter with Matchers {
     }
 
     it("should use the first value of the X-Forwarded-For header when there are multiple non-split values") {
-      ipUserFilter.configurationUpdated(createConfig())
       servletRequest.setRemoteAddr("10.1.2.3")
       servletRequest.addHeader("X-Forwarded-For", "10.123.123.123")
       servletRequest.addHeader("X-Forwarded-For", "10.55.66.77")
@@ -76,7 +75,6 @@ class IpUserFilterTest extends FunSpec with BeforeAndAfter with Matchers {
     }
 
     it("should use the first value of the X-Forwarded-For header when there are multiple splittable values") {
-      ipUserFilter.configurationUpdated(createConfig())
       servletRequest.setRemoteAddr("10.1.2.3")
       servletRequest.addHeader("X-Forwarded-For", "10.233.10.67,10.55.66.77")
 

--- a/repose-aggregator/components/filters/ip-user-filter/src/test/scala/org/openrepose/filters/ipuser/IpUserFilterTest.scala
+++ b/repose-aggregator/components/filters/ip-user-filter/src/test/scala/org/openrepose/filters/ipuser/IpUserFilterTest.scala
@@ -1,0 +1,100 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.filters.ipuser
+
+import org.junit.runner.RunWith
+import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
+import org.openrepose.filters.ipuser.config.{GroupType, IpUserConfig}
+import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.junit.JUnitRunner
+import org.springframework.mock.web.{MockFilterChain, MockHttpServletRequest, MockHttpServletResponse}
+
+@RunWith(classOf[JUnitRunner])
+class IpUserFilterTest extends FunSpec with BeforeAndAfter with Matchers {
+
+  val DefaultQuality = ";q=0.4"
+
+  var ipUserFilter: IpUserFilter = _
+  var servletRequest: MockHttpServletRequest = _
+  var servletResponse: MockHttpServletResponse = _
+  var filterChain: MockFilterChain = _
+
+  before {
+    ipUserFilter = new IpUserFilter(null)
+    servletRequest = new MockHttpServletRequest
+    servletResponse = new MockHttpServletResponse
+    filterChain = new MockFilterChain
+  }
+
+  describe("setting the request x-pp-user header") {
+    it("should use the value of the remote IP address of the request when no X-Forwarded-For header is included") {
+      ipUserFilter.configurationUpdated(createConfig())
+      servletRequest.setRemoteAddr("10.1.2.3")
+
+      ipUserFilter.doFilter(servletRequest, servletResponse, filterChain)
+
+      getPostFilterRequest.getHeader("x-pp-user") shouldEqual "10.1.2.3" + DefaultQuality
+    }
+
+    it("should use the value of the X-Forwarded-For header when it is included") {
+      ipUserFilter.configurationUpdated(createConfig())
+      servletRequest.setRemoteAddr("10.1.2.3")
+      servletRequest.addHeader("X-Forwarded-For", "10.55.66.77")
+
+      ipUserFilter.doFilter(servletRequest, servletResponse, filterChain)
+
+      getPostFilterRequest.getHeader("x-pp-user") shouldEqual "10.55.66.77" + DefaultQuality
+    }
+
+    it("should use the first value of the X-Forwarded-For header when there are multiple non-split values") {
+      ipUserFilter.configurationUpdated(createConfig())
+      servletRequest.setRemoteAddr("10.1.2.3")
+      servletRequest.addHeader("X-Forwarded-For", "10.123.123.123")
+      servletRequest.addHeader("X-Forwarded-For", "10.55.66.77")
+
+      ipUserFilter.doFilter(servletRequest, servletResponse, filterChain)
+
+      getPostFilterRequest.getHeader("x-pp-user") shouldEqual "10.123.123.123" + DefaultQuality
+    }
+
+    it("should use the first value of the X-Forwarded-For header when there are multiple splittable values") {
+      ipUserFilter.configurationUpdated(createConfig())
+      servletRequest.setRemoteAddr("10.1.2.3")
+      servletRequest.addHeader("X-Forwarded-For", "10.233.10.67,10.55.66.77")
+
+      ipUserFilter.doFilter(servletRequest, servletResponse, filterChain)
+
+      getPostFilterRequest.getHeader("x-pp-user") shouldEqual "10.233.10.67" + DefaultQuality
+    }
+  }
+
+  def getPostFilterRequest: HttpServletRequestWrapper = filterChain.getRequest.asInstanceOf[HttpServletRequestWrapper]
+
+  def createConfig(): IpUserConfig = {
+    val group = new GroupType
+    group.setName("ipv4-match-all")
+    group.getCidrIp.add("0.0.0.0/0")
+
+    val config = new IpUserConfig
+    config.getGroup.add(group)
+    config
+  }
+}

--- a/repose-aggregator/tests/functional-tests/src/test/groovy/features/filters/ipuser/IpUserTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/test/groovy/features/filters/ipuser/IpUserTest.groovy
@@ -44,29 +44,6 @@ class IpUserTest extends ReposeValveTest {
         }
     }
 
-    def "classifying a request by its IP"() {
-        def params = properties.defaultTemplateParams
-        repose.configurationProvider.applyConfigs("common", params)
-        repose.configurationProvider.applyConfigs("features/filters/ipuser", params)
-        repose.start()
-
-        when: "Request is sent through repose"
-        def mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get')
-        def sentRequest = ((MessageChain) mc).handlings[0]
-
-        then: "Repose will send x-pp-group with the configured value"
-        mc.handlings.size() == 1
-
-        and: "Repose will send x-pp-user based on requestor ip"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 1
-        def user = sentRequest.request.headers.getFirstValue("x-pp-user")
-        // The possible IPv4/6 addresses.
-        user == "127.0.0.1;q=0.4" || user == "0:0:0:0:0:0:0:1;q=0.4" || user == "::1;q=0.4"
-
-        and: "Repose will send x-pp-groups with the configured value"
-        ((Handling) sentRequest).request.headers.getFirstValue("x-pp-groups").equalsIgnoreCase("local-group;q=0.4")
-    }
-
     def "verify classifying with other config"() {
         def params = properties.defaultTemplateParams
         repose.configurationProvider.applyConfigs("common", params)
@@ -118,64 +95,4 @@ class IpUserTest extends ReposeValveTest {
         !group.contains("local-lan-ip;q=0.6")
     }
 
-    //REP-3838 fix using x-forward-for as x-pp-user
-    def "When X-Forwarded-For header when it is included should use vaule for x-pp-user"() {
-        given: "x-forwarded-for header is set"
-        def params = properties.defaultTemplateParams
-        repose.configurationProvider.applyConfigs("common", params)
-        repose.configurationProvider.applyConfigs("features/filters/ipuser", params)
-        repose.start()
-        def headers = ['x-forwarded-for': '10.1.1.3']
-
-        when: "Request is sent through repose"
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
-        def sentRequest = mc.handlings[0]
-
-        then: "Repose will send x-pp-group with the configured value"
-        mc.handlings.size() == 1
-
-        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
-        sentRequest.request.headers.findAll("x-pp-user").size() == 1
-        sentRequest.request.headers.getFirstValue("x-pp-user") == '10.1.1.3;q=0.4'
-    }
-
-    def "When multi x-forwarded-for headers are included shoud take 1st valued for x-pp-user"() {
-        given: "x-forwarded-for header is set"
-        def params = properties.defaultTemplateParams
-        repose.configurationProvider.applyConfigs("common", params)
-        repose.configurationProvider.applyConfigs("features/filters/ipuser", params)
-        repose.start()
-        def headers = ['x-forwarded-for': '192.25.25.15',
-                       'X-Forwarded-For': '10.1.1.3']
-        when: "Request is sent through repose"
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
-        def sentRequest = mc.handlings[0]
-
-        then: "Repose will send x-pp-group with the configured value"
-        mc.handlings.size() == 1
-
-        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
-        sentRequest.request.headers.findAll("x-pp-user").size() == 1
-        sentRequest.request.headers.getFirstValue("x-pp-user") == '192.25.25.15;q=0.4'
-    }
-
-    def "When multi x-forwarded-for splitable headers are included shoud take 1st valued for x-pp-user"() {
-        given: "x-forwarded-for header is set"
-        def params = properties.defaultTemplateParams
-        repose.configurationProvider.applyConfigs("common", params)
-        repose.configurationProvider.applyConfigs("features/filters/ipuser", params)
-        repose.start()
-        def headers = ['x-forwarded-for': '192.25.25.15, 10.1.1.3']
-
-        when: "Request is sent through repose"
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
-        def sentRequest = mc.handlings[0]
-
-        then: "Repose will send x-pp-group with the configured value"
-        mc.handlings.size() == 1
-
-        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
-        sentRequest.request.headers.findAll("x-pp-user").size() == 1
-        sentRequest.request.headers.getFirstValue("x-pp-user") == '192.25.25.15;q=0.4'
-    }
 }

--- a/repose-aggregator/tests/functional-tests/src/test/groovy/features/filters/ipuser/IpUserTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/test/groovy/features/filters/ipuser/IpUserTest.groovy
@@ -117,4 +117,65 @@ class IpUserTest extends ReposeValveTest {
         !group.contains("local-group;q=0.6")
         !group.contains("local-lan-ip;q=0.6")
     }
+
+    //REP-3838 fix using x-forward-for as x-pp-user
+    def "When X-Forwarded-For header when it is included should use vaule for x-pp-user"() {
+        given: "x-forwarded-for header is set"
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/ipuser", params)
+        repose.start()
+        def headers = ['x-forwarded-for': '10.1.1.3']
+
+        when: "Request is sent through repose"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
+        def sentRequest = mc.handlings[0]
+
+        then: "Repose will send x-pp-group with the configured value"
+        mc.handlings.size() == 1
+
+        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
+        sentRequest.request.headers.findAll("x-pp-user").size() == 1
+        sentRequest.request.headers.getFirstValue("x-pp-user") == '10.1.1.3;q=0.4'
+    }
+
+    def "When multi x-forwarded-for headers are included shoud take 1st valued for x-pp-user"() {
+        given: "x-forwarded-for header is set"
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/ipuser", params)
+        repose.start()
+        def headers = ['x-forwarded-for': '192.25.25.15',
+                       'X-Forwarded-For': '10.1.1.3']
+        when: "Request is sent through repose"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
+        def sentRequest = mc.handlings[0]
+
+        then: "Repose will send x-pp-group with the configured value"
+        mc.handlings.size() == 1
+
+        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
+        sentRequest.request.headers.findAll("x-pp-user").size() == 1
+        sentRequest.request.headers.getFirstValue("x-pp-user") == '192.25.25.15;q=0.4'
+    }
+
+    def "When multi x-forwarded-for splitable headers are included shoud take 1st valued for x-pp-user"() {
+        given: "x-forwarded-for header is set"
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/ipuser", params)
+        repose.start()
+        def headers = ['x-forwarded-for': '192.25.25.15, 10.1.1.3']
+
+        when: "Request is sent through repose"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
+        def sentRequest = mc.handlings[0]
+
+        then: "Repose will send x-pp-group with the configured value"
+        mc.handlings.size() == 1
+
+        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
+        sentRequest.request.headers.findAll("x-pp-user").size() == 1
+        sentRequest.request.headers.getFirstValue("x-pp-user") == '192.25.25.15;q=0.4'
+    }
 }

--- a/repose-aggregator/tests/functional-tests/src/test/groovy/features/filters/ipuser/IpUserWXForwardedForHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/test/groovy/features/filters/ipuser/IpUserWXForwardedForHeaderTest.groovy
@@ -22,6 +22,7 @@ package features.filters.ipuser
 import framework.ReposeValveTest
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
+
 /**
  * Created by jennyvo on 4/26/16.
  *  REP-3838 fix using x-forward-for as x-pp-user
@@ -46,6 +47,7 @@ class IpUserWXForwardedForHeaderTest extends ReposeValveTest {
             repose.stop()
         }
     }
+
     def "classifying a request by its IP"() {
         when: "Request is sent through repose"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get')

--- a/repose-aggregator/tests/functional-tests/src/test/groovy/features/filters/ipuser/IpUserWXForwardedForHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/test/groovy/features/filters/ipuser/IpUserWXForwardedForHeaderTest.groovy
@@ -1,0 +1,115 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.filters.ipuser
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+/**
+ * Created by jennyvo on 4/26/16.
+ *  REP-3838 fix using x-forward-for as x-pp-user
+ */
+class IpUserWXForwardedForHeaderTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        //Just set up a simple endpoint
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/ipuser", params)
+        repose.start()
+    }
+
+    def cleanupSpec() {
+        if (deproxy) {
+            deproxy.shutdown()
+        }
+        if (repose) {
+            repose.stop()
+        }
+    }
+    def "classifying a request by its IP"() {
+        when: "Request is sent through repose"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get')
+        def sentRequest = mc.handlings[0]
+
+        then: "Repose will send x-pp-group with the configured value"
+        mc.handlings.size() == 1
+
+        and: "Repose will send x-pp-user based on requestor ip"
+        sentRequest.request.getHeaders().findAll("x-pp-user").size() == 1
+        def user = sentRequest.request.headers.getFirstValue("x-pp-user")
+        // The possible IPv4/6 addresses.
+        user == "127.0.0.1;q=0.4" || user == "0:0:0:0:0:0:0:1;q=0.4" || user == "::1;q=0.4"
+
+        and: "Repose will send x-pp-groups with the configured value"
+        sentRequest.request.headers.getFirstValue("x-pp-groups").equalsIgnoreCase("local-group;q=0.4")
+    }
+
+    //REP-3838 fix using x-forward-for as x-pp-user
+    def "When X-Forwarded-For header when it is included should use vaule for x-pp-user"() {
+        given: "x-forwarded-for header is set"
+        def headers = ['x-forwarded-for': '10.1.1.3']
+
+        when: "Request is sent through repose"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
+        def sentRequest = mc.handlings[0]
+
+        then: "Repose will send x-pp-group with the configured value"
+        mc.handlings.size() == 1
+
+        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
+        sentRequest.request.headers.findAll("x-pp-user").size() == 1
+        sentRequest.request.headers.getFirstValue("x-pp-user") == '10.1.1.3;q=0.4'
+    }
+
+    def "When multi x-forwarded-for headers are included shoud take 1st valued for x-pp-user"() {
+        given: "x-forwarded-for header is set"
+        def headers = ['x-forwarded-for': '192.25.25.15',
+                       'X-Forwarded-For': '10.1.1.3']
+        when: "Request is sent through repose"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
+        def sentRequest = mc.handlings[0]
+
+        then: "Repose will send x-pp-group with the configured value"
+        mc.handlings.size() == 1
+
+        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
+        sentRequest.request.headers.findAll("x-pp-user").size() == 1
+        sentRequest.request.headers.getFirstValue("x-pp-user") == '192.25.25.15;q=0.4'
+    }
+
+    def "When multi x-forwarded-for splitable headers are included shoud take 1st valued for x-pp-user"() {
+        given: "x-forwarded-for header is set"
+        def headers = ['x-forwarded-for': '192.25.25.15, 10.1.1.3']
+
+        when: "Request is sent through repose"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: 'get', headers: headers)
+        def sentRequest = mc.handlings[0]
+
+        then: "Repose will send x-pp-group with the configured value"
+        mc.handlings.size() == 1
+
+        and: "Repose will x-pp-user base on x-forward-for header plus default quality"
+        sentRequest.request.headers.findAll("x-pp-user").size() == 1
+        sentRequest.request.headers.getFirstValue("x-pp-user") == '192.25.25.15;q=0.4'
+    }
+}


### PR DESCRIPTION
The IP User filter now grabs the first splittable value of the X-Forwarded-For header to populate the x-pp-user header if it's available.  Otherwise, it'll use the remote IP address in the request (like it previously did).

There were some unit tests for this filter already, but none of them verified that the IP address was put into the X-PP-User header.  I added some unit tests to verify this and the behavior for when the X-Forwarded-For header is in the request.