### PR TITLE
REP-4804 Use SAML Library to do Translation

### DIFF
--- a/repose-aggregator/components/filters/saml-policy-translation-filter/build.gradle
+++ b/repose-aggregator/components/filters/saml-policy-translation-filter/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile "com.google.guava:guava"
     //todo: remove this once we can move the translation filter up to the same version of saxon
     compile "net.sf.saxon:Saxon-EE:9.7.0-8"
+    compile "com.rackspace.identity.components.attribute-mapper:mapper-core"
 
     provided "javax.servlet:javax.servlet-api"
     provided "javax.inject:javax.inject"

--- a/repose-aggregator/components/filters/saml-policy-translation-filter/src/main/scala/org/openrepose/filters/samlpolicy/SamlPolicyTranslationFilter.scala
+++ b/repose-aggregator/components/filters/saml-policy-translation-filter/src/main/scala/org/openrepose/filters/samlpolicy/SamlPolicyTranslationFilter.scala
@@ -30,6 +30,7 @@ import javax.servlet.{FilterChain, ServletInputStream, ServletRequest, ServletRe
 import javax.ws.rs.core.MediaType
 
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
+import com.rackspace.identity.components.AttributeMapper
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import net.sf.saxon.s9api.XsltExecutable
 import org.openrepose.commons.utils.http.CommonHttpHeader.{CONTENT_LENGTH, CONTENT_TYPE}
@@ -170,7 +171,13 @@ class SamlPolicyTranslationFilter @Inject()(configurationService: ConfigurationS
     * @return the translated document
     * @throws SamlPolicyException if the translation fails
     */
-  def translateResponse(document: Document, policy: XsltExecutable): Document = ???
+  def translateResponse(document: Document, policy: XsltExecutable): Document = {
+    try {
+      AttributeMapper.convertAssertion(policy, document)
+    } catch {
+      case e: Exception => throw SamlPolicyException(SC_BAD_REQUEST, "Failed to translate the SAML Response", e)
+    }
+  }
 
   /**
     * Signs the saml response.

--- a/repose-aggregator/components/filters/saml-policy-translation-filter/src/test/scala/org/openrepose/filters/samlpolicy/SamlPolicyTranslationFilterTest.scala
+++ b/repose-aggregator/components/filters/saml-policy-translation-filter/src/test/scala/org/openrepose/filters/samlpolicy/SamlPolicyTranslationFilterTest.scala
@@ -156,8 +156,8 @@ class SamlPolicyTranslationFilterTest extends FunSpec with BeforeAndAfterEach wi
       }.statusCode shouldEqual SC_BAD_REQUEST
     }
 
-    it("should return the translated document without throwing an exception") {
-      filter.translateResponse(document, workingXsltExec)
+    it("should return a translated document without throwing an exception") {
+      filter.translateResponse(document, workingXsltExec) should not be document
     }
   }
 

--- a/versions.properties
+++ b/versions.properties
@@ -8,6 +8,7 @@ com.google.code.findbugs:jsr305=1.3.9
 com.google.guava:guava=18.0
 com.josephpconley:play-jsonpath_2.11=2.4.0
 com.mockrunner:mockrunner-servlet=1.0.0
+com.rackspace.identity.components.attribute-mapper:mapper-core=1.0.0-SNAPSHOT
 com.rackspace.papi.components.api-checker:checker-core=2.0.3
 jerseyVersion=1.19
 com.sun.jersey:jersey-server=$jerseyVersion


### PR DESCRIPTION
I'm just all around not happy with this. The method itself is basically a one-line call through to the SAML library with some exception translation wrapped around it. The SAML library is already expected to be tested, so I didn't want to write tests proving that method call works, but I also cannot easily mock it since it's a Scala `object`. PowerMock does not play nice with Scala, and there does not seem to be a Scalatest native mocking framework with the power I would need. So in the end, I need a valid `Document` and `XsltExecutable`. Those are a bit of a pain to create, and in the end, I didn't care about the content, so I wrote dumb placeholders. I actually started by stealing a test case from the `AttributeMapper` library, but going from the Identity mapping `String` to a `XsltExecutable` had me calling `AttributeMapper.generateXSLExec(...)` which would not generate a failing XSLT. I decided that if I was going to have to write custom XSLT, I would just make them simple, stupid ones that always fail/succeed. Same goes for the SAML Response, actually.

So basically, the code I wrote just translates exceptions, but it was incredibly aggravating to set up tests for that.

Please, if you have suggestions, let me know.