### PR TITLE
Adding a hard version dependency for virtual packages

### DIFF
--- a/repose-aggregator/artifacts/cli-utils/build.gradle
+++ b/repose-aggregator/artifacts/cli-utils/build.gradle
@@ -93,7 +93,7 @@ ospackage {
         fileMode 0444
     }
 
-    requires('repose', project.version, EQUAL)
+    requires("repose-$project.version")
 
     replaces('cli-utils')
 }

--- a/repose-aggregator/artifacts/experimental-filter-bundle/build.gradle
+++ b/repose-aggregator/artifacts/experimental-filter-bundle/build.gradle
@@ -83,7 +83,7 @@ ospackage {
         fileMode 0444
     }
 
-    requires('repose', project.version, EQUAL)
+    requires("repose-$project.version")
 }
 
 buildDeb {

--- a/repose-aggregator/artifacts/extensions-filter-bundle/build.gradle
+++ b/repose-aggregator/artifacts/extensions-filter-bundle/build.gradle
@@ -80,7 +80,7 @@ ospackage {
         fileMode 0444
     }
 
-    requires('repose', project.version, EQUAL)
+    requires("repose-$project.version")
 
     replaces('repose-extension-filters')
 }

--- a/repose-aggregator/artifacts/filter-bundle/build.gradle
+++ b/repose-aggregator/artifacts/filter-bundle/build.gradle
@@ -108,7 +108,7 @@ ospackage {
         fileMode 0444
     }
 
-    requires('repose', project.version, EQUAL)
+    requires("repose-$project.version")
 
     replaces('repose-filters')
 }

--- a/repose-aggregator/artifacts/valve/build.gradle
+++ b/repose-aggregator/artifacts/valve/build.gradle
@@ -207,7 +207,7 @@ ospackage {
         fileMode 0444
     }
 
-    provides('repose')
+    provides("repose-$project.version")
     conflicts('repose-war')
     recommends('repose-filter-bundle')
     suggests('repose-extensions-bundle')

--- a/repose-aggregator/artifacts/web-application/build.gradle
+++ b/repose-aggregator/artifacts/web-application/build.gradle
@@ -144,7 +144,7 @@ ospackage {
         fileMode 0444
     }
 
-    provides('repose')
+    provides("repose-$project.version")
     conflicts('repose-valve')
     recommends('repose-filter-bundle')
     suggests('repose-extensions-bundle')


### PR DESCRIPTION
This change allowed me to install packages on a local Ubuntu VM, whereas before dpkg was complaining about requiring a specific version of a virtual package.