### PR TITLE
REP-3390 - CORS Access-Control-Request-Headers

### DIFF
--- a/repose-aggregator/components/filters/cors-filter/src/main/scala/org/openrepose/filters/cors/CorsFilter.scala
+++ b/repose-aggregator/components/filters/cors-filter/src/main/scala/org/openrepose/filters/cors/CorsFilter.scala
@@ -122,7 +122,6 @@ class CorsFilter @Inject()(configurationService: ConfigurationService)
           }
         case OriginNotAllowed =>
           logger.debug("Request rejected because origin '{}' is not allowed.", origin)
-          httpServletResponse.setHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN, "null")
           httpServletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN)
         case MethodNotAllowed =>
           logger.debug("Request rejected because method '{}' is not allowed for resource '{}'.",

--- a/repose-aggregator/components/filters/cors-filter/src/main/scala/org/openrepose/filters/cors/CorsFilter.scala
+++ b/repose-aggregator/components/filters/cors-filter/src/main/scala/org/openrepose/filters/cors/CorsFilter.scala
@@ -119,7 +119,7 @@ class CorsFilter @Inject()(configurationService: ConfigurationService)
               }
           }
         case OriginNotAllowed =>
-          httpServletResponse.setHeader(CorsHttpHeader.ORIGIN, "null")
+          httpServletResponse.setHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN, "null")
           httpServletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN)
         case MethodNotAllowed =>
           httpServletResponse.setHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN, origin)

--- a/repose-aggregator/components/filters/cors-filter/src/test/scala/org/openrepose/filters/cors/CorsFilterTest.scala
+++ b/repose-aggregator/components/filters/cors-filter/src/test/scala/org/openrepose/filters/cors/CorsFilterTest.scala
@@ -22,12 +22,12 @@ package org.openrepose.filters.cors
 import javax.servlet.FilterChain
 
 import org.junit.runner.RunWith
-import org.mockito.Matchers.{any, eq => mockitoEq}
+import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.openrepose.commons.utils.http.{CommonHttpHeader, CorsHttpHeader, HeaderConstant}
-import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
+import org.openrepose.commons.utils.servlet.http.{HttpServletRequestWrapper, HttpServletResponseWrapper}
 import org.openrepose.filters.cors.config.Origins.Origin
 import org.openrepose.filters.cors.config._
 import org.scalatest.junit.JUnitRunner
@@ -67,7 +67,7 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
           corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-          verify(filterChain).doFilter(any(classOf[HttpServletRequestWrapper]), mockitoEq(servletResponse))
+          verify(filterChain).doFilter(any(classOf[HttpServletRequestWrapper]), any(classOf[HttpServletResponseWrapper]))
         }
 
         it(s"should not add CORS specific headers for HTTP method $httpMethod") {
@@ -158,6 +158,7 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
           corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
           servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should not be null
+          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
         }
 
         List(
@@ -176,7 +177,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
             corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-            servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS) should contain theSameElementsAs expectedAllowedHeaders
+            servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS) should have size 1
+            servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS).split(",") should contain theSameElementsAs expectedAllowedHeaders
           }
         }
 
@@ -233,7 +235,7 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
           corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-          verify(filterChain).doFilter(any(classOf[HttpServletRequestWrapper]), mockitoEq(servletResponse))
+          verify(filterChain).doFilter(any(classOf[HttpServletRequestWrapper]), any(classOf[HttpServletResponseWrapper]))
         }
 
         it(s"should not add preflight specific headers for HTTP method $httpMethod") {
@@ -276,10 +278,11 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
             corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
             // Access-Control-Expose-Headers should have all of the response headers in it except for itself and the Vary header
-            servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS) should contain theSameElementsAs
+            servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS).split(",") should contain theSameElementsAs
               servletResponse.getHeaderNames.asScala.filter { headerName =>
                 headerName != CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString &&
                   headerName != CommonHttpHeader.VARY.toString}
+            servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS) should have size 1
           }
         }
 
@@ -448,7 +451,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
           corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain (httpMethod)
+          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+          servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain (httpMethod)
         }
 
         it(s"should not permit HTTP method $httpMethod when it is not globally allowed in config") {
@@ -472,7 +476,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
           corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain (httpMethod)
+          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+          servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain (httpMethod)
         }
 
         it(s"should not permit HTTP method $httpMethod when it is not configured and a root resource allows something else") {
@@ -508,7 +513,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
           corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain (httpMethod)
+          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+          servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain (httpMethod)
         }
 
         it(s"should permit HTTP method $httpMethod when a specific child resource allows it") {
@@ -520,7 +526,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
           corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain (httpMethod)
+          servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+          servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain (httpMethod)
         }
 
         it(s"should return a 403 when the requested method is not allowed for method $httpMethod") {
@@ -545,7 +552,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain theSameElementsAs List("GET", "POST", "PUT", "DELETE")
+        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain theSameElementsAs List("GET", "POST", "PUT", "DELETE")
       }
 
       it("should permit multiple HTTP methods specified in both global config and a specific resource") {
@@ -557,7 +565,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain theSameElementsAs List("GET", "POST", "PUT", "DELETE")
+        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain theSameElementsAs List("GET", "POST", "PUT", "DELETE")
       }
 
       it("should permit multiple HTTP methods specified in both global config and a specific root resource") {
@@ -569,7 +578,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain theSameElementsAs List("GET", "POST", "PUT", "PATCH")
+        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain theSameElementsAs List("GET", "POST", "PUT", "PATCH")
       }
 
       it("should be able to handle a path param with a configured resource path specified with regex") {
@@ -581,7 +591,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain theSameElementsAs List("GET", "POST", "PUT", "PATCH")
+        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain theSameElementsAs List("GET", "POST", "PUT", "PATCH")
       }
 
       it("should permit multiple HTTP methods specified in both global config and a specific resource with no methods") {
@@ -593,7 +604,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
 
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
-        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should contain theSameElementsAs List("GET", "POST")
+        servletResponse.getHeaders(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS) should have size 1
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS).split(",") should contain theSameElementsAs List("GET", "POST")
       }
     }
   }

