### PR TITLE
REP-4653 UAE Lost Password

### DIFF
--- a/repose-aggregator/components/filters/herp-filter/src/main/scala/org/openrepose/filters/herp/HerpFilter.scala
+++ b/repose-aggregator/components/filters/herp-filter/src/main/scala/org/openrepose/filters/herp/HerpFilter.scala
@@ -135,9 +135,10 @@ class HerpFilter @Inject()(configurationService: ConfigurationService,
     val reqProjectIds = getSplitProjectHeaders(new HttpServletRequestWrapper(httpServletRequest))
     val projectIds = if (reqProjectIds.nonEmpty) reqProjectIds else getSplitProjectHeaders(httpServletResponse)
 
-    //def nullIfEmpty(it: Iterable[Any]) = if (it.isEmpty) null else it
     val eventValues: Map[String, Any] = Map(
-      "userName" -> stripHeaderParams(httpServletRequest.getHeader(OpenStackServiceHeader.USER_NAME.toString)),
+      "userName" -> Option(stripHeaderParams(httpServletRequest.getHeader(OpenStackServiceHeader.USER_NAME.toString)))
+        .filterNot(_.isEmpty)
+        .getOrElse(stripHeaderParams(httpServletResponse.getHeader(OpenStackServiceHeader.USER_NAME.toString))),
       "impersonatorName" -> stripHeaderParams(httpServletRequest.getHeader(OpenStackServiceHeader.IMPERSONATOR_NAME.toString)),
       "defaultProjectId" -> stripHeaderParams(getPreferredHeader(projectIds)),
       "projectID" -> projectIds.map(stripHeaderParams).toArray,

--- a/repose-aggregator/components/filters/rackspace-auth-user-filter/src/main/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilter.scala
+++ b/repose-aggregator/components/filters/rackspace-auth-user-filter/src/main/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilter.scala
@@ -103,7 +103,12 @@ class RackspaceAuthUserFilter @Inject()(configurationService: ConfigurationServi
     }
   }
 
-  def getUsername(domain: String, user: String): String = if (domain.equals("Rackspace")) s"Racker:$user" else user
+  def getUsername(domain: String, user: String): String =
+    if (domain == "Rackspace") {
+      s"Racker:$user"
+    } else {
+      user
+    }
 
   /**
     * Many payloads to parse here, should be fun

--- a/repose-aggregator/components/filters/rackspace-auth-user-filter/src/test/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilterTest.scala
+++ b/repose-aggregator/components/filters/rackspace-auth-user-filter/src/test/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilterTest.scala
@@ -150,8 +150,8 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
           |    }
           |  }
           |}""".stripMargin.getBytes)
-      servletRequest.addHeader(RackspaceAuthUserFilter.sessionIdHeader, "foo-bar")
-      when(datastore.get(s"${RackspaceAuthUserFilter.ddKey}:foo-bar")).thenReturn(Option(RackspaceAuthUserGroup(Option("Rackspace"), "Racker:jqsmith", "GROUP", 0.6)), Nil: _*)
+      servletRequest.addHeader(RackspaceAuthUserFilter.SessionIdHeader, "foo-bar")
+      when(datastore.get(s"${RackspaceAuthUserFilter.DdKey}:foo-bar")).thenReturn(Option(RackspaceAuthUserGroup(Option("Rackspace"), "Racker:jqsmith", "GROUP", 0.6)), Nil: _*)
 
       filter.doWork(servletRequest, servletResponse, filterChain)
 
@@ -174,8 +174,8 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
           |    }
           |  }
           |}""".stripMargin.getBytes)
-      servletRequest.addHeader(RackspaceAuthUserFilter.sessionIdHeader, "banana;q=0.5,foo-bar;q=0.7")
-      when(datastore.get(s"${RackspaceAuthUserFilter.ddKey}:foo-bar")).thenReturn(Option(RackspaceAuthUserGroup(Option("Rackspace"), "Racker:jqsmith", "GROUP", 0.6)), Nil: _*)
+      servletRequest.addHeader(RackspaceAuthUserFilter.SessionIdHeader, "banana;q=0.5,foo-bar;q=0.7")
+      when(datastore.get(s"${RackspaceAuthUserFilter.DdKey}:foo-bar")).thenReturn(Option(RackspaceAuthUserGroup(Option("Rackspace"), "Racker:jqsmith", "GROUP", 0.6)), Nil: _*)
 
       filter.doWork(servletRequest, servletResponse, filterChain)
 
@@ -185,7 +185,7 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
       request.getHeader(PowerApiHeader.USER.toString) shouldBe "Racker:jqsmith;q=0.6"
       request.getHeader(PowerApiHeader.GROUPS.toString) shouldBe "GROUP;q=0.6"
 
-      verify(datastore, times(0)).get(s"${RackspaceAuthUserFilter.ddKey}:banana")
+      verify(datastore, times(0)).get(s"${RackspaceAuthUserFilter.DdKey}:banana")
     }
 
     it("will search the datastore till it finds the session") {
@@ -200,8 +200,8 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
           |    }
           |  }
           |}""".stripMargin.getBytes)
-      servletRequest.addHeader(RackspaceAuthUserFilter.sessionIdHeader, "banana;q=0.7,foo-bar;q=0.5")
-      when(datastore.get(s"${RackspaceAuthUserFilter.ddKey}:foo-bar")).thenReturn(Option(RackspaceAuthUserGroup(Option("Rackspace"), "Racker:jqsmith", "GROUP", 0.6)), Nil: _*)
+      servletRequest.addHeader(RackspaceAuthUserFilter.SessionIdHeader, "banana;q=0.7,foo-bar;q=0.5")
+      when(datastore.get(s"${RackspaceAuthUserFilter.DdKey}:foo-bar")).thenReturn(Option(RackspaceAuthUserGroup(Option("Rackspace"), "Racker:jqsmith", "GROUP", 0.6)), Nil: _*)
 
       filter.doWork(servletRequest, servletResponse, filterChain)
 
@@ -211,7 +211,7 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
       request.getHeader(PowerApiHeader.USER.toString) shouldBe "Racker:jqsmith;q=0.6"
       request.getHeader(PowerApiHeader.GROUPS.toString) shouldBe "GROUP;q=0.6"
 
-      verify(datastore).get(s"${RackspaceAuthUserFilter.ddKey}:banana")
+      verify(datastore).get(s"${RackspaceAuthUserFilter.DdKey}:banana")
     }
 
     List("/v2.0/users/RAX-AUTH/forgot-pwd", "/v2.0/users/RAX-AUTH/forgot-pwd/") foreach { uri =>
@@ -607,17 +607,17 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
 
     List(
       (List("OS-MF sessionId='123456', factor='PASSCODE'"),
-        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":123456"),
+        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.DdKey + ":123456"),
                                 meq(Option(RackspaceAuthUserGroup(None, "bob", "GROUP", 0.6))),
                                 meq(5),
                                 meq(TimeUnit.MINUTES)) }),
       (List("OS-MF sessionId='green', factor='PASSCODE'", "Keystone uri=https://some.identity.com"),
-        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":green"),
+        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.DdKey + ":green"),
                                 meq(Option(RackspaceAuthUserGroup(None, "bob", "GROUP", 0.6))),
                                 meq(5),
                                 meq(TimeUnit.MINUTES)) }),
       (List("Keystone uri=https://some.identity.com", "OS-MF sessionId='banana', factor='PASSCODE'"),
-        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":banana"),
+        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.DdKey + ":banana"),
                                 meq(Option(RackspaceAuthUserGroup(None, "bob", "GROUP", 0.6))),
                                 meq(5),
                                 meq(TimeUnit.MINUTES)) }),

--- a/repose-aggregator/components/filters/rackspace-auth-user-filter/src/test/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilterTest.scala
+++ b/repose-aggregator/components/filters/rackspace-auth-user-filter/src/test/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilterTest.scala
@@ -539,36 +539,36 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
 
     List(
       (List("OS-MF sessionId='123456', factor='PASSCODE'"),
-        Asserter({ verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":123456"),
+        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":123456"),
                                 meq(Option(RackspaceAuthUserGroup(None, "bob", "GROUP", 0.6))),
                                 meq(5),
-                                meq(TimeUnit.MINUTES)) })),
+                                meq(TimeUnit.MINUTES)) }),
       (List("OS-MF sessionId='green', factor='PASSCODE'", "Keystone uri=https://some.identity.com"),
-        Asserter({ verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":green"),
+        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":green"),
                                 meq(Option(RackspaceAuthUserGroup(None, "bob", "GROUP", 0.6))),
                                 meq(5),
-                                meq(TimeUnit.MINUTES)) })),
+                                meq(TimeUnit.MINUTES)) }),
       (List("Keystone uri=https://some.identity.com", "OS-MF sessionId='banana', factor='PASSCODE'"),
-        Asserter({ verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":banana"),
+        { () => verify(datastore).put(meq(RackspaceAuthUserFilter.ddKey + ":banana"),
                                 meq(Option(RackspaceAuthUserGroup(None, "bob", "GROUP", 0.6))),
                                 meq(5),
-                                meq(TimeUnit.MINUTES)) })),
+                                meq(TimeUnit.MINUTES)) }),
       (List.empty,
-        Asserter({ verify(datastore, times(0)).put(anyString,
+        { () => verify(datastore, times(0)).put(anyString,
                                                    any(classOf[Option[RackspaceAuthUserGroup]]),
                                                    anyInt,
-                                                   any(classOf[TimeUnit])) })),
+                                                   any(classOf[TimeUnit])) }),
       (List("OS-MF factor='PASSCODE'"),
-        Asserter({ verify(datastore, times(0)).put(anyString,
+        { () => verify(datastore, times(0)).put(anyString,
                                                    any(classOf[Option[RackspaceAuthUserGroup]]),
                                                    anyInt,
-                                                   any(classOf[TimeUnit])) })),
+                                                   any(classOf[TimeUnit])) }),
       (List("OS-MF sessionId='123456"),
-        Asserter({ verify(datastore, times(0)).put(anyString,
+        { () => verify(datastore, times(0)).put(anyString,
                                                    any(classOf[Option[RackspaceAuthUserGroup]]),
                                                    anyInt,
-                                                   any(classOf[TimeUnit])) }))
-    ) foreach { case(headers: List[String], asserter: Asserter) =>
+                                                   any(classOf[TimeUnit])) })
+    ) foreach { case (headers: List[String], asserter: Asserter) =>
       it(s"should write to the dd as appropriate with headers: $headers") {
         filter.configurationUpdated(auth2_0Config())
         servletRequest.setMethod("POST")
@@ -581,21 +581,10 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
 
         filter.doWork(servletRequest, servletResponse, filterChain)
 
-        asserter.assert()
+        asserter()
       }
     }
   }
 
-  //I couldn't get the typing and evaluation time to work right without this, if you can solve it, please do and share
-  class Asserter(assertion: => Unit) {
-    def assert(): Unit = {
-      assertion
-    }
-  }
-
-  object Asserter {
-    def apply(someCode: => Unit): Asserter = {
-      new Asserter(someCode)
-    }
-  }
+  type Asserter = () => Unit
 }

--- a/repose-aggregator/components/filters/rackspace-auth-user-filter/src/test/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilterTest.scala
+++ b/repose-aggregator/components/filters/rackspace-auth-user-filter/src/test/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilterTest.scala
@@ -704,15 +704,6 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
         domain shouldBe None
         username shouldBe None
       }
-
-      it("does not return a username nor throw an exception if request is malformed") {
-        val payload = "<legit_xml>I forgot my password. Please let me in. I am root. kthxbai.</legit_xml>"
-
-        val (domain, username) = filter.usernameForgotPassword2_0Xml(new ByteArrayInputStream(payload.getBytes))
-
-        domain shouldBe None
-        username shouldBe None
-      }
     }
 
     describe("JSON") {
@@ -766,19 +757,6 @@ class RackspaceAuthUserFilterTest extends FunSpec with BeforeAndAfterEach with M
             |        "portal": "astra_prod"
             |    }
             |}""".stripMargin
-
-        val (domain, username) = filter.usernameForgotPassword2_0Json(new ByteArrayInputStream(payload.getBytes))
-
-        domain shouldBe None
-        username shouldBe None
-      }
-
-      it("does not return a username nor throw an exception if request is malformed") {
-        val payload =
-          """"RAX-AUTH:forgotPasswordCredentials":
-            |  username: rpurnell
-            |  portal: astra_prod
-            |""".stripMargin
 
         val (domain, username) = filter.usernameForgotPassword2_0Json(new ByteArrayInputStream(payload.getBytes))
 

--- a/repose-aggregator/src/docs/asciidoc/filters/herp.adoc
+++ b/repose-aggregator/src/docs/asciidoc/filters/herp.adoc
@@ -16,7 +16,17 @@ Events are recorded even if the API request is rejected by Repose before reachin
 
 == Prerequisites & Postconditions
 === Required Headers
-This filter has no required headers.
+[cols="15,12,73", options="header"]
+.Response
+|===
+| Response Headers
+| Value
+| Conditions of Requirement
+
+| `X-User-Name`
+| Username of the requestor
+| Required when the username was not provided in the request (e.g., for change password requests to Identity using a temporary token)
+|===
 
 === Required Preceding Filters
 This filter has no dependencies on other filters and can be placed wherever it is needed in the filter chain.
@@ -65,7 +75,7 @@ To use the HERP filter, you need to:
 . Configure the data-center attribute to note the data center of the service.
 . Configure the template element to define the format of the messages to be logged by the HERP filter.
 
-=== Optional user-configurable filtering
+=== Optional User-Configurable Filtering
 The HERP filter allows user-configurable filtering along with optional pre and post log identifiers.
 
 Each `filterOut` block contains all of the criteria required for a single filter.
@@ -88,10 +98,12 @@ In other words, the `match` elements are logically AND'd and the `filterOut` blo
 .highly-efficient-record-processor.cfg.xml
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<highly-efficient-record-processor xmlns="http://docs.openrepose.org/repose/highly-efficient-record-processor/v1.0"
-                                   pre-filter-logger-name="org.openrepose.herp.pre.filter"
-                                   post-filter-logger-name="org.openrepose.herp.post.filter"
-                                   service-code="repose" region="USA" data-center="DFW">
+<highly-efficient-record-processor
+    xmlns="http://docs.openrepose.org/repose/highly-efficient-record-processor/v1.0"
+    pre-filter-logger-name="org.openrepose.herp.pre.filter"
+    post-filter-logger-name="org.openrepose.herp.post.filter"
+    service-code="repose" region="USA" data-center="DFW">
+
     <template crush="true">
         <![CDATA[
             <cadf:event xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event"
@@ -154,7 +166,7 @@ If you aren't using that filter, `{{methodLabel}}` will return empty string.
 ====
 
 == Additional Information
-=== Optional user-configurable filtering
+=== Optional User-Configurable Filtering
 The HERP filter allows user-configurable filtering along with optional pre and post log identifiers.
 
 Each `filterOut` block contains all of the criteria required for a single filter.
@@ -176,7 +188,7 @@ In other words, the `match` elements are logically AND'd and the `filterOut` blo
 === User Access Event Recording With Flume
 For information about using the Flume with the HERP filter for user access event recording, see <<../recipes/api-event-flume.adoc#,CF Flume Sink>> for more details.
 
-=== Configurable parameters
+=== Configurable Parameters
 In the `template` element, certain template keys may be used to add dynamic content to the text being logged.
 Any valid key enclosed in brackets (i.e., `{{<key>}}`) will be replaced, brackets included, by the value associated with that key at runtime.
 Note that key names are case sensitive.
@@ -231,7 +243,7 @@ The following helpers are available:
 | cadfMethod <requestMethod> | Converts a HTTP method into the CADF format.
 |===
 
-=== Recommendation for managing disk space
+=== Recommendation For Managing Disk Space
 If you expect heavy usage, you should use a logging tool, such as link:http://logstash.net/[Logstash], for managing events and logs and should not write events to files.
 Even if you rely on auditing, it is not recommended that you use the file system with the audit logs.
 Repose has developed <<../recipes/api-event-flume.adoc#,CF Flume Sink>> to eliminate disk space and log file issues.

--- a/repose-aggregator/src/docs/asciidoc/filters/rackspace-auth-user.adoc
+++ b/repose-aggregator/src/docs/asciidoc/filters/rackspace-auth-user.adoc
@@ -5,15 +5,15 @@ include::../_includes/in-progress.adoc[]
 The Rackspace Auth User filter is for usage in *Repose* instances that sit in front of Keystone v1 and v2 deployments.
 It's meant to be used for login requests to capture username for both <<../recipes/rate-limiting.adoc#,rate limiting>> and <<../recipes/user-access-events.adoc#,user access events>>.
 
-== General filter information
+== General Filter Information
 * *Name:* rackspace-auth-user
-* *Default Configuration:* rackspace-auth-user.cfg.xml
 * *Released:* v3.1.1 & v6.1.1.0+
 * *Bundle:* repose-filter-bundle
-* link:../schemas/rackspace-auth-user-configuration.xsd[Schema]
+* *Default Configuration:* rackspace-auth-user.cfg.xml
+* *Configuration Schema:* link:../schemas/rackspace-auth-user-configuration.xsd[rackspace-auth-user-configuration.xsd]
 
 == Prerequisites & Postconditions
-=== Required headers
+=== Required Headers
 [cols="3", options="header,autowidth"]
 .Request
 |===
@@ -38,11 +38,11 @@ It's meant to be used for login requests to capture username for both <<../recip
 | Required during the first call of a multi-factor authentication attempt
 |===
 
-=== Required preceding filters
+=== Required Preceding Filters
 This filter has no dependencies on other filters.
 
-=== Request headers created
-[cols="3", options="header,autowidth"]
+=== Request Headers Created
+[cols="15,12,73", options="header"]
 .Request
 |===
 | Request Headers
@@ -51,25 +51,27 @@ This filter has no dependencies on other filters.
 
 | `X-PP-User`
 | Username of the requester
-| Username present in the request or session id present for MFA. Prepended with `Racker:` if domain was present and had a value of `Rackspace`.
+| Username present in the request body or the session id present for MFA.
+  Prepended with `Racker:` if domain was present and had a value of `Rackspace`.
 
 | `X-User-Name`
 | Username of the requester
-| Username present in the request or session id present for MFA. Prepended with `Racker:` if domain was present and had a value of `Rackspace`.
+| Username present in the request body or the session id present for MFA.
+  Prepended with `Racker:` if domain was present and had a value of `Rackspace`.
 
 | `X-PP-Groups`
 | Configured value
-| Username present in the request or session id present for MFA.
+| Username present in the request body or the session id present for MFA.
 
 | `X-Domain`
 | Domain in the request
-| Username and Domain present in the request or session id present for MFA.
+| Username and Domain present in the request body or the session id present for MFA.
 |===
 
-=== Request body changes
+=== Request Body Changes
 This filter does not modify the request body.
 
-=== Recommended follow-on (succeeding) filters
+=== Recommended Follow-On (Succeeding) Filters
 This filter needs to appear in the filter chain before any of the filters that need the information that derives and provides.
 That means the <<rate-limiting.adoc#,rate limiting filter>> when rate limiting, and <<herp.adoc#,herp filter>> when doing user access events.
 When doing both the order should be:
@@ -80,10 +82,10 @@ When doing both the order should be:
 
 For further details about the reasoning behind this ordering see <<../recipes/user-access-events.adoc#,user access events>>.
 
-=== Response body changes
+=== Response Body Changes
 This filter does not modify the response body.
 
-=== Response headers created
+=== Response Headers Created
 This filter does not modify any response headers.
 
 === Response Status Codes
@@ -109,7 +111,7 @@ There are no cases where this filter will terminate further processing of the fi
 
 </rackspace-auth-user>
 ----
-<1> The `v1_1` element lets the filter know that you'd like to try to process bodies using the 1.1 contract.
+<1> The `v1_1` element lets the filter know that you'd like to try to process request bodies using the 1.1 contract for auth requests.
     It is optional.
 <2> The `content-body-read-limit` attribute specifies how much of the body you'd like the filter to read before giving up and assuming it's not present.
     It is optional and defaults to `4096`.
@@ -117,7 +119,7 @@ There are no cases where this filter will terminate further processing of the fi
     It is optional and defaults to `Pre_Auth`.
 <4> The `quality` element specifies what quality to apply to the `X-PP-User` and `X-PP-Groups` headers, it should be a value between `0` and `1.0`.
     It is optional and defaults to `0.6`.
-<5> The `v2_0` element is similar to the `v1_1` element but specifies that the filter should try to process request bodies with the 2.0 contract.
+<5> The `v2_0` element is similar to the `v1_1` element but specifies that the filter should try to process request bodies using the 2.0 contract for auth requests and forgotten password requests.
     It is optional.
-    The elements are not exclusive and you can specify one, both, or neither.
+    The elements are not exclusive, and you can specify one, both, or neither.
     This element can also take a `content-body-read-limit` attribute with the same behavior as the `v1_1` element.

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/herp/HerpUserAccessEventFilterTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/herp/HerpUserAccessEventFilterTest.groovy
@@ -446,8 +446,8 @@ class HerpUserAccessEventFilterTest extends ReposeValveTest {
     @Unroll
     def "will populate and log the username '#expectedUsername' when the request header username is '#requestUsername' and the response header is '#responseUsername'"() {
         given:
-        def requestHeaders = requestUsername ? [(OpenStackServiceHeader.USER_NAME.toString()): requestUsername] : [:]
-        def responseHeaders = responseUsername ? [(OpenStackServiceHeader.USER_NAME.toString()): responseUsername] : [:]
+        def requestHeaders = requestUsername != null ? [(OpenStackServiceHeader.USER_NAME.toString()): requestUsername] : [:]
+        def responseHeaders = responseUsername != null ? [(OpenStackServiceHeader.USER_NAME.toString()): responseUsername] : [:]
         def customHandler = { new Response(HttpServletResponse.SC_OK, null, responseHeaders) }
 
         when:

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/herp/HerpUserAccessEventFilterTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/herp/HerpUserAccessEventFilterTest.groovy
@@ -33,9 +33,6 @@ import javax.servlet.http.HttpServletResponse
 
 import static javax.ws.rs.HttpMethod.GET
 
-/**
- * Created by jennyvo on 2/10/15.
- */
 class HerpUserAccessEventFilterTest extends ReposeValveTest {
 
     def setupSpec() {
@@ -447,52 +444,36 @@ class HerpUserAccessEventFilterTest extends ReposeValveTest {
     }
 
     // Check all required attributes in the log
-    private static boolean checkAttribute(String jsonpart, List<String> listattr) {
-        boolean check = true
-        for (attr in listattr) {
-            if (!jsonpart.contains(attr)) {
-                check = false
-                break
-            }
-        }
-        return check
+    private static boolean checkAttribute(String jsonpart, List<String> attributes) {
+        attributes.every { jsonpart.contains(it) }
     }
 
     // Build map for query parameters from request
-    private static Map<String, List> buildParamList(String parameters) {
-        Map<String, List> params = [:]
-        List<String> list = parameters.split("&")
+    private static Map<String, List> buildParamList(String parameterString) {
+        Map<String, List> parameters = [:]
         List<String> av = []
-        for (e in list) {
+
+        parameterString.split("&").each { e ->
             def (k, v) = e.split("=")
             av.add(v)
-            if (params[k] == null) {
-                params[k] = av
+            if (parameters[k] == null) {
+                parameters[k] = av
                 av = []
             } else {
-                List ov = params[k]
-                ov.add(v)
-                params[k] = ov
+                parameters[k] += v
             }
         }
-        return params
+
+        parameters
     }
 
     // Check if all parameters include in Parameters tag
-    private static boolean checkParams(String jsonpart, Map<String, List<String>> map) {
-        def slurper = new JsonSlurper()
-        def result = slurper.parseText(jsonpart)
-        boolean check = true
+    private static boolean checkParams(String jsonpart, Map<String, List<String>> parameters) {
+        def result = new JsonSlurper().parseText(jsonpart)
 
-        for (e in map) {
-            def iv = e.value
-            for (v in iv) {
-                if (!(result.Request.Parameters.(e.key).contains(URLDecoder.decode(v, "UTF-8")))) {
-                    check = false
-                    break
-                }
-            }
+        parameters.every { key, values ->
+            def jsonValue = result.Request.Parameters[key]
+            values.every { jsonValue.contains(URLDecoder.decode(it, "UTF-8")) }
         }
-        return check
     }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/herp/HerpUserAccessEventFilterTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/herp/HerpUserAccessEventFilterTest.groovy
@@ -443,6 +443,78 @@ class HerpUserAccessEventFilterTest extends ReposeValveTest {
         "200"        | "test12" | "tenantId=12345" | "PUT"  | "OK"
     }
 
+    @Unroll
+    def "will populate and log the username '#expectedUsername' when the request header username is '#requestUsername' and the response header is '#responseUsername'"() {
+        given:
+        def requestHeaders = requestUsername ? [(OpenStackServiceHeader.USER_NAME.toString()): requestUsername] : [:]
+        def responseHeaders = responseUsername ? [(OpenStackServiceHeader.USER_NAME.toString()): responseUsername] : [:]
+        def customHandler = { new Response(HttpServletResponse.SC_OK, null, responseHeaders) }
+
+        when:
+        deproxy.makeRequest(
+                url: reposeEndpoint,
+                method: GET,
+                headers: requestHeaders,
+                defaultHandler: customHandler)
+
+        then: "the filter will log the details of the request using JSON"
+        def logLine = reposeLogSearch.searchByString("INFO  org.openrepose.herp.pre.filter").first()
+        def result = new JsonSlurper().parseText(logLine.substring(logLine.indexOf("{")))
+
+        and: "the logged JSON will contain the expected Username"
+        result.Request.UserName == expectedUsername
+
+        where:
+        expectedUsername | requestUsername     | responseUsername
+        "requestFoo"     | "requestFoo"        | null
+        // should use the response header if the request header is missing or empty
+        "responseBar"    | null                | "responseBar"
+        "responseBar"    | ""                  | "responseBar"
+        "responseBar"    | ";q=0.8"            | "responseBar"
+        // should prefer the request header if it's available, no matter the quality
+        "requestFoo"     | "requestFoo"        | "responseBar"
+        "requestFoo"     | "requestFoo;q=0.2"  | "responseBar;q=0.9"
+        "requestFoo"     | "requestFoo;q=1.0"  | "responseBar"
+        "requestFoo"     | "requestFoo"        | "responseBar;q=1.0"
+        "requestFoo"     | "requestFoo;q=1.0"  | "responseBar;q=1.0"
+        // should not be tripped up by different header attributes
+        "foo"            | "foo;q=0.4;a=b"     | null
+        "foo"            | "foo;a=b;q=0.4"     | null
+        "foo"            | "foo;a=b;q=0.4;c=d" | null
+        "foo"            | "foo;q=0.4;qq=0.0"  | null
+        "foo"            | "foo;qq=0.0;q=0.4"  | null
+        "bar"            | null                | "bar;q=0.4;a=b"
+        "bar"            | null                | "bar;a=b;q=0.4"
+        "bar"            | null                | "bar;a=b;q=0.4;c=d"
+        "bar"            | null                | "bar;q=0.4;qq=0.0"
+        "bar"            | null                | "bar;qq=0.0;q=0.4"
+        "baz"            | "baz;q=0.4;a=b"     | "qux;q=0.4;a=b"
+        "baz"            | "baz;a=b;q=0.4"     | "qux;a=b;q=0.4"
+        "baz"            | "baz;a=b;q=0.4;c=d" | "qux;a=b;q=0.4;c=d"
+        "baz"            | "baz;q=0.4;qq=0.0"  | "qux;q=0.4;qq=0.0"
+        "baz"            | "baz;qq=0.0;q=0.4"  | "qux;qq=0.0;q=0.4"
+        // should be okay with different precision qualities
+        "foo"            | "foo;q=0.1"         | null
+        "foo"            | "foo;q=0.01"        | null
+        "foo"            | "foo;q=0.001"       | null
+        "foo"            | "foo;q=1"           | null
+        "foo"            | "foo;q=1.0"         | null
+        "foo"            | "foo;q=1.00"        | null
+        "foo"            | "foo;q=1.000"       | null
+        "bar"            | null                | "bar;q=0.1"
+        "bar"            | null                | "bar;q=0.01"
+        "bar"            | null                | "bar;q=0.001"
+        "bar"            | null                | "bar;q=1"
+        "bar"            | null                | "bar;q=1.0"
+        "bar"            | null                | "bar;q=1.00"
+        "bar"            | null                | "bar;q=1.000"
+        // should be okay with some whitespace
+        "foo"            | "foo; q=0.5"        | null
+        "bar"            | null                | "bar; q=0.5"
+        // should be okay with the same value
+        "foo"            | "foo"               | "foo"
+    }
+
     // Check all required attributes in the log
     private static boolean checkAttribute(String jsonpart, List<String> attributes) {
         attributes.every { jsonpart.contains(it) }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/RackspaceAuthPayloads.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/RackspaceAuthPayloads.groovy
@@ -62,6 +62,15 @@ class RackspaceAuthPayloads {
     }
 }"""
 
+    public static String userForgotXmlV20 = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<forgotPasswordCredentials xmlns="http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1.0" username="demoAuthor"/>"""
+
+    public static String userForgotJsonV20 = """{
+    "RAX-AUTH:forgotPasswordCredentials": {
+        "username": "demoAuthor"
+    }
+}"""
+
     public static String userApiKeyXmlV20 = """<?xml version="1.0" encoding="UTF-8"?>
 <auth>
     <apiKeyCredentials xmlns="http://docs.rackspace.com/identity/api/ext/RAX-KSKEY/v1.0"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/RackspaceAuthUserTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/RackspaceAuthUserTest.groovy
@@ -21,8 +21,6 @@ package features.filters.rackspaceauthuser
 
 import framework.ReposeValveTest
 import org.rackspace.deproxy.Deproxy
-import org.rackspace.deproxy.Handling
-import org.rackspace.deproxy.MessageChain
 import spock.lang.Unroll
 
 import static features.filters.rackspaceauthuser.RackspaceAuthPayloads.*
@@ -36,7 +34,7 @@ class RackspaceAuthUserTest extends ReposeValveTest {
         def params = properties.defaultTemplateParams
         repose.configurationProvider.applyConfigs("common", params)
         repose.configurationProvider.applyConfigs("features/filters/rackspaceauthuser", params)
-        repose.start([waitOnJmxAfterStarting: false])
+        repose.start(waitOnJmxAfterStarting: false)
         waitUntilReadyToServiceRequests()
     }
 
@@ -44,21 +42,21 @@ class RackspaceAuthUserTest extends ReposeValveTest {
     def "when identifying requests by header"() {
 
         when: "Request body contains user credentials"
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST"])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST")
+        def sentRequest = messageChain.getHandlings()[0]
 
         then: "Repose will send x-pp-user with a single value"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 1
+        sentRequest.request.getHeaders().findAll("x-pp-user").size() == 1
 
         and: "Repose will send user from Request body"
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-pp-user") == (expectedUser + ";q=0.8")
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-user-name") == expectedUser
+        sentRequest.request.getHeaders().getFirstValue("x-pp-user") == expectedUser + ";q=0.8"
+        sentRequest.request.getHeaders().getFirstValue("x-user-name") == expectedUser
 
         and: "Repose will send a single value for x-pp-groups"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 1
+        sentRequest.request.getHeaders().findAll("x-pp-groups").size() == 1
 
         and: "Repose will send 'My Group' for x-pp-groups"
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-pp-groups") == "2_0 Group;q=0.8"
+        sentRequest.request.getHeaders().getFirstValue("x-pp-groups") == "2_0 Group;q=0.8"
 
         where:
         requestBody              | contentType | expectedUser | testName
@@ -76,27 +74,27 @@ class RackspaceAuthUserTest extends ReposeValveTest {
     def "when identifying requests by header with domain"() {
 
         when: "Request body contains user credentials"
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST"])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST")
+        def sentRequest = messageChain.getHandlings()[0]
 
         then: "Repose will send x-pp-user with a single value"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 1
+        sentRequest.request.getHeaders().findAll("x-pp-user").size() == 1
 
         and: "Repose will send user from Request body"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").contains(expectedUser + ";q=0.8")
-        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").contains(expectedUser)
+        sentRequest.request.getHeaders().findAll("x-pp-user").contains(expectedUser + ";q=0.8")
+        sentRequest.request.getHeaders().findAll("x-user-name").contains(expectedUser)
 
         and: "Repose will send two values for x-domain"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-domain").size() == 1
+        sentRequest.request.getHeaders().findAll("x-domain").size() == 1
 
         and: "Repose will send #expectedDomain x-domain"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-domain").contains(expectedDomain)
+        sentRequest.request.getHeaders().findAll("x-domain").contains(expectedDomain)
 
         and: "Repose will send a single value for x-pp-groups"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 1
+        sentRequest.request.getHeaders().findAll("x-pp-groups").size() == 1
 
         and: "Repose will send 'My Group' for x-pp-groups"
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-pp-groups") == "2_0 Group;q=0.8"
+        sentRequest.request.getHeaders().getFirstValue("x-pp-groups") == "2_0 Group;q=0.8"
 
         where:
         requestBody              | contentType | expectedDomain | expectedUser     | testName
@@ -112,15 +110,15 @@ class RackspaceAuthUserTest extends ReposeValveTest {
     def "when attempting to identity user by content and passed bad content"() {
 
         when: "Request body contains user credentials"
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST"])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST")
+        def sentRequest = messageChain.getHandlings()[0]
 
         then: "Repose will not send x-pp-user"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 0
+        sentRequest.request.getHeaders().findAll("x-pp-user").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-user-name").isEmpty()
 
         and: "Repose will not send x-pp-groups"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 0
+        sentRequest.request.getHeaders().findAll("x-pp-groups").isEmpty()
 
         where:
         requestBody            | contentType | testName
@@ -136,21 +134,21 @@ class RackspaceAuthUserTest extends ReposeValveTest {
     def "when using identity1.1 identifying requests by header"() {
 
         when: "Request body contains user credentials"
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST"])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST")
+        def sentRequest = messageChain.getHandlings()[0]
 
         then: "Repose will send x-pp-user with a single value"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 1
+        sentRequest.request.getHeaders().findAll("x-pp-user").size() == 1
 
         and: "Repose will send user from Request body"
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-pp-user") == (expectedUser + ";q=0.75")
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-user-name") == expectedUser
+        sentRequest.request.getHeaders().getFirstValue("x-pp-user") == expectedUser + ";q=0.75"
+        sentRequest.request.getHeaders().getFirstValue("x-user-name") == expectedUser
 
         and: "Repose will send a single value for x-pp-groups"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 1
+        sentRequest.request.getHeaders().findAll("x-pp-groups").size() == 1
 
         and: "Repose will send 'My Group' for x-pp-groups"
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-pp-groups") == "1_1 Group;q=0.75"
+        sentRequest.request.getHeaders().getFirstValue("x-pp-groups") == "1_1 Group;q=0.75"
 
         where:
         requestBody         | contentType | expectedUser | testName
@@ -163,33 +161,30 @@ class RackspaceAuthUserTest extends ReposeValveTest {
     @Unroll("Does not affect #method requests")
     def "Does not affect non-post requests"() {
         when: "Request is a #method"
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint, method: method])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint, method: method)
+        def sentRequest = messageChain.getHandlings()[0]
 
         then: "Repose will not add any headers"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 0
+        sentRequest.request.getHeaders().findAll("x-pp-user").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-user-name").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-pp-groups").isEmpty()
 
         and: "The result will be passed through"
         messageChain.receivedResponse.code == "200"
 
         where:
-        method   | _
-        "GET"    | _
-        "DELETE" | _
-        "PUT"    | _
+        method << ["GET", "DELETE", "PUT"]
     }
 
     def "Does not affect random post requests"() {
         when:
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint, method: 'POST'])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint, method: 'POST')
+        def sentRequest = messageChain.getHandlings()[0]
 
         then: "Repose will not add any headers"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 0
+        sentRequest.request.getHeaders().findAll("x-pp-user").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-user-name").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-pp-groups").isEmpty()
 
         and: "The result will be passed through"
         messageChain.receivedResponse.code == "200"
@@ -198,18 +193,18 @@ class RackspaceAuthUserTest extends ReposeValveTest {
     @Unroll("Will parse Forgot Password request for username when sent to appropriate URL (#testName)")
     def "Will parse a Forgot Password request if the URL matches /v2.0/users/RAX-AUTH/forgot-pwd"() {
         when: "Request body contains forgot password credentials"
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint + "/v2.0/users/RAX-AUTH/forgot-pwd", requestBody: requestBody, headers: contentType, method: "POST"])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint + "/v2.0/users/RAX-AUTH/forgot-pwd", requestBody: requestBody, headers: contentType, method: "POST")
+        def sentRequest = messageChain.getHandlings()[0]
 
         then: "Repose will send x-pp-user with a single value"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 1
-        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 1
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 1
-        ((Handling) sentRequest).request.getHeaders().findAll("x-domain").size() == 0
+        sentRequest.request.getHeaders().findAll("x-pp-user").size() == 1
+        sentRequest.request.getHeaders().findAll("x-user-name").size() == 1
+        sentRequest.request.getHeaders().findAll("x-pp-groups").size() == 1
+        sentRequest.request.getHeaders().findAll("x-domain").isEmpty()
 
         and: "Repose will send user from Request body"
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-pp-user") == ("demoAuthor;q=0.8")
-        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-user-name") == "demoAuthor"
+        sentRequest.request.getHeaders().getFirstValue("x-pp-user") == "demoAuthor;q=0.8"
+        sentRequest.request.getHeaders().getFirstValue("x-user-name") == "demoAuthor"
 
         where:
         requestBody       | contentType | testName
@@ -220,14 +215,14 @@ class RackspaceAuthUserTest extends ReposeValveTest {
     @Unroll("Will not parse Forgot Password request for username when sent to an inappropriate URL (#testName)")
     def "will not parse a Forgot Password request if the URL does not match /v2.0/users/RAX-AUTH/forgot-pwd"() {
         when: "Request body contains forgot password credentials"
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST"])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST")
+        def sentRequest = messageChain.getHandlings()[0]
 
-        then: "Repose will send x-pp-user with a single value"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-domain").size() == 0
+        then: "Repose will not send x-pp-user nor the other related headers"
+        sentRequest.request.getHeaders().findAll("x-pp-user").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-user-name").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-pp-groups").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-domain").isEmpty()
 
         where:
         requestBody       | contentType | testName
@@ -238,14 +233,14 @@ class RackspaceAuthUserTest extends ReposeValveTest {
     @Unroll("Will not parse an Auth request if the URL matches /v2.0/users/RAX-AUTH/forgot-pwd (#testName)" )
     def "will not parse an Auth request if the URL matches /v2.0/users/RAX-AUTH/forgot-pwd" () {
         when: "Request body contains user credentials"
-        def messageChain = deproxy.makeRequest([url: reposeEndpoint + "/v2.0/users/RAX-AUTH/forgot-pwd", requestBody: requestBody, headers: contentType, method: "POST"])
-        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+        def messageChain = deproxy.makeRequest(url: reposeEndpoint + "/v2.0/users/RAX-AUTH/forgot-pwd", requestBody: requestBody, headers: contentType, method: "POST")
+        def sentRequest = messageChain.getHandlings()[0]
 
-        then: "Repose will send x-pp-user with a single value"
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 0
-        ((Handling) sentRequest).request.getHeaders().findAll("x-domain").size() == 0
+        then: "Repose will not send x-pp-user nor the other related headers"
+        sentRequest.request.getHeaders().findAll("x-pp-user").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-user-name").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-pp-groups").isEmpty()
+        sentRequest.request.getHeaders().findAll("x-domain").isEmpty()
 
         where:
         requestBody              | contentType | testName

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/RackspaceAuthUserTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/rackspaceauthuser/RackspaceAuthUserTest.groovy
@@ -194,4 +194,72 @@ class RackspaceAuthUserTest extends ReposeValveTest {
         and: "The result will be passed through"
         messageChain.receivedResponse.code == "200"
     }
+
+    @Unroll("Will parse Forgot Password request for username when sent to appropriate URL (#testName)")
+    def "Will parse a Forgot Password request if the URL matches /v2.0/users/RAX-AUTH/forgot-pwd"() {
+        when: "Request body contains forgot password credentials"
+        def messageChain = deproxy.makeRequest([url: reposeEndpoint + "/v2.0/users/RAX-AUTH/forgot-pwd", requestBody: requestBody, headers: contentType, method: "POST"])
+        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+
+        then: "Repose will send x-pp-user with a single value"
+        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 1
+        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 1
+        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 1
+        ((Handling) sentRequest).request.getHeaders().findAll("x-domain").size() == 0
+
+        and: "Repose will send user from Request body"
+        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-pp-user") == ("demoAuthor;q=0.8")
+        ((Handling) sentRequest).request.getHeaders().getFirstValue("x-user-name") == "demoAuthor"
+
+        where:
+        requestBody       | contentType | testName
+        userForgotXmlV20  | contentXml  | "userForgotXmlV20"
+        userForgotJsonV20 | contentJson | "userForgotJsonV20"
+    }
+
+    @Unroll("Will not parse Forgot Password request for username when sent to an inappropriate URL (#testName)")
+    def "will not parse a Forgot Password request if the URL does not match /v2.0/users/RAX-AUTH/forgot-pwd"() {
+        when: "Request body contains forgot password credentials"
+        def messageChain = deproxy.makeRequest([url: reposeEndpoint, requestBody: requestBody, headers: contentType, method: "POST"])
+        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+
+        then: "Repose will send x-pp-user with a single value"
+        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 0
+        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 0
+        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 0
+        ((Handling) sentRequest).request.getHeaders().findAll("x-domain").size() == 0
+
+        where:
+        requestBody       | contentType | testName
+        userForgotXmlV20  | contentXml  | "userForgotXmlV20"
+        userForgotJsonV20 | contentJson | "userForgotJsonV20"
+    }
+
+    @Unroll("Will not parse an Auth request if the URL matches /v2.0/users/RAX-AUTH/forgot-pwd (#testName)" )
+    def "will not parse an Auth request if the URL matches /v2.0/users/RAX-AUTH/forgot-pwd" () {
+        when: "Request body contains user credentials"
+        def messageChain = deproxy.makeRequest([url: reposeEndpoint + "/v2.0/users/RAX-AUTH/forgot-pwd", requestBody: requestBody, headers: contentType, method: "POST"])
+        def sentRequest = ((MessageChain) messageChain).getHandlings()[0]
+
+        then: "Repose will send x-pp-user with a single value"
+        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-user").size() == 0
+        ((Handling) sentRequest).request.getHeaders().findAll("x-user-name").size() == 0
+        ((Handling) sentRequest).request.getHeaders().findAll("x-pp-groups").size() == 0
+        ((Handling) sentRequest).request.getHeaders().findAll("x-domain").size() == 0
+
+        where:
+        requestBody              | contentType | testName
+        userKeyXmlV11            | contentXml  | "userKeyXmlV11"
+        userKeyJsonV11           | contentJson | "userKeyJsonV11"
+        userKeyXmlEmptyV11       | contentXml  | "userKeyXmlEmptyV11"
+        userKeyJsonEmptyV11      | contentJson | "userKeyJsonEmptyV11"
+        userPasswordXmlV20       | contentXml  | "userPasswordXmlV20"
+        userPasswordJsonV20      | contentJson | "userPasswordJsonV20"
+        userApiKeyXmlV20         | contentXml  | "userApiKeyXmlV20"
+        userApiKeyJsonV20        | contentJson | "userApiKeyJsonV20"
+        userPasswordXmlEmptyV20  | contentXml  | "userPasswordXmlEmptyV20"
+        userPasswordJsonEmptyV20 | contentJson | "userPasswordJsonEmptyV20"
+        userMfaSetupXmlV20       | contentXml  | "userMfaSetupXmlV20"
+        userMfaSetupJsonV20      | contentJson | "userMfaSetupJsonV20"
+    }
 }


### PR DESCRIPTION
Story is here:
https://repose.atlassian.net/browse/REP-4653

Updated Rackspace Auth User filter to read the request body of a Forgot Password request to grab the username, and it will only attempt to do so if the URL matches the current one used by Identity (trailing slash optional).  Otherwise, it will act like normal and try to read the request body like it was an auth request.  All of this only applies if it's a POST request, of course.

Also updated HERP filter to check the response from the origin service for an X-User-Name header if there wasn't one on the request.