### PR TITLE
REP-3311 - Fix RPM installer

### DIFF
--- a/repose-aggregator/artifacts/experimental-filter-bundle/build.gradle
+++ b/repose-aggregator/artifacts/experimental-filter-bundle/build.gradle
@@ -98,5 +98,6 @@ buildDeb {
 }
 
 buildRpm {
+    addParentDirs false
     requires('java', '1.8.0', GREATER | EQUAL)
 }

--- a/repose-aggregator/artifacts/extensions-filter-bundle/build.gradle
+++ b/repose-aggregator/artifacts/extensions-filter-bundle/build.gradle
@@ -95,5 +95,6 @@ buildDeb {
 }
 
 buildRpm {
+    addParentDirs false
     requires('java', '1.8.0', GREATER | EQUAL)
 }

--- a/repose-aggregator/artifacts/filter-bundle/build.gradle
+++ b/repose-aggregator/artifacts/filter-bundle/build.gradle
@@ -137,5 +137,6 @@ buildDeb {
 }
 
 buildRpm {
+    addParentDirs false
     requires('java', '1.8.0', GREATER | EQUAL)
 }

--- a/repose-aggregator/artifacts/src/config/scripts/preinst-rpm
+++ b/repose-aggregator/artifacts/src/config/scripts/preinst-rpm
@@ -19,8 +19,8 @@ then
         exit 1
     fi
 else
-    getent group repose &gt;&gt; /dev/null 2&gt;&amp;1 || groupadd -r repose
-    getent passwd repose &gt;&gt; /dev/null 2&gt;&amp;1 || useradd -r -g repose -s \
+    getent group repose >> /dev/null 2>&1 || groupadd -r repose
+    getent passwd repose >> /dev/null 2>&1 || useradd -r -g repose -s \
     /sbin/nologin -d /usr/share/repose -c "Repose" repose
 fi
 exit 0


### PR DESCRIPTION
The install script for the RPM installer was encoded to be in an XML file which it isn't anymore, so I fixed that.

Also, the filter RPMs wouldn't install because they were trying to create directories that already existed (from the valve RPM).  I updated the Gradle build to have the filter RPMs not try to create the directories.

I was able to install the valve RPM and the three filter RPMs in a Vagrant CentOS 7 VM.