--- a/repose-aggregator/components/filters/cors-filter/src/test/scala/org/openrepose/filters/cors/CorsFilterTest.scala
+++ b/repose-aggregator/components/filters/cors-filter/src/test/scala/org/openrepose/filters/cors/CorsFilterTest.scala
@@ -372,6 +372,7 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
         servletResponse.getStatus shouldBe 403
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN) shouldBe "null"
       }
 
       it("should allow an actual request with a specific origin") {
@@ -418,6 +419,7 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
         servletResponse.getStatus shouldBe 403
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN) shouldBe "null"
       }
 
       it("should allow a non-CORS request that does not have an origin header") {

--- a/repose-aggregator/components/filters/cors-filter/src/test/scala/org/openrepose/filters/cors/CorsFilterTest.scala
+++ b/repose-aggregator/components/filters/cors-filter/src/test/scala/org/openrepose/filters/cors/CorsFilterTest.scala
@@ -165,7 +165,8 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
           (List("x-panda, x-unicorn"), List("x-panda", "x-unicorn")),
           (List("x-cupcake", "x-pineapple"), List("x-cupcake", "x-pineapple")),
           (List("accept, user-agent, x-trans-id"), List("accept", "user-agent", "x-trans-id")),
-          (List("x-one, x-two", "x-three"), List("x-one", "x-two", "x-three"))
+          (List("x-one, x-two", "x-three"), List("x-one", "x-two", "x-three")),
+          (List("x-red", "x-green", "x-blue"), List("x-red", "x-green", "x-blue"))
         ) foreach { case (requestHeaders, expectedAllowedHeaders) =>
           it(s"should have the Access-Control-Allow-Headers header set to $expectedAllowedHeaders for request HTTP method $requestMethod and request headers $requestHeaders") {
             servletRequest.setMethod("OPTIONS")

--- a/repose-aggregator/components/filters/cors-filter/src/test/scala/org/openrepose/filters/cors/CorsFilterTest.scala
+++ b/repose-aggregator/components/filters/cors-filter/src/test/scala/org/openrepose/filters/cors/CorsFilterTest.scala
@@ -373,7 +373,7 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
         servletResponse.getStatus shouldBe 403
-        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN) shouldBe "null"
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN) shouldBe null
       }
 
       it("should allow an actual request with a specific origin") {
@@ -420,7 +420,7 @@ class CorsFilterTest extends FunSpec with BeforeAndAfterEach with Matchers {
         corsFilter.doFilter(servletRequest, servletResponse, filterChain)
 
         servletResponse.getStatus shouldBe 403
-        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN) shouldBe "null"
+        servletResponse.getHeader(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN) shouldBe null
       }
 
       it("should allow a non-CORS request that does not have an origin header") {

--- a/repose-aggregator/src/docs/asciidoc/filters/cors.adoc
+++ b/repose-aggregator/src/docs/asciidoc/filters/cors.adoc
@@ -1,6 +1,4 @@
 = CORS
-:toc:
-:icons: font
 
 include::../_includes/in-progress.adoc[]
 
@@ -51,6 +49,9 @@ a| * `Access-Control-Allow-Credentials`
 If the CORS filter rejects the request, the following header will be added to the response:
 
 * `Access-Control-Allow-Origin`
+
+The value of the header will be `"null"` (including the quotation marks) if the origin was not allowed.
+Otherwise, the value will be the same value as the `Origin` header in the request if the origin was allowed but the HTTP method for the requested resource was not.
 
 == Early Termination Conditions
 These are the scenarios in which the CORS filters will stop processing the request and immediately return a response:

--- a/repose-aggregator/src/docs/asciidoc/filters/cors.adoc
+++ b/repose-aggregator/src/docs/asciidoc/filters/cors.adoc
@@ -1,4 +1,6 @@
 = CORS
+:toc:
+:icons: font
 
 include::../_includes/in-progress.adoc[]
 
@@ -49,9 +51,6 @@ a| * `Access-Control-Allow-Credentials`
 If the CORS filter rejects the request, the following header will be added to the response:
 
 * `Access-Control-Allow-Origin`
-
-The value of the header will be "null" (quotes not included) if the origin was not allowed.
-Otherwise, the value will be the same value as the `Origin` header in the request if the origin was allowed but the HTTP method for the requested resource was not.
 
 == Early Termination Conditions
 These are the scenarios in which the CORS filters will stop processing the request and immediately return a response:

--- a/repose-aggregator/src/docs/asciidoc/filters/cors.adoc
+++ b/repose-aggregator/src/docs/asciidoc/filters/cors.adoc
@@ -50,7 +50,7 @@ If the CORS filter rejects the request, the following header will be added to th
 
 * `Access-Control-Allow-Origin`
 
-The value of the header will be `"null"` (including the quotation marks) if the origin was not allowed.
+The value of the header will be "null" (quotes not included) if the origin was not allowed.
 Otherwise, the value will be the same value as the `Origin` header in the request if the origin was allowed but the HTTP method for the requested resource was not.
 
 == Early Termination Conditions

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
@@ -147,9 +147,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
         and: "the request does not make it to the origin service"
         mc.getHandlings().size() == 0
 
-        and: "the 'Access-Control-Allow-Origin' header is set to 'null' to indicate the 'Origin' was not allowed"
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == "null"
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
+        and: "the 'Access-Control-Allow-Origin' header is not set to indicate the 'Origin' was not allowed"
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 0
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
@@ -174,9 +173,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
         and: "the request does not make it to the origin service"
         mc.getHandlings().size() == 0
 
-        and: "the 'Access-Control-Allow-Origin' header is set to 'null' to indicate the 'Origin' was not allowed"
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == "null"
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
+        and: "the 'Access-Control-Allow-Origin' header is not set to indicate the 'Origin' was not allowed"
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 0
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
@@ -392,14 +392,14 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.findAll("Vary") == ['origin']
 
         where:
-        method    | path
-        "PATCH"   | "/status"
-        "DELETE"  | "/status"
-        "PATCH"   | "/"
-        "DELETE"  | "/"
-        "PUT"     | "/"
-        "POST"    | "/"
-        "TRACE"   | "/"
+        method   | path
+        "PATCH"  | "/status"
+        "DELETE" | "/status"
+        "PATCH"  | "/"
+        "DELETE" | "/"
+        "PUT"    | "/"
+        "POST"   | "/"
+        "TRACE"  | "/"
     }
 
     @Unroll
