### PR TITLE
Fix ClassLoaderTest port issue

### DIFF
--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/classloader/ClassLoaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/classloader/ClassLoaderTest.groovy
@@ -24,6 +24,7 @@ import framework.ReposeValveLauncher
 import framework.ReposeValveTest
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.MessageChain
+import org.rackspace.deproxy.PortFinder
 
 class ClassLoaderTest extends ReposeValveTest {
     static int originServicePort
@@ -60,6 +61,7 @@ class ClassLoaderTest extends ReposeValveTest {
         originServicePort = properties.targetPort
         deproxy.addEndpoint(originServicePort)
 
+        properties.reposePort = PortFinder.Singleton.getNextOpenPort()
         reposePort = properties.reposePort
         url = "http://localhost:${reposePort}"
 
@@ -123,6 +125,7 @@ class ClassLoaderTest extends ReposeValveTest {
         originServicePort = properties.targetPort
         deproxy.addEndpoint(originServicePort)
 
+        properties.reposePort = PortFinder.Singleton.getNextOpenPort()
         reposePort = properties.reposePort
         url = "http://localhost:${reposePort}"
 
@@ -169,6 +172,7 @@ class ClassLoaderTest extends ReposeValveTest {
         originServicePort = properties.targetPort
         deproxy.addEndpoint(originServicePort)
 
+        properties.reposePort = PortFinder.Singleton.getNextOpenPort()
         reposePort = properties.reposePort
         url = "http://localhost:${reposePort}"
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/classloader/ClassLoaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/classloader/ClassLoaderTest.groovy
@@ -27,7 +27,6 @@ import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.PortFinder
 
 class ClassLoaderTest extends ReposeValveTest {
-    static int originServicePort
     static int reposePort
     static String url
     static ReposeConfigurationProvider reposeConfigProvider
@@ -58,8 +57,8 @@ class ClassLoaderTest extends ReposeValveTest {
      */
     def "An ear file can access a dependency that is not present in another ear"() {
         deproxy = new Deproxy()
-        originServicePort = properties.targetPort
-        deproxy.addEndpoint(originServicePort)
+        properties.targetPort = PortFinder.Singleton.getNextOpenPort()
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
 
         properties.reposePort = PortFinder.Singleton.getNextOpenPort()
         reposePort = properties.reposePort
@@ -122,8 +121,8 @@ class ClassLoaderTest extends ReposeValveTest {
      */
     def "Ensure filter three (in filter-bundle-three) cannot reach a dependency in filter-bundle-one"() {
         deproxy = new Deproxy()
-        originServicePort = properties.targetPort
-        deproxy.addEndpoint(originServicePort)
+        properties.targetPort = PortFinder.Singleton.getNextOpenPort()
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
 
         properties.reposePort = PortFinder.Singleton.getNextOpenPort()
         reposePort = properties.reposePort
@@ -169,8 +168,8 @@ class ClassLoaderTest extends ReposeValveTest {
 
     def "test class loader three"() {
         deproxy = new Deproxy()
-        originServicePort = properties.targetPort
-        deproxy.addEndpoint(originServicePort)
+        properties.targetPort = PortFinder.Singleton.getNextOpenPort()
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
 
         properties.reposePort = PortFinder.Singleton.getNextOpenPort()
         reposePort = properties.reposePort


### PR DESCRIPTION
The ClassLoaderTest was failing fairly often on the Jenkins nodes either on the second or third test.  The failures in the nightly builds and the ones I observed when running on slave4 all occurred when Deproxy was adding a new endpoint for the origin service.  The same port was being used across the three tests, so I updated the code to ensure that a new port would be used for the origin service and Repose for each test.

I verified in the logs that new ports are being used for each test run, and I verified that I could run the test 12 times on slave4 successfully.

Ninja task: https://repose.atlassian.net/browse/REP-4610