### PR TITLE
Extracting regex operators to a commons utility

### DIFF
--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/string/RegexStringOperators.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/string/RegexStringOperators.scala
@@ -28,7 +28,7 @@ import scala.language.implicitConversions
   * Allows the implicit conversion to RegexString to be mixed-in.
   */
 trait RegexStringOperators {
-  implicit def stringToStringRegex(str: String): RegexString = new RegexString(str)
+  implicit def stringToRegexString(str: String): RegexString = new RegexString(str)
 }
 
 /**

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/string/RegexStringOperators.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/string/RegexStringOperators.scala
@@ -1,0 +1,58 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package org.openrepose.commons.utils.string
+
+import java.util.regex.{Matcher, Pattern}
+
+import scala.language.implicitConversions
+
+/**
+  * Allows the implicit conversion to RegexString to be mixed-in.
+  */
+trait RegexStringOperators {
+  implicit def stringToStringRegex(str: String): RegexString = new RegexString(str)
+}
+
+/**
+  * Allows the implicit conversion to RegexString to be imported.
+  */
+object RegexString extends RegexStringOperators {}
+
+class RegexString(string: String) {
+
+  val pattern: Pattern = string.r.pattern
+
+  /**
+    * Attempts to match this, as a regular expression, against another string.
+    *
+    * @param other the string to attempt to match against
+    * @return true if other fully matches, false otherwise
+    */
+  def =~(other: String): Boolean = ==~(other).matches
+
+  /**
+    * Attempts to create a matcher with this, as a regular expression, against another string.
+    *
+    * @param other the string to create a matcher for
+    * @return a matcher for this against other
+    */
+  def ==~(other: String): Matcher = pattern.matcher(other)
+}

--- a/repose-aggregator/commons/commons-utilities/src/test/scala/org/openrepose/commons/utils/string/RegexStringOperatorsTest.scala
+++ b/repose-aggregator/commons/commons-utilities/src/test/scala/org/openrepose/commons/utils/string/RegexStringOperatorsTest.scala
@@ -1,0 +1,70 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package org.openrepose.commons.utils.string
+
+import java.util.regex.Matcher
+
+import org.scalatest.{FunSpec, Matchers}
+
+class RegexStringOperatorsTest extends FunSpec with Matchers {
+
+  describe("RegexString") {
+    describe("==~") {
+      it("should create a matcher") {
+        val regexString = new RegexString("/foo/\\d+")
+        (regexString ==~ "/foo/123") shouldBe a[Matcher]
+      }
+    }
+
+    describe("=~") {
+      it("should return true if the regex fully matches the operand") {
+        val regexString = new RegexString("/foo/\\d+")
+        (regexString =~ "/foo/123") shouldBe true
+      }
+
+      it("should return false if the regex partially matches the operand") {
+        val regexString = new RegexString("/v2/\\d+")
+        (regexString =~ "/foo/123/bar") shouldBe false
+      }
+
+      it("should return false if the regex does not match the operand") {
+        val regexString = new RegexString("/v2/\\d+")
+        (regexString =~ "baz") shouldBe false
+      }
+
+      it("should implicitly convert a String to a RegexString") {
+        import RegexString._
+
+        val rs: RegexString = "/foo/\\d+"
+        rs shouldBe a[RegexString]
+      }
+    }
+  }
+
+  describe("RegexStringOperators") {
+    it("should implicitly convert a String to a RegexString") {
+      val anonymousTrait = new RegexStringOperators {
+        def convert(regex: String): RegexString = regex
+      }
+
+      anonymousTrait.convert("/foo/\\d+") shouldBe a[RegexString]
+    }
+  }
+}

--- a/repose-aggregator/components/filters/body-patcher-filter/src/main/scala/org/openrepose/filters/bodypatcher/BodyPatcherFilter.scala
+++ b/repose-aggregator/components/filters/body-patcher-filter/src/main/scala/org/openrepose/filters/bodypatcher/BodyPatcherFilter.scala
@@ -33,6 +33,7 @@ import gnieh.diffson.playJson._
 import org.openrepose.commons.utils.io.stream.ServletInputStreamWrapper
 import org.openrepose.commons.utils.servlet.http.ResponseMode.{MUTABLE, PASSTHROUGH}
 import org.openrepose.commons.utils.servlet.http.{HttpServletRequestWrapper, HttpServletResponseWrapper}