@@ -408,8 +408,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
         def origin = 'http://openrepose.com:80'
         def path = '/testupdate'
         def headers = [
-                (CorsHttpHeader.ORIGIN.toString()): origin,
-                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method,
+                (CorsHttpHeader.ORIGIN.toString())                        : origin,
+                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()) : method,
                 (CorsHttpHeader.ACCESS_CONTROL_REQUEST_HEADERS.toString()): requestHeaders
         ]
 
@@ -464,13 +464,16 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.getHandlings().size() == 0
 
         and: "the CORS headers for a preflight request are added"
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).size() == 1
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()).size() == 1
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
-        and: "the 'Access-Control-Allow-Headers' header is set to the values that were in the 'Access-Control-Request-Headers' header correctly split"
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()) == allowHeaders
+        and: "the 'Access-Control-Allow-Headers' header is set to the values that were in the 'Access-Control-Request-Headers' header without being split"
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).size() == 1
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).tokenize(',').containsAll(allowHeaders)
 
         and: "the CORS headers for an actual request are not added"
         !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
@@ -71,7 +71,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
     }
 
     def "Actual request with method OPTIONS is not treated like a Preflight request if it does not have an 'Access-Control-Request-Method' header"() {
-        given: "the request has an 'origin' header making this an actual CORS request"
+        given: "the request has an 'Origin' header making this an actual CORS request"
         def origin = 'http://test.repose.site:80'
         def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
 
@@ -99,7 +99,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
     @Unroll
     def "Preflight request with 'Access-Control-Request-Method' header of #method, path #path, and origin #origin should return a 200"() {
-        given: "the request has both an 'origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
+        given: "the request has both an 'Origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
         def headers = [
                 (CorsHttpHeader.ORIGIN.toString())                       : origin,
                 (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
@@ -133,7 +133,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
     @Unroll
     def "Preflight request from an unauthorized origin results in a 403 for an 'Access-Control-Request-Method' header of #method, path #path, and origin #origin"() {
-        given: "the request has both an 'origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
+        given: "the request has both an 'Origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
         def headers = [
                 (CorsHttpHeader.ORIGIN.toString())                       : origin,
                 (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
@@ -162,7 +162,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
     @Unroll
     def "Actual request from an unauthorized origin results in a 403 for an 'Access-Control-Request-Method' header of #method, path #path, and origin #origin"() {
-        given: "the request has an 'origin' header making this an actual CORS request"
+        given: "the request has an 'Origin' header making this an actual CORS request"
         def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
 
         when: "the request is made"
@@ -189,7 +189,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
     @Unroll
     def "Preflight request for a path matching '/status.*' resource in config will return a 200 with 'Access-Control-Request-Method' header of #method and origin #origin"() {
-        given: "the request has both an 'origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
+        given: "the request has both an 'Origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
         def headers = [
                 (CorsHttpHeader.ORIGIN.toString())                       : origin,
                 (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
@@ -225,7 +225,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
     @Unroll
     def "Preflight request for a path matching '/testupdate.*' resource in config will return a 200 with 'Access-Control-Request-Method' header of #method and origin #origin"() {
-        given: "the request has both an 'origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
+        given: "the request has both an 'Origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
         def headers = [
                 (CorsHttpHeader.ORIGIN.toString())                       : origin,
                 (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
@@ -300,7 +300,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
     @Unroll
     def "Actual request for a path matching '/testupdate.*' resource in config will return a 200 with origin #origin"() {
-        given: "the request has an 'origin' header making this an actual CORS request"
+        given: "the request has an 'Origin' header making this an actual CORS request"
         def path = "/testupdate"
         def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
 
@@ -389,7 +389,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
         and: "the 'Access-Control-Allow-Methods' header does not exist"
         !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
 
-        and: "the 'Vary' header is set with the correct values for an OPTIONS request"
+        and: "the 'Vary' header is set with the correct values for a non-OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
         mc.receivedResponse.headers.findAll("Vary") == ['origin']
 
@@ -446,7 +446,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
     }
 
     @Unroll
-    def "Preflight request with 'Access-Control-Request-Headers' headers #requestHeaders results in 'Access-Control-Allow-Headers' headers #allowHeaders"() {
+    def "Preflight request with 'Access-Control-Request-Headers' headers #requestHeaders results in response with 'Access-Control-Allow-Headers' headers #allowHeaders"() {
         given: "an actual request with an allowed origin, valid path, and an 'Access-Control-Request-Headers' header"
         def origin = 'http://openrepose.com:80'
         def path = '/testupdate'

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
@@ -115,7 +115,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
         and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).size() == 1
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).tokenize(',').contains(method)
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
@@ -204,7 +205,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
         and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).size() == 1
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).tokenize(',').contains(method)
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
@@ -240,7 +242,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
 
         and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).size() == 1
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).tokenize(',').contains(method)
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
@@ -285,7 +288,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
         !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
 
         and: "all of the special headers from the origin service are added to the list of values in the 'Access-Control-Expose-Headers' header"
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).containsAll(responseHeaders)
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).size() == 1
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).tokenize(',').containsAll(responseHeaders)
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
@@ -423,9 +427,10 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.getHandlings().size() == 0
 
         and: "the CORS headers for a preflight request are added"
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).size() == 1
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).tokenize(',').contains(method)
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the 'Access-Control-Allow-Headers' header is set to the values that were in the 'Access-Control-Request-Headers' header"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
@@ -26,14 +26,13 @@ import org.rackspace.deproxy.MessageChain
 import org.rackspace.deproxy.Response
 import spock.lang.Unroll
 
-/**
- * Created by jennyvo on 9/29/15.
- */
+import javax.servlet.http.HttpServletResponse
+
 class CorsFilterBasicTest extends ReposeValveTest {
     def setupSpec() {
         reposeLogSearch.cleanLog()
         deproxy = new Deproxy()
-        deproxy.addEndpoint(properties.targetPort)
+        deproxy.addEndpoint(properties.targetPort, 'origin service')
 
         def params = properties.getDefaultTemplateParams()
         repose.configurationProvider.applyConfigs("common", params)
@@ -42,260 +41,363 @@ class CorsFilterBasicTest extends ReposeValveTest {
         repose.waitForNon500FromUrl(reposeEndpoint)
     }
 
-    @Unroll("Non-CORS request with method OPTIONS and a CORS header request Method: #method")
-    def "OPTIONS request without origin header will bypass CORS and make to origin service"() {
-        def headers = [
-                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
+    @Unroll
+    def "Non-CORS request with method OPTIONS, 'Access-Control-Request-Method' header of #method, and path #path should make it to origin service"() {
+        given: "the request has no 'Origin' header making this a non-CORS request"
+        def headers = [(CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
 
-        when:
+        when: "the request is made"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
 
-        then:
-        mc.receivedResponse.code == '200'
-        mc.getHandlings().size() == 1  // OPTIONS request without origin will make to it origin service
+        then: "the response status is OK"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
+
+        and: "the request makes it to the origin service"
+        mc.getHandlings().size() == 1
+
+        and: "none of the CORS headers are added to the response"
         !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
         !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
         !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+
+        and: "the 'Vary' header is set with the correct values for an OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
-        mc.receivedResponse.headers.findAll('Vary') == ['origin', 'access-control-request-headers', 'access-control-request-method']
+        mc.receivedResponse.headers.findAll("Vary") == ['origin', 'access-control-request-headers', 'access-control-request-method']
 
         where:
-        [method, path, origin] << [['GET', 'HEAD'], ['/', '/status'], ['http://openrepose.com:80', 'http://test.repose.site:80']].combinations()
+        [method, path] << [['GET', 'HEAD'], ['/', '/status']].combinations()
     }
 
-    def "Actual request with method OPTIONS"() {
-        given:
-        def origin = 'http://openrepose.com:80'
+    def "Actual request with method OPTIONS is not treated like a Preflight request if it does not have an 'Access-Control-Request-Method' header"() {
+        given: "the request has an 'origin' header making this an actual CORS request"
+        def origin = 'http://test.repose.site:80'
         def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
 
-        when:
+        when: "the request is made"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + '/testoptions', method: 'OPTIONS', headers: headers)
 
-        then:
-        mc.receivedResponse.code == '200'
-        mc.getHandlings().size() == 1   // actual request should make it through to the origin service
+        then: "the response status is OK"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
+
+        and: "the request makes it to the origin service"
+        mc.getHandlings().size() == 1
+
+        and: "the CORS headers for an actual request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
+
+        and: "the CORS headers for a preflight request are not added"
         !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+
+        and: "the 'Vary' header is set with the correct values for an OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
-        mc.receivedResponse.headers.findAll('Vary') == ['origin', 'access-control-request-headers', 'access-control-request-method']
-    }
-
-    @Unroll("Preflight request with origin #origin and request method #method ")
-    def "When sending preflight request with cors filter, the specific headers should be added for requested method #method, origin #origin, and path #path"() {
-        given:
-        def headers = [
-                (CorsHttpHeader.ORIGIN.toString())                       : origin,
-                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
-
-        when:
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
-
-        then:
-        mc.receivedResponse.code == '200'
-        mc.getHandlings().size() == 0  // preflight request doesn't make it to the origin service
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
-        mc.receivedResponse.headers.contains("Vary")
-
-        where:
-        [method, path, origin] << [['GET', 'HEAD'], ['/', '/status'], ['http://openrepose.com:80', 'http://test.repose.site:80']].combinations()
-    }
-
-    @Unroll("Prefight request Not allowed Origin request header with method #method, path #path, and origin #origin")
-    def "Origin request header is not allow in the config response 403"() {
-        given:
-        def headers = [
-                (CorsHttpHeader.ORIGIN.toString())                       : origin,
-                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
-
-        when:
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
-
-        then:
-        mc.receivedResponse.code == '403'
-        mc.getHandlings().size() == 0
-        mc.receivedResponse.headers.contains("Vary")
-
-        where:
-        [method, path, origin] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"],
-                                   ["/", "/status"],
-                                   ["http://test.forbidden.com", "http://test.home.site:80"]].combinations()
-    }
-
-    @Unroll("Actual request Not allowed Origin request header with method #method, path #path, and origin #origin")
-    def "Actual Request with Origin request header is not allow in the config response 403"() {
-        given:
-        def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
-
-        when:
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: method, headers: headers)
-
-        then:
-        mc.receivedResponse.code == '403'
-        mc.getHandlings().size() == 0
-        mc.receivedResponse.headers.contains("Vary")
-
-        where:
-        [method, path, origin] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"],
-                                   ["/", "/status"],
-                                   ["http://test.forbidden.com", "http://test.home.site:80"]].combinations()
-    }
-
-    @Unroll("Preflight request, Allowed resource and Origin request header with method #method, path #path, and origin #origin")
-    def "Origin request header is allow in the config"() {
-        given:
-        def headers = [
-                (CorsHttpHeader.ORIGIN.toString())                       : origin,
-                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
-
-        when:
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
-
-        then:
-        mc.receivedResponse.code == '200'
-        mc.getHandlings().size() == 0
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
-        mc.receivedResponse.headers.contains("Vary")
-
-        where:
-        [method, path, origin] << [["PUT", "POST", "GET", "HEAD"], ["/status"],
-                                   ['http://openrepose.com:80', "http://test.repose.site:80"]].combinations()
-    }
-
-    @Unroll("Preflight request, Allowed Resource with Origin request header with method #method, path #path, and origin #origin")
-    def "Origin request header is allow resource in the config"() {
-        given:
-        def headers = [
-                (CorsHttpHeader.ORIGIN.toString())                       : origin,
-                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
-
-        when:
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
-
-        then:
-        mc.receivedResponse.code == '200'
-        mc.getHandlings().size() == 0
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
-        mc.receivedResponse.headers.contains("Vary")
-
-        where:
-        [method, path, origin] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"], ["/testupdate"],
-                                   ['http://openrepose.com:80', "http://test.repose.site:80"]].combinations()
+        mc.receivedResponse.headers.findAll("Vary") == ['origin', 'access-control-request-headers', 'access-control-request-method']
     }
 
     @Unroll
-    def "Actual request with allowed Resource with Origin request header with method #method, path #path, and origin #origin and headers #responseHeaders"() {
-        given:
-        def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
-        // have deproxy add the response headers
-        def handler = { request -> new Response(200, 'OK', (responseHeaders as List<String>).collectEntries{[(it): 'value']})}
+    def "Preflight request with 'Access-Control-Request-Method' header of #method, path #path, and origin #origin should return a 200"() {
+        given: "the request has both an 'origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
+        def headers = [
+                (CorsHttpHeader.ORIGIN.toString())                       : origin,
+                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
 
-        when:
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: method, headers: headers, defaultHandler: handler)
+        when: "the request is made"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
 
-        then:
+        then: "the response status is OK"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
 
-        mc.receivedResponse.code == '200'
-        mc.getHandlings().size() == 1
+        and: "the request does not make it to the origin service"
+        mc.getHandlings().size() == 0
+
+        and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
-        mc.receivedResponse.headers.contains('Vary')
+
+        and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+
+        and: "the CORS headers for an actual request are not added"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+
+        and: "the 'Vary' header is set"
+        mc.receivedResponse.headers.contains("Vary")
 
         where:
-        [method, path, origin, responseHeaders] << [
+        [method, path, origin] << [['GET', 'HEAD'], ['/', '/status'], ['http://openrepose.com:80', 'http://test.repose.site:80']].combinations()
+    }
+
+    @Unroll
+    def "Preflight request from an unauthorized origin results in a 403 for an 'Access-Control-Request-Method' header of #method, path #path, and origin #origin"() {
+        given: "the request has both an 'origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
+        def headers = [
+                (CorsHttpHeader.ORIGIN.toString())                       : origin,
+                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
+
+        when: "the request is made"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
+
+        then: "the response status is Forbidden"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_FORBIDDEN
+
+        and: "the request does not make it to the origin service"
+        mc.getHandlings().size() == 0
+
+        and: "the 'Vary' header is set"
+        mc.receivedResponse.headers.contains("Vary")
+
+        where:
+        [method, path, origin] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"],
+                                   ["/", "/status"],
+                                   ["http://test.forbidden.com", "http://test.home.site:80"]].combinations()
+    }
+
+    @Unroll
+    def "Actual request from an unauthorized origin results in a 403 for an 'Access-Control-Request-Method' header of #method, path #path, and origin #origin"() {
+        given: "the request has an 'origin' header making this an actual CORS request"
+        def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
+
+        when: "the request is made"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: method, headers: headers)
+
+        then: "the response status is Forbidden"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_FORBIDDEN
+
+        and: "the request does not make it to the origin service"
+        mc.getHandlings().size() == 0
+
+        and: "the 'Vary' header is set"
+        mc.receivedResponse.headers.contains("Vary")
+
+        where:
+        [method, path, origin] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"],
+                                   ["/", "/status"],
+                                   ["http://test.forbidden.com", "http://test.home.site:80"]].combinations()
+    }
+
+    @Unroll
+    def "Preflight request for a path matching '/status.*' resource in config will return a 200 with 'Access-Control-Request-Method' header of #method and origin #origin"() {
+        given: "the request has both an 'origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
+        def headers = [
+                (CorsHttpHeader.ORIGIN.toString())                       : origin,
+                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
+        def path = "/status"
+
+        when: "the request is made using a path that will match a specific resource in config"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
+
+        then: "the response status is OK"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
+
+        and: "the request does not make it to the origin service"
+        mc.getHandlings().size() == 0
+
+        and: "the CORS headers for a preflight request are added"
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
+
+        and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+
+        and: "the CORS headers for an actual request are not added"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+
+        and: "the 'Vary' header is set"
+        mc.receivedResponse.headers.contains("Vary")
+
+        where:
+        [method, origin] << [["PUT", "POST", "GET", "HEAD"],
+                             ['http://openrepose.com:80', "http://test.repose.site:80"]].combinations()
+    }
+
+    @Unroll
+    def "Preflight request for a path matching '/testupdate.*' resource in config will return a 200 with 'Access-Control-Request-Method' header of #method and origin #origin"() {
+        given: "the request has both an 'origin' and 'Access-Control-Request-Method' header making it a preflight CORS request"
+        def headers = [
+                (CorsHttpHeader.ORIGIN.toString())                       : origin,
+                (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
+        def path = "/testupdate"
+
+        when: "the request is made using a path that will match a specific resource in config"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
+
+        then: "the response status is OK"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
+
+        and: "the request does not make it to the origin service"
+        mc.getHandlings().size() == 0
+
+        and: "the CORS headers for a preflight request are added"
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
+
+        and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+
+        and: "the CORS headers for an actual request are not added"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+
+        and: "the 'Vary' header is set"
+        mc.receivedResponse.headers.contains("Vary")
+
+        where:
+        [method, origin] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"],
+                             ['http://openrepose.com:80', "http://test.repose.site:80"]].combinations()
+    }
+
+    @Unroll
+    def "Actual request will contain response header 'Access-Control-Expose-Headers' with values #responseHeaders for method #method"() {
+        given: "an actual request"
+        def path = "/testupdate"
+        def origin = 'http://test.repose.site:80'
+        def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
+
+        and: "the origin service will return special response headers"
+        def handler = { request -> new Response(200, 'OK', (responseHeaders as List<String>).collectEntries{[(it): 'value']})}
+
+        when: "the request is made using the specified method"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: method, headers: headers, defaultHandler: handler)
+
+        then: "the response status is OK"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
+
+        and: "the request makes it to the origin service"
+        mc.getHandlings().size() == 1
+
+        and: "the CORS headers for an actual request are added"
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
+
+        and: "the CORS headers for a preflight request are not added"
+        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
+        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+
+        and: "all of the special headers from the origin service are added to the list of values in the 'Access-Control-Expose-Headers' header"
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).containsAll(responseHeaders)
+
+        and: "the 'Vary' header is set"
+        mc.receivedResponse.headers.contains("Vary")
+
+        where:
+        [method, responseHeaders] << [
                 ["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"],
-                ["/testupdate"],
-                ['http://openrepose.com:80', "http://test.repose.site:80"],
                 [['x-potatoes'], ['Content-Encoding'], ['x-success', 'Content-Encoding']]].combinations()
     }
 
-    @Unroll("Actual request, Allowed Resource with Origin request header with method #method, path #path, and origin #origin")
-    def "Actual request with allow resource in the config"() {
-        given:
+    @Unroll
+    def "Actual request for a path matching '/testupdate.*' resource in config will return a 200 with origin #origin"() {
+        given: "the request has an 'origin' header making this an actual CORS request"
+        def path = "/testupdate"
         def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
 
-        when:
+        when: "the request is made using a path that will match a specific resource in config"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: method, headers: headers)
 
-        then:
-        mc.receivedResponse.code == '200'
+        then: "the response status is OK"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
+
+        and: "the request makes it to the origin service"
         mc.getHandlings().size() == 1
+
+        and: "the CORS headers for an actual request are added"
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
+
+        and: "the CORS headers for a preflight request are not added"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+
+        and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
 
         where:
-        [method, path, origin] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"], ["/testupdate"],
-                                   ['http://openrepose.com:80', "http://test.repose.site:80"]].combinations()
+        [method, origin] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"],
+                             ['http://openrepose.com:80', "http://test.repose.site:80"]].combinations()
     }
 
-    @Unroll("Preflight request, Not allowed resource with origin request header with method #method, path #path, and origin #origin")
-    def "Origin request method is not allow resource in the config"() {
-        given:
+    @Unroll
+    def "Preflight request with a path #path that does not match the resource needed for requested method #method to be allowed results in a 403"() {
+        given: "a preflight request with an allowed origin"
+        def origin = "http://test.repose.site:80"
         def headers = [
                 (CorsHttpHeader.ORIGIN.toString())                       : origin,
                 (CorsHttpHeader.ACCESS_CONTROL_REQUEST_METHOD.toString()): method]
 
-        when:
+        when: "the request is made using a path that does not match the resource that would have allowed the requested method"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
 
-        then:
-        mc.receivedResponse.code == '403'
+        then: "the response status is Forbidden"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_FORBIDDEN
+
+        and: "the request does not make it to the origin service"
         mc.getHandlings().size() == 0
+
+        and: "the 'Origin' header exists because it was valid"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
+
+        and: "the 'Access-Control-Allow-Methods' header does not exist"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
+
+        and: "the 'Vary' header is set with the correct values for an OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
-        mc.receivedResponse.headers.findAll('Vary') == ['origin', 'access-control-request-headers', 'access-control-request-method']
+        mc.receivedResponse.headers.findAll("Vary") == ['origin', 'access-control-request-headers', 'access-control-request-method']
 
         where:
-        method   | path      | origin
-        "PATCH"  | "/status" | 'http://openrepose.com:80'
-        "DELETE" | "/status" | "http://test.repose.site:80"
-        "PATCH"  | "/"       | 'http://openrepose.com:80'
-        "DELETE" | "/"       | "http://test.repose.site:80"
-        "PUT"    | "/"       | 'http://openrepose.com:80'
-        "POST"   | "/"       | "http://test.repose.site:80"
-
-    }
-
-    @Unroll("Actual Request Not allowed resource with method #method, path #path, and origin #origin")
-    def "Actual Request request method is not allow resource in the config"() {
-        given:
-        def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
-
-        when:
-        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: method, headers: headers)
-
-        then:
-        mc.receivedResponse.code == '403'
-        mc.getHandlings().size() == 0
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
-        mc.receivedResponse.headers.contains('Vary')
-        mc.receivedResponse.headers.findAll('Vary') == ['origin']
-
-        where:
-        method    | path      | origin
-        "PATCH"   | "/status" | 'http://openrepose.com:80'
-        "DELETE"  | "/status" | 'http://test.repose.site:80'
-        "PATCH"   | "/"       | 'http://openrepose.com:80'
-        "DELETE"  | "/"       | 'http://test.repose.site:80'
-        "PUT"     | "/"       | 'http://openrepose.com:80'
-        "POST"    | "/"       | 'http://test.repose.site:80'
-        "TRACE"   | "/"       | 'http://openrepose.com:80'
+        method   | path
+        "PATCH"  | "/status"
+        "DELETE" | "/status"
+        "PATCH"  | "/"
+        "DELETE" | "/"
+        "PUT"    | "/"
+        "POST"   | "/"
     }
 
     @Unroll
-    def "Preflight request has preflight CORS headers for request method #method and headers #requestHeaders"() {
-        given:
+    def "Actual request with a path #path that does not match the resource needed for method #method to be allowed results in a 403"() {
+        given: "an actual request with an allowed origin"
+        def origin = "http://test.repose.site:80"
+        def headers = [(CorsHttpHeader.ORIGIN.toString()): origin]
+
+        when: "the request is made using a path that does not match the resource that would have allowed the requested method"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: method, headers: headers)
+
+        then: "the response status is Forbidden"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_FORBIDDEN
+
+        and: "the request does not make it to the origin service"
+        mc.getHandlings().size() == 0
+
+        and: "the 'Access-Control-Allow-Origin' header is set correctly since the origin was valid"
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
+
+        and: "the 'Access-Control-Allow-Methods' header does not exist"
+        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
+
+        and: "the 'Vary' header is set with the correct values for an OPTIONS request"
+        mc.receivedResponse.headers.contains("Vary")
+        mc.receivedResponse.headers.findAll("Vary") == ['origin']
+
+        where:
+        method    | path
+        "PATCH"   | "/status"
+        "DELETE"  | "/status"
+        "PATCH"   | "/"
+        "DELETE"  | "/"
+        "PUT"     | "/"
+        "POST"    | "/"
+        "TRACE"   | "/"
+    }
+
+    @Unroll
+    def "Preflight request with 'Access-Control-Request-Headers' header #requestHeaders results in 'Access-Control-Allow-Headers' header in response with the same values for requested method #method"() {
+        given: "an actual request with an allowed origin, valid path, and an 'Access-Control-Request-Headers' header"
         def origin = 'http://openrepose.com:80'
         def path = '/testupdate'
         def headers = [
@@ -304,20 +406,30 @@ class CorsFilterBasicTest extends ReposeValveTest {
                 (CorsHttpHeader.ACCESS_CONTROL_REQUEST_HEADERS.toString()): requestHeaders
         ]
 
-        when:
+        when: "the request is made"
         MessageChain mc = deproxy.makeRequest(url: reposeEndpoint + path, method: 'OPTIONS', headers: headers)
 
-        then:
-        mc.receivedResponse.code == '200'
+        then: "the response status is OK"
+        mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
+
+        and: "the request does not make it to the origin service"
         mc.getHandlings().size() == 0
+
+        and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains(method)
-        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()) == requestHeaders
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
-        mc.receivedResponse.headers.contains('Vary')
-        mc.receivedResponse.headers.findAll('Vary') == ['origin', 'access-control-request-headers', 'access-control-request-method']
+
+        and: "the 'Access-Control-Allow-Headers' header is set to the values that were in the 'Access-Control-Request-Headers' header"
+        mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()) == requestHeaders
+
+        and: "the CORS headers for an actual request are not added"
+        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+
+        and: "the 'Vary' header is set with the correct values for an OPTIONS request"
+        mc.receivedResponse.headers.contains("Vary")
+        mc.receivedResponse.headers.findAll("Vary") == ['origin', 'access-control-request-headers', 'access-control-request-method']
 
         where:
         [method, requestHeaders] << [["GET", "HEAD", "PUT", "POST", "PATCH", "DELETE"],

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/cors/CorsFilterBasicTest.groovy
@@ -57,10 +57,10 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.getHandlings().size() == 1
 
         and: "none of the CORS headers are added to the response"
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).isEmpty()
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).isEmpty()
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()).isEmpty()
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).isEmpty()
 
         and: "the 'Vary' header is set with the correct values for an OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
@@ -89,8 +89,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the CORS headers for a preflight request are not added"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).isEmpty()
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).isEmpty()
 
         and: "the 'Vary' header is set with the correct values for an OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
@@ -111,7 +111,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
@@ -120,10 +120,10 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).isEmpty()
 
         and: "the CORS headers for an actual request are not added"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).isEmpty()
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
@@ -146,10 +146,10 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_FORBIDDEN
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the 'Access-Control-Allow-Origin' header is not set to indicate the 'Origin' was not allowed"
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 0
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).isEmpty()
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
@@ -172,10 +172,10 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_FORBIDDEN
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the 'Access-Control-Allow-Origin' header is not set to indicate the 'Origin' was not allowed"
-        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 0
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).isEmpty()
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
@@ -201,7 +201,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
@@ -210,10 +210,10 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).isEmpty()
 
         and: "the CORS headers for an actual request are not added"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).isEmpty()
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
@@ -238,7 +238,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
@@ -247,10 +247,10 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the 'Access-Control-Allow-Headers' header is not set since none were requested"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).isEmpty()
 
         and: "the CORS headers for an actual request are not added"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).isEmpty()
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
@@ -284,8 +284,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the CORS headers for a preflight request are not added"
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).isEmpty()
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).isEmpty()
 
         and: "all of the special headers from the origin service are added to the list of values in the 'Access-Control-Expose-Headers' header"
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).size() == 1
@@ -320,8 +320,8 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()) == 'true'
 
         and: "the CORS headers for a preflight request are not added"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).isEmpty()
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).isEmpty()
 
         and: "the 'Vary' header is set"
         mc.receivedResponse.headers.contains("Vary")
