### PR TITLE
Removed all references to the RPM's requiring daemonize.

### DIFF
--- a/repose-aggregator/artifacts/valve/build.gradle
+++ b/repose-aggregator/artifacts/valve/build.gradle
@@ -248,7 +248,6 @@ buildRpm {
     }
 
     requires('java', '1.8.0', GREATER | EQUAL)
-    requires('daemonize')
     preInstall file('../src/config/scripts/preinst-rpm')
     postInstall('/sbin/chkconfig --add repose-valve')
 }


### PR DESCRIPTION
Since RPM platforms were the first to move to `systemd`, I think it is safe to remove System V support from them.