+import org.openrepose.commons.utils.string.RegexStringOperators
 import org.openrepose.core.filter.AbstractConfiguredFilter
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.filters.bodypatcher.config.{BodyPatcherConfig, ChangeDetails, Patch}
@@ -47,7 +48,7 @@ import scala.util.{Failure, Success, Try}
   */
 @Named
 class BodyPatcherFilter @Inject()(configurationService: ConfigurationService)
-  extends AbstractConfiguredFilter[BodyPatcherConfig](configurationService) with LazyLogging {
+  extends AbstractConfiguredFilter[BodyPatcherConfig](configurationService) with RegexStringOperators with LazyLogging {
   override val DEFAULT_CONFIG: String = "body-patcher.cfg.xml"
   override val SCHEMA_LOCATION: String = "/META-INF/schema/config/body-patcher.xsd"
 
@@ -123,7 +124,7 @@ class BodyPatcherFilter @Inject()(configurationService: ConfigurationService)
   def filterPathChanges(request: HttpServletRequest): List[ChangeDetails] = {
     val path: String = URLDecoder.decode(request.getRequestURI, StandardCharsets.UTF_8.toString)
     configuration.getChange.asScala.toList
-        .filter(_.getPath.r.pattern.matcher(path).matches)
+        .filter(_.getPath =~ path)
   }
 
   def filterRequestChanges(changes: List[ChangeDetails]): List[Patch] = {

--- a/repose-aggregator/components/filters/uri-stripper-filter/src/main/scala/org/openrepose/filters/uristripper/UriStripperFilter.scala
+++ b/repose-aggregator/components/filters/uri-stripper-filter/src/main/scala/org/openrepose/filters/uristripper/UriStripperFilter.scala
@@ -33,6 +33,7 @@ import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.StringUriUtilities
 import org.openrepose.commons.utils.http.CommonHttpHeader
 import org.openrepose.commons.utils.servlet.http.{HttpServletRequestWrapper, HttpServletResponseWrapper, ResponseMode}
+import org.openrepose.commons.utils.string.RegexStringOperators
 import org.openrepose.core.filter.FilterConfigHelper
 import org.openrepose.core.services.config.ConfigurationService
 import org.openrepose.filters.uristripper.config._
@@ -46,7 +47,7 @@ import scala.util.{Failure, Success, Try}
 
 @Named
 class UriStripperFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[UriStripperConfig] with LazyLogging {
+  extends Filter with UpdateListener[UriStripperConfig] with RegexStringOperators with LazyLogging {
 
   import UriStripperFilter._
 
@@ -120,7 +121,7 @@ class UriStripperFilter @Inject()(configurationService: ConfigurationService)
       }
 
       val applicableLinkPaths = config.getLinkResource
-        .filter(resource => resource.getUriPathRegex.r.pattern.matcher(wrappedRequest.getRequestURI).matches)
+        .filter(resource => resource.getUriPathRegex =~ wrappedRequest.getRequestURI)
         .filter(resource => isMatchingMethod(resource.getHttpMethods.toSet, wrappedRequest.getMethod))
         .map(resource => getPathsForContentType(wrappedResponse.getContentType, resource.getResponse))
         .fold(List.empty[LinkPath])(_ ++ _)


### PR DESCRIPTION
These match two of Groovy's regex operators, `=~` and `==~`. There are two ways to use this utility in Scala -- import the implicit conversion, or mix-in the trait. Technically, I suppose you could also instantiate the extended class, or do some other shenanigans to pull the implicit conversion into scope, but the two aforementioned methods are probably preferred.

Note that this branched is branched off of REP-4010, because I wanted to update that code to use the new operator.