@@ -346,14 +346,14 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_FORBIDDEN
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the 'Access-Control-Allow-Origin' header is set correctly since the origin was valid"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
 
         and: "the 'Access-Control-Allow-Methods' header does not exist"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).isEmpty()
 
         and: "the 'Vary' header is set with the correct values for an OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
@@ -382,14 +382,14 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_FORBIDDEN
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the 'Access-Control-Allow-Origin' header is set correctly since the origin was valid"
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()) == origin
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
 
         and: "the 'Access-Control-Allow-Methods' header does not exist"
-        !mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_METHODS.toString()).isEmpty()
 
         and: "the 'Vary' header is set with the correct values for a non-OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
@@ -424,7 +424,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
@@ -437,7 +437,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()) == requestHeaders
 
         and: "the CORS headers for an actual request are not added"
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).isEmpty()
 
         and: "the 'Vary' header is set with the correct values for an OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")
@@ -466,7 +466,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == HttpServletResponse.SC_OK
 
         and: "the request does not make it to the origin service"
-        mc.getHandlings().size() == 0
+        mc.getHandlings().isEmpty()
 
         and: "the CORS headers for a preflight request are added"
         mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.toString()).size() == 1
@@ -481,7 +481,7 @@ class CorsFilterBasicTest extends ReposeValveTest {
         mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_ALLOW_HEADERS.toString()).tokenize(',').containsAll(allowHeaders)
 
         and: "the CORS headers for an actual request are not added"
-        !mc.receivedResponse.headers.getFirstValue(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString())
+        mc.receivedResponse.headers.findAll(CorsHttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS.toString()).isEmpty()
 
         and: "the 'Vary' header is set with the correct values for an OPTIONS request"
         mc.receivedResponse.headers.contains("Vary")


### PR DESCRIPTION
Update is to better handle the Access-Control-Request-Headers header on the request.  Previously, the value was taken from this header and put into the Access-Control-Allow-Headers header on the response without concern for whether or not there was more than one value.  This worked fine if the Access-Control-Request-Headers header was merged into one comma-separated value, but if the value was split, only the first value would be put in the Access-Control-Allow-Headers header.  This PR addresses the issue by calling `getSplittableHeaderScala` and adding a Access-Control-Allow-Headers header to the response for each value.

The CORS functional test was pretty confusing, so I cleaned it up before adding additional tests.