### PR TITLE
Chunked Encoding Test

### DIFF
--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/services/httpconnectionpool/chunkedfalse/http-connection-pool.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/services/httpconnectionpool/chunkedfalse/http-connection-pool.cfg.xml
@@ -7,16 +7,6 @@
     -->
     <pool id="default"
           default="true"
-          chunked-encoding="false"
-          http.conn-manager.max-total="10"
-          http.conn-manager.max-per-route="2"
-          http.socket.timeout="30000"
-          http.socket.buffer-size="8192"
-          http.connection.timeout="30000"
-          http.connection.max-line-length="8192"
-          http.connection.max-header-count="100"
-          http.connection.max-status-line-garbage="100"
-          http.tcp.nodelay="true"
-          keepalive.timeout="0"/>
+          chunked-encoding="false"/>
 
 </http-connection-pools>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/proxy/ContentLengthTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/proxy/ContentLengthTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Unroll
 
 class ContentLengthTest extends ReposeValveTest {
 
-    def timeBombDate = new GregorianCalendar(2017, Calendar.JANUARY, 5)
+    public static def TIME_BOMB_DATE = new GregorianCalendar(2017, Calendar.JANUARY, 5)
 
     def setupSpec() {
         deproxy = new Deproxy()
@@ -67,7 +67,7 @@ class ContentLengthTest extends ReposeValveTest {
         "TRACE" | null    | 0            | 0              | 0
     }
 
-    @IgnoreIf({ new Date() < timeBombDate.getTime() })
+    @IgnoreIf({ new Date() < ContentLengthTest.TIME_BOMB_DATE.getTime() })
     @Unroll("should not send chunked request for incoming chunked #method request with request body: #reqBody")
     def "when chunked encoding is set to false and the incoming request is chunked, Repose should not send chunked requests"() {
         when:

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/proxy/ContentLengthTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/proxy/ContentLengthTest.groovy
@@ -23,9 +23,12 @@ import framework.ReposeValveTest
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.Handling
 import org.rackspace.deproxy.MessageChain
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 class ContentLengthTest extends ReposeValveTest {
+
+    def timeBombDate = new GregorianCalendar(2017, Calendar.JANUARY, 5)
 
     def setupSpec() {
         deproxy = new Deproxy()
@@ -64,6 +67,7 @@ class ContentLengthTest extends ReposeValveTest {
         "TRACE" | null    | 0            | 0              | 0
     }
 
+    @IgnoreIf({ new Date() < timeBombDate.getTime() })
     @Unroll("should not send chunked request for incoming chunked #method request with request body: #reqBody")
     def "when chunked encoding is set to false and the incoming request is chunked, Repose should not send chunked requests"() {
         when:


### PR DESCRIPTION
Adding test (that is expected to fail) to prove that Repose sends the "Transfer-Encoding: chunked" header if the user sends it, regardless of the value of the "chunked-encoding" attribute of the default connection pool.

Story: https://repose.atlassian.net/browse/REP-4490