### PR TITLE
Logrotate needs root ownership

### DIFF
--- a/repose-aggregator/artifacts/valve/build.gradle
+++ b/repose-aggregator/artifacts/valve/build.gradle
@@ -139,8 +139,8 @@ ospackage {
     from('../src/config/logrotate.d') {
         into '/etc/logrotate.d'
         createDirectoryEntry false
-        user 'repose'
-        permissionGroup 'repose'
+        user 'root'
+        permissionGroup 'root'
         fileMode 0644
     }
 

--- a/repose-aggregator/artifacts/web-application/build.gradle
+++ b/repose-aggregator/artifacts/web-application/build.gradle
@@ -112,8 +112,8 @@ ospackage {
     from('../src/config/logrotate.d') {
         into '/etc/logrotate.d'
         createDirectoryEntry false
-        user 'repose'
-        permissionGroup 'repose'
+        user 'root'
+        permissionGroup 'root'
         fileMode 0644
     }
 


### PR DESCRIPTION
[root@some-server ~]# cat /etc/redhat-release
CentOS Linux release 7.2.1511 (Core)

[root@some-server ~]# ls -lah /etc/logrotate.d/repose
-rw-r--r--. 1 repose repose 109 May  6 10:11 /etc/logrotate.d/repose

[root@some-server ~]# logrotate -v /etc/logrotate.d/repose
Ignoring /etc/logrotate.d/repose because the file owner is wrong (should be root).

Handling 0 logs
set default create context
