### PR TITLE
REP-4582 Merging the 7.3.8.1 release into master

### DIFF
--- a/repose-aggregator/components/filters/rackspace-auth-user-filter/src/main/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserHandler.scala
+++ b/repose-aggregator/components/filters/rackspace-auth-user-filter/src/main/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserHandler.scala
@@ -65,8 +65,8 @@ class RackspaceAuthUserHandler(filterConfig: RackspaceAuthUserConfig) extends La
   }
 
   /**
-   * Many payloads to parse here, should be fun
-   */
+    * Many payloads to parse here, should be fun
+    */
   val username2_0XML: UsernameParsingFunction = { is =>
     val xml = XML.load(is)
     val auth = xml \\ "auth"
@@ -157,13 +157,12 @@ class RackspaceAuthUserHandler(filterConfig: RackspaceAuthUserConfig) extends La
   }
 
   /**
-   * Build a function that takes our config, the request itself, functions to transform if given json, and if given XML
-   * and then a resultant function that can take that config and the username to do the work with.
-   */
+    * Build a function that takes our config, the request itself, functions to transform if given json, and if given XML
+    * and then a resultant function that can take that config and the username to do the work with.
+    */
   def parseUsername(config: IdentityGroupConfig, inputStream: InputStream, contentType: String, json: UsernameParsingFunction, xml: UsernameParsingFunction)(usernameFunction: (IdentityGroupConfig, Option[String], Option[String]) => Unit) = {
     val limit = BigInt(config.getContentBodyReadLimit).toLong
-    //Copied this limited read stuff from the other content-identity filter...
-    val limitedInputStream = new LimitedReadInputStream(limit, inputStream) //Allows me to reset?
+    val limitedInputStream = new LimitedReadInputStream(limit, inputStream)
     limitedInputStream.mark(limit.toInt)
     try {
       val (domainOpt, userOpt) = if (contentType.contains("xml")) {

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/compression.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/compression.cfg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<content-compression xmlns="http://docs.openrepose.org/repose/content-compression/v1.0">
+    <compression compression-threshold="1024" include-content-types="application/xml application/json"/>
+</content-compression>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/rackspace-auth-user.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/rackspace-auth-user.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rackspace-auth-user xmlns='http://docs.openrepose.org/repose/rackspace-auth-user/v1.0'>
+    <!-- both of the version configs are optional, if neither are specified, this filter is a no-op -->
+    <v1_1>
+        <group>Some Group</group>
+        <quality>0.80</quality>
+    </v1_1>
+    <v2_0>
+        <group>Some Group</group>
+        <quality>0.80</quality>
+    </v2_0>
+</rackspace-auth-user>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/slf4j-http-logging.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/slf4j-http-logging.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<slf4j-http-logging xmlns="http://docs.openrepose.org/repose/slf4j-http-logging/v1.0">
+    <!-- The id attribute is the named target of the log output,
+it can then be used in log4j backend to determine which appender to go to -->
+    <!-- The format includes what will be logged. The arguments with % are a subset of the apache mod_log_config
+found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->
+    <slf4j-http-log
+            id="my-special-log"
+            format="Remote User=%u\tURL Path Requested=%U\tRequest Protocol=%H\tServer Port=%p\tQuery String=%q\tResponse Time=%T seconds\tResponse Time=%D microseconds\tRequest Line=&quot;%r&quot;\tTime Request Received=%t\tStatus=%s\n"/>
+    <slf4j-http-log id="my-test-log"
+                    format="Remote IP=%a Local IP=%A Request Method=%m Response Code=%s Response Time=%D "/>
+</slf4j-http-logging>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/system-model.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/system-model.cfg.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+
+        <nodes>
+            <node id="node1" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+
+        <filters>
+            <filter name="${preceding-filter}"/>
+            <filter name="rackspace-auth-user"/>
+        </filters>
+
+        <destinations>
+            <endpoint id="openrepose" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
+                      default="true"/>
+        </destinations>
+
+    </repose-cluster>
+
+</system-model>
+

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/translation.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/rackspaceauthuser/inputstream/translation.cfg.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<translation xmlns="http://docs.openrepose.org/repose/translation/v1.0" allow-doctype-decl="true">
+    <request-translations>
+        <request-translation content-type="application/xml" translated-content-type="application/xml">
+            <style-sheets>
+                <style id="copy">
+                    <xsl>
+                        <xsl:stylesheet
+                                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                                version="2.0">
+
+                            <xsl:output method="xml" encoding="UTF-8"/>
+
+                            <xsl:template match="node() | @*">
+                                <xsl:copy>
+                                    <xsl:apply-templates select="@* | node()"/>
+                                </xsl:copy>
+                            </xsl:template>
+                        </xsl:stylesheet>
+                    </xsl>
+                </style>
+            </style-sheets>
+        </request-translation>
+    </request-translations>
+</translation>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/RackspaceAuthPayloads.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/RackspaceAuthPayloads.groovy
@@ -19,6 +19,8 @@
  */
 package features.filters.rackspaceauthuser
 
+import groovy.transform.Canonical
+
 class RackspaceAuthPayloads {
     public static Map contentXml = ["content-type": "application/xml"]
     public static Map contentJson = ["content-type": "application/json"]
@@ -83,6 +85,7 @@ class RackspaceAuthPayloads {
     // TODO: Have the API documentation updated and update this payload.
     public static String userMfaSetupXmlV20 = """<?xml version="1.0" encoding="UTF-8"?>
 <auth xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:RAX-AUTH="http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1.0"
       xmlns="http://docs.openstack.org/identity/api/v2.0">
     <RAX-AUTH:scope>SETUP-MFA</RAX-AUTH:scope>
     <passwordCredentials username="demoAuthor" password="myPassword01"/>
@@ -192,4 +195,32 @@ class RackspaceAuthPayloads {
         }
     }
 }"""
+
+    def static payloadTests = [
+            new PayloadTest("userPasswordXmlV20", userPasswordXmlV20, contentXml, "demoAuthor"),
+            new PayloadTest("userPasswordJsonV20", userPasswordJsonV20, contentJson, "demoAuthor"),
+            new PayloadTest("userApiKeyXmlV20", userApiKeyXmlV20, contentXml, "demoAuthor"),
+            new PayloadTest("userApiKeyJsonV20", userApiKeyJsonV20, contentJson, "demoAuthor"),
+            new PayloadTest("userPasswordXmlEmptyV20", userPasswordXmlEmptyV20, contentXml, "demoAuthor"),
+            new PayloadTest("userPasswordJsonEmptyV20", userPasswordJsonEmptyV20, contentJson, "demoAuthor"),
+            new PayloadTest("userMfaSetupXmlV20", userMfaSetupXmlV20, contentXml, "demoAuthor"),
+            new PayloadTest("userMfaSetupJsonV20", userMfaSetupJsonV20, contentJson, "demoAuthor"),
+            new PayloadTest("rackerPasswordXmlV20", rackerPasswordXmlV20, contentXml, "Racker:jqsmith"),
+            new PayloadTest("rackerPasswordJsonV20", rackerPasswordJsonV20, contentJson, "Racker:jqsmith"),
+            new PayloadTest("rackerTokenKeyXmlV20", rackerTokenKeyXmlV20, contentXml, "Racker:jqsmith"),
+            new PayloadTest("rackerTokenKeyJsonV20", rackerTokenKeyJsonV20, contentJson, "Racker:jqsmith"),
+            new PayloadTest("federatedTokenKeyXmlV20", federatedPasswordXmlV20, contentXml, "jqsmith"),
+            new PayloadTest("federatedTokenKeyJsonV20", federatedPasswordJsonV20, contentJson, "jqsmith"),
+            new PayloadTest("userKeyXmlV11", userKeyXmlV11, contentXml, "test-user"),
+            new PayloadTest("userKeyJsonV11", userKeyJsonV11, contentJson, "test-user"),
+            new PayloadTest("userKeyXmlEmptyV11", userKeyXmlEmptyV11, contentXml, "test-user"),
+            new PayloadTest("userKeyJsonEmptyV11", userKeyJsonEmptyV11, contentJson, "test-user")]
+
+    @Canonical
+    static class PayloadTest {
+        String testName
+        String requestBody
+        Map contentType
+        String expectedUser
+    }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/inputstream/PrecededByCompressionFilterTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/inputstream/PrecededByCompressionFilterTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.rackspaceauthuser.inputstream
+
+import features.filters.compression.CompressionHeaderTest
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import spock.lang.Unroll
+
+import static features.filters.rackspaceauthuser.RackspaceAuthPayloads.*
+
+class PrecededByCompressionFilterTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
+
+        Map params = properties.defaultTemplateParams + ["preceding-filter": "compression"]
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/rackspaceauthuser/inputstream", params)
+        repose.start()
+        repose.waitForNon500FromUrl(reposeEndpoint)
+    }
+
+    @Unroll
+    def "username is parsed correctly when the compression filter precedes the Rackspace Auth User filter for test #payloadTest.testName"() {
+        when:
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint,
+                requestBody: payloadTest.requestBody,
+                headers: payloadTest.contentType,
+                method: "POST")
+
+        then:
+        mc.handlings[0].request.headers.findAll("x-pp-user").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-user") == payloadTest.expectedUser + ";q=0.8"
+        mc.handlings[0].request.headers.findAll("x-pp-groups").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-groups") == "Some Group;q=0.8"
+
+        where:
+        payloadTest << payloadTests
+    }
+
+    @Unroll
+    def "username is parsed correctly when request body comes in compressed for test #payloadTest.testName"() {
+        given:
+        def compressedRequestBody = CompressionHeaderTest.compressGzipContent(payloadTest.requestBody)
+
+        when:
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint,
+                requestBody: compressedRequestBody,
+                headers: payloadTest.contentType + ["Content-Encoding": "gzip"],
+                method: "POST")
+
+        then:
+        mc.handlings[0].request.headers.findAll("x-pp-user").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-user") == payloadTest.expectedUser + ";q=0.8"
+        mc.handlings[0].request.headers.findAll("x-pp-groups").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-groups") == "Some Group;q=0.8"
+
+        where:
+        payloadTest << payloadTests
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/inputstream/PrecededByContentTypeStripperFilterTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/inputstream/PrecededByContentTypeStripperFilterTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.rackspaceauthuser.inputstream
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import spock.lang.Unroll
+
+import static features.filters.rackspaceauthuser.RackspaceAuthPayloads.*
+
+class PrecededByContentTypeStripperFilterTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
+
+        Map params = properties.defaultTemplateParams + ["preceding-filter": "content-type-stripper"]
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/rackspaceauthuser/inputstream", params)
+        repose.start()
+        repose.waitForNon500FromUrl(reposeEndpoint)
+    }
+
+    @Unroll
+    def "username is parsed correctly when the content-type-stripper filter precedes the Rackspace Auth User filter for test #payloadTest.testName"() {
+        when:
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint,
+                requestBody: payloadTest.requestBody,
+                headers: payloadTest.contentType,
+                method: "POST")
+
+        then:
+        mc.handlings[0].request.headers.findAll("x-pp-user").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-user") == payloadTest.expectedUser + ";q=0.8"
+        mc.handlings[0].request.headers.findAll("x-pp-groups").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-groups") == "Some Group;q=0.8"
+
+        where:
+        payloadTest << payloadTests
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/inputstream/PrecededBySlf4jHttpLoggingFilterTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/inputstream/PrecededBySlf4jHttpLoggingFilterTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.rackspaceauthuser.inputstream
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import spock.lang.Unroll
+
+import static features.filters.rackspaceauthuser.RackspaceAuthPayloads.*
+
+class PrecededBySlf4jHttpLoggingFilterTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
+
+        Map params = properties.defaultTemplateParams + ["preceding-filter": "slf4j-http-logging"]
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/rackspaceauthuser/inputstream", params)
+        repose.start()
+        repose.waitForNon500FromUrl(reposeEndpoint)
+    }
+
+    @Unroll
+    def "username is parsed correctly when the slf4j-http-logging filter precedes the Rackspace Auth User filter for test #payloadTest.testName"() {
+        when:
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint,
+                requestBody: payloadTest.requestBody,
+                headers: payloadTest.contentType,
+                method: "POST")
+
+        then:
+        mc.handlings[0].request.headers.findAll("x-pp-user").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-user") == payloadTest.expectedUser + ";q=0.8"
+        mc.handlings[0].request.headers.findAll("x-pp-groups").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-groups") == "Some Group;q=0.8"
+
+        where:
+        payloadTest << payloadTests
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/inputstream/PrecededByTranslationFilterTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/inputstream/PrecededByTranslationFilterTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.rackspaceauthuser.inputstream
+
+import framework.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import spock.lang.Unroll
+
+import static features.filters.rackspaceauthuser.RackspaceAuthPayloads.*
+
+class PrecededByTranslationFilterTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
+
+        Map params = properties.defaultTemplateParams + ["preceding-filter": "translation"]
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/rackspaceauthuser/inputstream", params)
+        repose.start()
+        repose.waitForNon500FromUrl(reposeEndpoint)
+    }
+
+    @Unroll
+    def "username is parsed correctly when the translation filter precedes the Rackspace Auth User filter for test #payloadTest.testName"() {
+        when:
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint,
+                requestBody: payloadTest.requestBody,
+                headers: payloadTest.contentType,
+                method: "POST")
+
+        then:
+        mc.handlings[0].request.headers.findAll("x-pp-user").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-user") == payloadTest.expectedUser + ";q=0.8"
+        mc.handlings[0].request.headers.findAll("x-pp-groups").size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-pp-groups") == "Some Group;q=0.8"
+
+        where:
+        payloadTest << payloadTests
+    }
+}


### PR DESCRIPTION
I updated the code to use the new way of handling streams. That is the only change to the content of the merge that was modified. All of the tests were just stuck in the right spot.

Once this is merged, we can delete the release branch (`REP-4575_FixInputStreamAssumptions`).