### PR TITLE
REP-4816 SAML Cache Tests

### DIFF
--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/cachettl/saml-policy.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/cachettl/saml-policy.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml-policy xmlns="http://docs.openrepose.org/repose/samlpolicy/v1.0">
+    <policy-acquisition>
+        <keystone-credentials uri="http://localhost:${identityPort}"
+                              username="admin_username"
+                              password="admin_password"/>
+        <policy-endpoint uri="http://localhost:${identityPort}"/>
+        <cache ttl="${cacheTtl}"/>
+    </policy-acquisition>
+    <signature-credentials keystore-filename="single.jks"
+                           keystore-password="password"
+                           key-name="server"
+                           key-password="password"/>
+</saml-policy>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/feedinvalidation/atom-feed-service.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/feedinvalidation/atom-feed-service.cfg.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<atom-feed-service xmlns="http://docs.openrepose.org/repose/atom-feed-service/v1.0"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <feed id="authenticated-policy-feed" uri="http://localhost:${atomPort}/feed" polling-frequency="${feedPollingFrequency}">
+        <authentication xsi:type="OpenStackIdentityV2AuthenticationType"
+                        uri="http://localhost:${identityPort}"
+                        username="admin_username"
+                        password="admin_password"/>
+    </feed>
+</atom-feed-service>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/feedinvalidation/saml-policy.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/feedinvalidation/saml-policy.cfg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<saml-policy xmlns="http://docs.openrepose.org/repose/samlpolicy/v1.0">
+    <policy-acquisition>
+        <keystone-credentials uri="http://localhost:${identityPort}"
+                              username="admin_username"
+                              password="admin_password"
+                              connection-pool-id="default"/>
+        <policy-endpoint uri="http://localhost:${identityPort}" connection-pool-id="default"/>
+        <cache ttl="3600" atom-feed-id="authenticated-policy-feed"/>
+    </policy-acquisition>
+    <signature-credentials keystore-filename="single.jks"
+                           keystore-password="password"
+                           key-name="server"
+                           key-password="password"/>
+</saml-policy>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/nocache/saml-policy.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/nocache/saml-policy.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml-policy xmlns="http://docs.openrepose.org/repose/samlpolicy/v1.0">
+    <policy-acquisition>
+        <keystone-credentials uri="http://localhost:${identityPort}"
+                              username="admin_username"
+                              password="admin_password"/>
+        <policy-endpoint uri="http://localhost:${identityPort}"/>
+        <cache ttl="0"/>
+    </policy-acquisition>
+    <signature-credentials keystore-filename="single.jks"
+                           keystore-password="password"
+                           key-name="server"
+                           key-password="password"/>
+</saml-policy>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/keystonev2/AtomFeedResponseSimulator.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/keystonev2/AtomFeedResponseSimulator.groovy
@@ -19,7 +19,7 @@
  */
 package features.filters.keystonev2
 
-import groovy.text.SimpleTemplateEngine
+import groovy.xml.MarkupBuilder
 import org.joda.time.DateTime
 import org.rackspace.deproxy.Request
 import org.rackspace.deproxy.Response
@@ -28,9 +28,10 @@ import org.rackspace.deproxy.Response
  * Simulates responses from an Identity Atom Feed
  */
 class AtomFeedResponseSimulator {
-    final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+    static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 
-    def templateEngine = new SimpleTemplateEngine()
+    static final Map DEFAULT_FEED_PARAMS = [id: "urn:uuid:12345678-9abc-def0-1234-56789abcdef0", isLastPage: false]
+
     volatile boolean hasEntry = false
     int atomPort
 
@@ -39,18 +40,22 @@ class AtomFeedResponseSimulator {
 
     def headers = [
             'Connection'  : 'close',
-            'Content-type': 'application/xml',
-    ]
+            'Content-type': 'application/xml']
 
     AtomFeedResponseSimulator(int atomPort) {
         this.atomPort = atomPort
     }
 
+    def getDefaultParams() {
+        [atomPort: atomPort,
+         time    : new DateTime().toString(DATE_FORMAT),
+         token   : client_token,
+         tenant  : client_tenant]
+    }
+
     /**
      * This is a method that takes params, and returns a closure
      * Creates an appropriate closure for the TRR user token revocation event
-     * @param userId
-     * @return
      */
     def trrEventHandler(String userId) {
         { request ->
@@ -58,7 +63,7 @@ class AtomFeedResponseSimulator {
                 // reset for next time
                 hasEntry = false
 
-                new Response(200, 'OK', headers, populateTemplate(tokenRevocationRecordAtomEntryXml, [userId: userId]))
+                new Response(200, null, headers, atomFeed(atomEntryForTokenRevocationRecord(userId: userId)))
             }
         }
     }
@@ -69,193 +74,184 @@ class AtomFeedResponseSimulator {
                 // reset for next time
                 hasEntry = false
 
-                new Response(200, 'OK', headers, populateTemplate(userUpdateEvent, [userId: userId]))
+                new Response(200, null, headers, atomFeed(atomEntryForUserUpdate(userId: userId)))
             }
         }
     }
 
     def handler = { request ->
-        def template = hasEntry ? atomWithEntryXml() : atomEmptyXml
+        def body = hasEntry ? atomFeed(atomEntryForTokenInvalidation()) : atomFeedWithNoEntries()
 
         // reset for next time
         hasEntry = false
 
-        return new Response(200, 'OK', headers, populateTemplate(template))
+        new Response(200, null, headers, body)
     }
 
-    def handlerWithEntries(List<String> entries) {
-        { Request request -> new Response(200, 'OK', headers, populateTemplate(atomWithEntryXml(entries))) }
+    def handlerWithEntry(Closure<MarkupBuilder> entry) {
+        { Request request -> new Response(200, null, headers, atomFeed(entry)) }
     }
 
-    def populateTemplate(String template, Map params = [:]) {
-        def defaultParams = [
-                atomPort: atomPort,
-                time    : new DateTime().toString(DATE_FORMAT),
-                token   : client_token,
-                tenant  : client_tenant,
-        ]
-
-        templateEngine.createTemplate(template).make(defaultParams + params)
+    def handlerWithEntries(List<Closure<MarkupBuilder>> entries) {
+        // use closure composition and inject (fold) to turn the list of closures into one closure
+        handlerWithEntry(entries.inject({ MarkupBuilder builder -> builder }) { composedEntries, entry ->
+            composedEntries >> entry
+        })
     }
 
-    def String atomEmptyXml = """\
-        |<?xml version="1.0"?>
-        |<feed xmlns="http://www.w3.org/2005/Atom">
-        |    <link href="http://localhost:\${atomPort}/feed/" rel="current"/>
-        |    <link href="http://localhost:\${atomPort}/feed/" rel="self"/>
-        |    <id>urn:uuid:12345678-9abc-def0-1234-56789abcdef0</id>
-        |    <title type="text">feed</title>
-        |    <link href="http://localhost:\${atomPort}/feed/?marker=last&amp;limit=25&amp;search=&amp;direction=backward"
-        |          rel="last"/>
-        |    <updated>\${time}</updated>
-        |</feed>""".stripMargin()
+    String atomFeed(Map values = [:], Closure<MarkupBuilder> entries) {
+        Map params = getDefaultParams() + DEFAULT_FEED_PARAMS + values
 
-    def String atomWithEntryXml(List entries = [createAtomEntry()]) {
-        """\
-        |<?xml version="1.0"?>
-        |    <feed xmlns="http://www.w3.org/2005/Atom">
-        |    <link href="http://localhost:\${atomPort}/feed/" rel="current"/>
-        |    <link href="http://localhost:\${atomPort}/feed/" rel="self"/>
-        |    <id>urn:uuid:12345678-9abc-def0-1234-56789abcdef0</id>
-        |    <title type="text">feed</title>
-        |    <link href="http://localhost:\${atomPort}/feed/?marker=urn:uuid:1&amp;limit=25&amp;search=&amp;direction=forward"
-        |          rel="previous"/>
-        |    <updated>\${time}</updated>
-        |${entries.join("\n")}
-        |</feed>""".stripMargin()
+        def writer = new StringWriter()
+        def xmlBuilder = new MarkupBuilder(writer)
+        xmlBuilder.doubleQuotes = true
+        xmlBuilder.mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8")
+
+        xmlBuilder.'feed'(xmlns: "http://www.w3.org/2005/Atom") {
+            'link'(href: "http://localhost:${params.atomPort}/feed/", rel: "current")
+            'link'(href: "http://localhost:${params.atomPort}/feed/", rel: "self")
+            'id'(params.id)
+            'title'(type: "text", "feed")
+            if (params.isLastPage) {
+                'link'(href: "http://localhost:${params.atomPort}/feed/?marker=last&amp;limit=25&amp;search=&amp;direction=backward", rel: "last")
+            } else {
+                'link'(href: "http://localhost:${params.atomPort}/feed/?marker=urn:uuid:1&amp;limit=25&amp;search=&amp;direction=forward", rel: "previous")
+            }
+            'updated'(params.time)
+            entries(xmlBuilder)
+        }
+
+        writer.toString()
     }
 
-    def String createAtomEntry(Map<String, String> params = [:]) {
-        populateTemplate("""\
-        |    <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
-        |                xmlns="http://docs.rackspace.com/core/event"
-        |                xmlns:id="http://docs.rackspace.com/event/identity/token">
-        |        <atom:id>${params['id'] ?: 'urn:uuid:1'}</atom:id>
-        |        <atom:category term="rgn:IDK" />
-        |        <atom:category term="dc:IDK1" />
-        |        <atom:category term="rid:\${token}" />
-        |        <atom:category term="cloudidentity.token.token.delete" />
-        |        <atom:title type="text">Identity Token Event</atom:title>
-        |        <atom:author>
-        |            <atom:name>Repose Team</atom:name>
-        |        </atom:author>
-        |        <atom:content type="application/xml">
-        |            <event dataCenter="IDK"
-        |                   environment="JUNIT"
-        |                   eventTime="\${time}"
-        |                   id="12345678-9abc-def0-1234-56789abcdef0"
-        |                   region="IDK"
-        |                   resourceId="\${token}"
-        |                   type="DELETE"
-        |                   version="1">
-        |                <id:product resourceType="TOKEN"
-        |                            serviceCode="CloudIdentity"
-        |                            tenants="\${tenant}"
-        |                            version="1" />
-        |            </event>
-        |        </atom:content>
-        |        <atom:link href="http://test.feed.atomhopper.rackspace.com/some/identity/feed/entries/urn:uuid:4fa194dc-5148-a465-254d-b8ccab3766bc"
-        |                   rel="self" />
-        |        <atom:updated>\${time}</atom:updated>
-        |        <atom:published>\${time}</atom:published>
-        |    </atom:entry>""".stripMargin())
+    String atomFeedWithNoEntries() {
+        atomFeed(isLastPage: true) { MarkupBuilder builder ->
+            builder
+        }
     }
 
-    /**
-     * This is to revoke a specific set of tokens for a specific user
-     * The resourceId is a user id, not a token ID.
-     */
-    def tokenRevocationRecordAtomEntryXml = """\
-        |<?xml version="1.0"?>
-        |<feed xmlns="http://www.w3.org/2005/Atom">
-        |    <link href="http://localhost:\${atomPort}/feed/" rel="current"/>
-        |    <link href="http://localhost:\${atomPort}/feed/" rel="self"/>
-        |    <id>urn:uuid:12345678-9abc-def0-1234-56789abcdef0</id>
-        |    <title type="text">feed</title>
-        |    <link href="http://localhost:\${atomPort}/feed/?marker=urn:uuid:1&amp;limit=25&amp;search=&amp;direction=forward"
-        |          rel="previous"/>
-        |    <updated>\${time}</updated>
-        |    <atom:entry xmlns:atom="http://www.w3.org/2005/Atom"
-        |        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        |        xmlns="http://www.w3.org/2001/XMLSchema">
-        |        <atom:id>urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814</atom:id>
-        |        <atom:category term="rgn:DFW"/>
-        |        <atom:category term="dc:DFW1"/>
-        |        <atom:category term="rid:\${userId}"/>
-        |        <atom:category term="cloudidentity.user.trr_user.delete"/>
-        |        <atom:category term="type:cloudidentity.user.trr_user.delete"/>
-        |        <atom:title>CloudIdentity</atom:title>
-        |        <atom:content type="application/xml">
-        |            <event xmlns="http://docs.rackspace.com/core/event"
-        |                xmlns:sample="http://docs.rackspace.com/event/identity/trr/user"
-        |                id="e53d007a-fc23-11e1-975c-cfa6b29bb814"
-        |                version="2"
-        |                resourceId="\${userId}"
-        |                eventTime="\${time}"
-        |                type="DELETE"
-        |                dataCenter="DFW1"
-        |                region="DFW">
-        |                <sample:product serviceCode="CloudIdentity"
-        |                    version="1"
-        |                    resourceType="TRR_USER"
-        |                    tokenCreationDate="2013-09-26T15:32:00Z">
-        |                    <sample:tokenAuthenticatedBy values="PASSWORD APIKEY"/>
-        |                </sample:product>
-        |            </event>
-        |        </atom:content>
-        |        <atom:link href="https://ord.feeds.api.rackspacecloud.com/identity/events/entries/urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814"
-        |            rel="self"/>
-        |        <atom:updated>\${time}</atom:updated>
-        |        <atom:published>\${time}</atom:published>
-        |    </atom:entry>
-        |</feed>""".stripMargin()
+    static Closure<MarkupBuilder> atomEntry(Map params = [:], Closure<MarkupBuilder> event) {
+        return { MarkupBuilder builder ->
+            builder.'atom:entry'(
+                    'xmlns:atom': "http://www.w3.org/2005/Atom",
+                    'xmlns': "http://docs.rackspace.com/core/event",
+                    'xmlns:id': "http://docs.rackspace.com/event/identity/token") {
+                'atom:id'(params.id)
+                params.categories.each {
+                    'atom:category'(term: it)
+                }
+                'atom:title'(type: "text", params.title)
+                'atom:author' {
+                    'atom:name'("Repose Team")
+                }
+                'atom:content'(type: "application/xml") {
+                    event(builder)
+                }
+                'atom:link'(href: params.selfLink, rel: "self")
+                'atom:updated'(params.time)
+                'atom:published'(params.time)
+            }
 
-    def userUpdateEvent = """\
-        |<?xml version="1.0"?>
-        |<feed xmlns="http://www.w3.org/2005/Atom">
-        |    <link href="http://localhost:\${atomPort}/feed/" rel="current"/>
-        |    <link href="http://localhost:\${atomPort}/feed/" rel="self"/>
-        |    <id>urn:uuid:12345678-9abc-def0-1234-56789abcdef0</id>
-        |    <title type="text">feed</title>
-        |    <link href="http://localhost:\${atomPort}/feed/?marker=urn:uuid:1&amp;limit=25&amp;search=&amp;direction=forward"
-        |          rel="previous"/>
-        |    <updated>\${time}</updated>
-        |    <atom:entry xmlns:atom="http://www.w3.org/2005/Atom">
-        |        <atom:id>urn:uuid:e29ac1ca-fd06-11e1-a80c-bb58fc4a6929</atom:id>
-        |        <atom:category term="rgn:DFW" />
-        |        <atom:category term="dc:DFW1" />
-        |        <atom:category term="rid:\${userId}"/>
-        |        <atom:category term="tid:123456" />
-        |        <atom:category term="cloudidentity.user.user.update" />
-        |        <atom:category term="type:cloudidentity.user.user.update" />
-        |        <atom:category term="updatedAttributes:GROUPS ROLES PASSWORD" />
-        |        <atom:title type="text">Identity Event</atom:title>
-        |        <atom:content type="application/xml">
-        |            <event xmlns="http://docs.rackspace.com/core/event"
-        |                xmlns:id="http://docs.rackspace.com/event/identity/user"
-        |                dataCenter="DFW1"
-        |                environment="PROD"
-        |                eventTime="\${time}"
-        |                id="e29ac1ca-fd06-11e1-a80c-bb58fc4a6929"
-        |                region="DFW"
-        |                resourceId="\${userId}"
-        |                tenantId="123456"
-        |                resourceName="testuser"
-        |                type="UPDATE" version="1">
-        |                <id:product displayName="testUser"
-        |                    groups="group1 group2 group3"
-        |                    migrated="false"
-        |                    multiFactorEnabled="false"
-        |                    resourceType="USER"
-        |                    roles="admin RAX:admin role3"
-        |                    serviceCode="CloudIdentity"
-        |                    updatedAttributes="GROUPS ROLES PASSWORD"
-        |                    version="2" />
-        |            </event>
-        |        </atom:content>
-        |        <atom:link href="http://localhost:\${atomPort}/feed/" rel="self"/>
-        |        <atom:updated>\${time}</atom:updated>
-        |        <atom:published>\${time}</atom:published>
-        |    </atom:entry>
-        |</feed>""".stripMargin()
+            builder
+        }
+    }
+
+    Closure<MarkupBuilder> atomEntryForTokenInvalidation(Map values = [:]) {
+        Map params = getDefaultParams()
+        params += [
+                title: "Identity Token Event",
+                id: "urn:uuid:1",
+                categories: ["rgn:IDK", "dc:IDK1", "rid:${values.token ?: params.token}",
+                             "cloudidentity.token.token.delete"],
+                selfLink: "http://test.feed.atomhopper.rackspace.com/some/identity/feed/entries/urn:uuid:4fa194dc-5148-a465-254d-b8ccab3766bc"]
+        params += values
+
+        return atomEntry(params) { MarkupBuilder builder ->
+            builder.'event'(
+                    dataCenter: "IDK",
+                    environment: "JUNIT",
+                    eventTime: params.time,
+                    id: "12345678-9abc-def0-1234-56789abcdef0",
+                    region: "IDK",
+                    resourceId: params.token,
+                    type: "DELETE",
+                    version: "1") {
+                'id:product'(resourceType: "TOKEN", serviceCode: "CloudIdentity", tenants: params.tenant, version: "1")
+            }
+
+            builder
+        }
+    }
+
+    Closure<MarkupBuilder> atomEntryForTokenRevocationRecord(Map values = [:]) {
+        Map params = getDefaultParams()
+        params += [
+                title: "CloudIdentity",
+                id: "urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                categories: ["rgn:DFW", "dc:DFW1", "rid:${values.userId ?: params.userId}",
+                             "cloudidentity.user.trr_user.delete", "type:cloudidentity.user.trr_user.delete"],
+                selfLink: "https://ord.feeds.api.rackspacecloud.com/identity/events/entries/urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814"]
+        params += values
+
+        return atomEntry(params) { MarkupBuilder builder ->
+            builder.'event'(
+                    'xmlns:sample': "http://docs.rackspace.com/event/identity/trr/user",
+                    dataCenter: "DFW1",
+                    eventTime: params.time,
+                    id: "e53d007a-fc23-11e1-975c-cfa6b29bb814",
+                    region: "DFW",
+                    resourceId: params.userId,
+                    type: "DELETE",
+                    version: "2") {
+                'sample:product'(resourceType: "TRR_USER", serviceCode: "CloudIdentity", version: "1", tokenCreationDate: "2013-09-26T15:32:00Z") {
+                    'sample:tokenAuthenticatedBy'(values: "PASSWORD APIKEY")
+                }
+            }
+
+            builder
+        }
+    }
+
+    Closure<MarkupBuilder> atomEntryForUserUpdate(Map values = [:]) {
+        Map params = getDefaultParams()
+        params += [
+                title: "Identity Event",
+                id: "urn:uuid:e29ac1ca-fd06-11e1-a80c-bb58fc4a6929",
+                categories: ["rgn:DFW", "dc:DFW1", "rid:${values.userId ?: params.userId}", "tid:123456",
+                             "cloudidentity.user.user.update", "type:cloudidentity.user.user.update",
+                             "updatedAttributes:GROUPS ROLES PASSWORD"],
+                selfLink: "http://localhost:${params.atomPort}/feed/"]
+        params += values
+
+        return atomEntry(params) { MarkupBuilder builder ->
+            builder.'event'(
+                    'xmlns:id': "http://docs.rackspace.com/event/identity/user",
+                    dataCenter: "DFW1",
+                    environment: "PROD",
+                    eventTime: params.time,
+                    id: "e29ac1ca-fd06-11e1-a80c-bb58fc4a6929",
+                    region: "DFW",
+                    resourceId: params.userId,
+                    tenantId: "123456",
+                    resourceName: "testuser",
+                    type: "UPDATE",
+                    version: "1") {
+                'id:product'(resourceType: "USER", serviceCode: "CloudIdentity", version: "2", displayName: "testUser",
+                        groups: "group1 group2 group3", migrated: "false", multiFactorEnabled: "false",
+                        roles: "admin RAX:admin role3", updatedAttributes: "GROUPS ROLES PASSWORD")
+            }
+
+            builder
+        }
+    }
+
+    static String buildXmlToString(Closure<MarkupBuilder> buildFunction) {
+        def writer = new StringWriter()
+        def xmlBuilder = new MarkupBuilder(writer)
+        xmlBuilder.doubleQuotes = true
+
+        buildFunction(xmlBuilder)
+
+        writer.toString()
+    }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/keystonev2/AtomFeedResponseSimulator.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/keystonev2/AtomFeedResponseSimulator.groovy
@@ -244,6 +244,38 @@ class AtomFeedResponseSimulator {
         }
     }
 
+    Closure<MarkupBuilder> atomEntryForIdpUpdate(Map values = [:]) {
+        Map params = getDefaultParams()
+        params += [
+                title: "Identity Provider Event",
+                id: "urn:uuid:${UUID.randomUUID().toString()}",
+                eventId: UUID.randomUUID().toString(),
+                idpId: "_${UUID.randomUUID().toString()}",
+                issuer: "http://idp.external.com",
+                eventType: "UPDATE",
+                resourceType: "IDP",
+                serviceCode: "CloudIdentity",
+                categories: [],
+                selfLink: "http://localhost:${params.atomPort}/feed/"]
+        params += values
+
+        return atomEntry(params) { MarkupBuilder builder ->
+            builder.'event'(
+                    'xmlns:idfed': "http://docs.rackspace.com/event/identity/idp",
+                    dataCenter: "DFW1",
+                    eventTime: params.time,
+                    id: params.eventId,
+                    region: "DFW",
+                    resourceId: params.idpId,
+                    type: params.eventType,
+                    version: "2") {
+                'idfed:product'(resourceType: params.resourceType, serviceCode: params.serviceCode, version: "1", issuer: params.issuer)
+            }
+
+            builder
+        }
+    }
+
     static String buildXmlToString(Closure<MarkupBuilder> buildFunction) {
         def writer = new StringWriter()
         def xmlBuilder = new MarkupBuilder(writer)

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/keystonev2/AtomFeedResponseSimulator.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/keystonev2/AtomFeedResponseSimulator.groovy
@@ -102,26 +102,25 @@ class AtomFeedResponseSimulator {
     String atomFeed(Map values = [:], Closure<MarkupBuilder> entries) {
         Map params = getDefaultParams() + DEFAULT_FEED_PARAMS + values
 
-        def writer = new StringWriter()
-        def xmlBuilder = new MarkupBuilder(writer)
-        xmlBuilder.doubleQuotes = true
-        xmlBuilder.mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8")
+        return buildXmlToString { MarkupBuilder xmlBuilder ->
+            xmlBuilder.mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8")
 
-        xmlBuilder.'feed'(xmlns: "http://www.w3.org/2005/Atom") {
-            'link'(href: "http://localhost:${params.atomPort}/feed/", rel: "current")
-            'link'(href: "http://localhost:${params.atomPort}/feed/", rel: "self")
-            'id'(params.id)
-            'title'(type: "text", "feed")
-            if (params.isLastPage) {
-                'link'(href: "http://localhost:${params.atomPort}/feed/?marker=last&amp;limit=25&amp;search=&amp;direction=backward", rel: "last")
-            } else {
-                'link'(href: "http://localhost:${params.atomPort}/feed/?marker=urn:uuid:1&amp;limit=25&amp;search=&amp;direction=forward", rel: "previous")
+            xmlBuilder.'feed'(xmlns: "http://www.w3.org/2005/Atom") {
+                'link'(href: "http://localhost:${params.atomPort}/feed/", rel: "current")
+                'link'(href: "http://localhost:${params.atomPort}/feed/", rel: "self")
+                'id'(params.id)
+                'title'(type: "text", "feed")
+                if (params.isLastPage) {
+                    'link'(href: "http://localhost:${params.atomPort}/feed/?marker=last&amp;limit=25&amp;search=&amp;direction=backward", rel: "last")
+                } else {
+                    'link'(href: "http://localhost:${params.atomPort}/feed/?marker=urn:uuid:1&amp;limit=25&amp;search=&amp;direction=forward", rel: "previous")
+                }
+                'updated'(params.time)
+                entries(xmlBuilder)
             }
-            'updated'(params.time)
-            entries(xmlBuilder)
-        }
 
-        writer.toString()
+            xmlBuilder
+        }
     }
 
     String atomFeedWithNoEntries() {

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/keystonev2/AtomFeedResponseSimulator.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/keystonev2/AtomFeedResponseSimulator.groovy
@@ -24,6 +24,8 @@ import org.joda.time.DateTime
 import org.rackspace.deproxy.Request
 import org.rackspace.deproxy.Response
 
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
 /**
  * Simulates responses from an Identity Atom Feed
  */
@@ -63,7 +65,7 @@ class AtomFeedResponseSimulator {
                 // reset for next time
                 hasEntry = false
 
-                new Response(200, null, headers, atomFeed(atomEntryForTokenRevocationRecord(userId: userId)))
+                new Response(SC_OK, null, headers, atomFeed(atomEntryForTokenRevocationRecord(userId: userId)))
             }
         }
     }
@@ -74,7 +76,7 @@ class AtomFeedResponseSimulator {
                 // reset for next time
                 hasEntry = false
 
-                new Response(200, null, headers, atomFeed(atomEntryForUserUpdate(userId: userId)))
+                new Response(SC_OK, null, headers, atomFeed(atomEntryForUserUpdate(userId: userId)))
             }
         }
     }
@@ -85,11 +87,11 @@ class AtomFeedResponseSimulator {
         // reset for next time
         hasEntry = false
 
-        new Response(200, null, headers, body)
+        new Response(SC_OK, null, headers, body)
     }
 
     def handlerWithEntry(Closure<MarkupBuilder> entry) {
-        { Request request -> new Response(200, null, headers, atomFeed(entry)) }
+        { Request request -> new Response(SC_OK, null, headers, atomFeed(entry)) }
     }
 
     def handlerWithEntries(List<Closure<MarkupBuilder>> entries) {

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
@@ -99,7 +99,7 @@ class SamlCacheDisabledTest extends ReposeValveTest {
 
         when:
         def mcs = (1..numOfRequests).collect {
-            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
             def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
             deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
         }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
@@ -1,0 +1,118 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.samlpolicy
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import org.rackspace.deproxy.Deproxy
+import org.spockframework.runtime.ConditionNotSatisfiedError
+import spock.lang.FailsWith
+
+import static features.filters.samlpolicy.util.SamlPayloads.*
+import static features.filters.samlpolicy.util.SamlUtilities.*
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
+/**
+ * This functional test verifies that the cache can be turned off.
+ */
+class SamlCacheDisabledTest extends ReposeValveTest {
+    static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+        reposeLogSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy/nocache", params)
+
+        deproxy = new Deproxy()
+
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        deproxy.addEndpoint(properties.targetPort, 'origin service', null, fakeIdentityV2Service.handler)
+        deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityV2Service.handler)
+
+        repose.start()
+        reposeLogSearch.awaitByString("Repose ready", 1, 30)
+
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+    }
+
+    def setup() {
+        fakeIdentityV2Service.resetCounts()
+    }
+
+    @FailsWith(ConditionNotSatisfiedError)
+    def "when the same saml:response is sent multiple times (same Issuer), the mapping policy should be retrieved from Identity each time"() {
+        given: "the same saml:response will be used in each request"
+        def url = reposeEndpoint + SAML_AUTH_URL
+        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(SAML_ONE_ASSERTION_SIGNED))
+
+        and: "we will make several requests"
+        def numOfRequests = 22
+
+        when:
+        def mcs = (1..numOfRequests).collect {
+            deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+        }
+
+        then: "the client gets back a good response every time"
+        mcs.every { it.receivedResponse.code as Integer == SC_OK }
+
+        and: "the origin service received the request every time"
+        mcs.every { it.handlings[0] }
+        fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == numOfRequests
+
+        and: "the IDP and Mapping Policy endpoints were called every time"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == numOfRequests
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == numOfRequests
+    }
+
+    @FailsWith(ConditionNotSatisfiedError)
+    def "when multiple unique saml:responses are sent with the same Issuer, the mapping policy should be retrieved from Identity each time"() {
+        given: "the same issuer will be used to generate each unique saml:response"
+        def samlIssuer = generateUniqueIssuer()
+        def url = reposeEndpoint + SAML_AUTH_URL
+        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+
+        and: "we will make several requests"
+        def numOfRequests = 21
+
+        when:
+        def mcs = (1..numOfRequests).collect {
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion())
+            def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+            deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+        }
+
+        then: "the client gets back a good response every time"
+        mcs.every { it.receivedResponse.code as Integer == SC_OK }
+
+        and: "the origin service received the request every time"
+        mcs.every { it.handlings[0] }
+        fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == numOfRequests
+
+        and: "the IDP and Mapping Policy endpoints were called every time"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == numOfRequests
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == numOfRequests
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
@@ -99,7 +99,7 @@ class SamlCacheDisabledTest extends ReposeValveTest {
 
         when:
         def mcs = (1..numOfRequests).collect {
-            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion())
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
             def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
             deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
         }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
@@ -82,7 +82,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         def url = reposeEndpoint + SAML_AUTH_URL
         def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
 
-        and: "an atom feed entry will be received with the same issuer as the saml:responses contain"
+        and: "an atom feed entry will be received with the same issuer as the saml:response contains"
         def atomFeedEntry = fakeAtomFeed.atomEntryForIdpUpdate(eventType: eventType, issuer: samlIssuer)
         def atomFeedHandlerWithEntry = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
 
@@ -138,7 +138,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
 
     @FailsWith(ConditionNotSatisfiedError)
     def "when an atom feed is received with multiple entries containing multiple issuers, the correct mapping policies are removed from the cache"() {
-        given: "a list of issuers that will be used to in the saml:responses"
+        given: "a list of issuers that will be used in the saml:responses"
         def samlIssuers = (1..5).collect { generateUniqueIssuer() }
         def url = reposeEndpoint + SAML_AUTH_URL
         def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
@@ -87,7 +87,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         def atomFeedHandlerWithEntry = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
 
         when: "a request is sent for the first time"
-        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -101,7 +101,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
 
         when: "a request is sent again immediately after the first request"
         fakeIdentityV2Service.resetCounts()
-        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -120,7 +120,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         and: "a request is sent after the cache entry is supposed to be invalidated"
         atomEndpoint.defaultHandler = fakeAtomFeed.handler
         fakeIdentityV2Service.resetCounts()
-        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -149,7 +149,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
 
         when: "requests are sent for each issuer for the first time"
         def mcs = samlIssuers.collect { samlIssuer ->
-            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
             def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
             deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
         }
@@ -165,7 +165,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         when: "requests are sent again immediately after the first round of requests"
         fakeIdentityV2Service.resetCounts()
         mcs = samlIssuers.collect { samlIssuer ->
-            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
             def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
             deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
         }
@@ -186,7 +186,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         atomEndpoint.defaultHandler = fakeAtomFeed.handler
         fakeIdentityV2Service.resetCounts()
         mcs = samlIssuers.collect { samlIssuer ->
-            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
             def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
             deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
         }
@@ -214,7 +214,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         def atomFeedHandlerWithEntry = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
 
         when: "a request is sent for the first time"
-        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -228,7 +228,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
 
         when: "a request is sent again immediately after the first request"
         fakeIdentityV2Service.resetCounts()
-        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -247,7 +247,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         and: "a request is sent after the cache entry is supposed to be invalidated"
         atomEndpoint.defaultHandler = fakeAtomFeed.handler
         fakeIdentityV2Service.resetCounts()
-        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
@@ -1,0 +1,269 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.samlpolicy
+
+import features.filters.keystonev2.AtomFeedResponseSimulator
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.Endpoint
+import org.spockframework.runtime.ConditionNotSatisfiedError
+import spock.lang.FailsWith
+import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
+
+import static features.filters.samlpolicy.util.SamlPayloads.*
+import static features.filters.samlpolicy.util.SamlUtilities.*
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
+/**
+ * This functional test exercises the cache feed invalidation.
+ */
+class SamlCacheFeedInvalidationTest extends ReposeValveTest {
+    static final int FEED_POLLING_FREQUENCY_SEC = 2
+    static final String ATOM_FEED_LOG_SEARCH_STRING = "</atom:entry>"
+    static final String SERVICE_CODE = "CloudIdentity"
+    static final String RESOURCE_TYPE = "IDP"
+
+    static MockIdentityV2Service fakeIdentityV2Service
+    static AtomFeedResponseSimulator fakeAtomFeed
+    static Endpoint atomEndpoint
+
+    def setupSpec() {
+        def params = properties.defaultTemplateParams + [feedPollingFrequency: FEED_POLLING_FREQUENCY_SEC]
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy/feedinvalidation", params)
+
+        deproxy = new Deproxy()
+
+        fakeAtomFeed = new AtomFeedResponseSimulator(properties.atomPort)
+        atomEndpoint = deproxy.addEndpoint(properties.atomPort, 'atom service', null, fakeAtomFeed.handler)
+
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        deproxy.addEndpoint(properties.targetPort, 'origin service', null, fakeIdentityV2Service.handler)
+        deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityV2Service.handler)
+
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+
+        repose.start()
+        reposeLogSearch.awaitByString("Repose ready", 1, 30)
+    }
+
+    def setup() {
+        fakeIdentityV2Service.resetCounts()
+        reposeLogSearch.cleanLog()
+    }
+
+    @Unroll
+    @FailsWith(ConditionNotSatisfiedError)
+    def "when an atom feed entry with serviceCode 'CloudIdentity', resourceType 'IDP', and type '#eventType' is received for an issuer, the mapping policy is removed from the cache"() {
+        given: "the same issuer will be used to generate each unique saml:response"
+        def samlIssuer = generateUniqueIssuer()
+        def url = reposeEndpoint + SAML_AUTH_URL
+        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+
+        and: "an atom feed entry will be received with the same issuer as the saml:responses contain"
+        def atomFeedEntry = fakeAtomFeed.atomEntryForIdpUpdate(eventType: eventType, issuer: samlIssuer)
+        def atomFeedHandlerWithEntry = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
+
+        when: "a request is sent for the first time"
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints are called"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
+
+        and: "the request is overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        when: "a request is sent again immediately after the first request"
+        fakeIdentityV2Service.resetCounts()
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints are not called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 0
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 0
+
+        and: "the request is overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        when: "the atom feed entry is made available and we wait until Repose logs that it processed the entry"
+        atomEndpoint.defaultHandler = atomFeedHandlerWithEntry
+        reposeLogSearch.awaitByString(ATOM_FEED_LOG_SEARCH_STRING, 1, FEED_POLLING_FREQUENCY_SEC + 1, TimeUnit.SECONDS)
+
+        and: "a request is sent after the cache entry is supposed to be invalidated"
+        atomEndpoint.defaultHandler = fakeAtomFeed.handler
+        fakeIdentityV2Service.resetCounts()
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints are called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
+
+        and: "the request is overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        where:
+        eventType << ["CREATE", "UPDATE", "DELETE"]
+    }
+
+    @FailsWith(ConditionNotSatisfiedError)
+    def "when an atom feed is received with multiple entries containing multiple issuers, the correct mapping policies are removed from the cache"() {
+        given: "a list of issuers that will be used to in the saml:responses"
+        def samlIssuers = (1..5).collect { generateUniqueIssuer() }
+        def url = reposeEndpoint + SAML_AUTH_URL
+        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+
+        and: "an atom feed will be received with entries containing the same issuers plus one more"
+        def atomFeedHandlerWithEntries = fakeAtomFeed.handlerWithEntries(
+                (samlIssuers + generateUniqueIssuer()).collect { fakeAtomFeed.atomEntryForIdpUpdate(issuer: it) })
+
+        when: "requests are sent for each issuer for the first time"
+        def mcs = samlIssuers.collect { samlIssuer ->
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+            def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+            deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+        }
+
+        then: "the IDP and Mapping Policy endpoints are called for each issuer"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == samlIssuers.size()
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == samlIssuers.size()
+
+        and: "the requests are all successful"
+        mcs.every { it.receivedResponse.code as Integer == SC_OK }
+        mcs.every { it.handlings[0] }
+
+        when: "requests are sent again immediately after the first round of requests"
+        fakeIdentityV2Service.resetCounts()
+        mcs = samlIssuers.collect { samlIssuer ->
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+            def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+            deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+        }
+
+        then: "the IDP and Mapping Policy endpoints are not called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 0
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 0
+
+        and: "the requests are all successful"
+        mcs.every { it.receivedResponse.code as Integer == SC_OK }
+        mcs.every { it.handlings[0] }
+
+        when: "the atom feed entry is made available and we wait until Repose logs that it processed the entries plus one more"
+        atomEndpoint.defaultHandler = atomFeedHandlerWithEntries
+        reposeLogSearch.awaitByString(ATOM_FEED_LOG_SEARCH_STRING, samlIssuers.size() + 1, FEED_POLLING_FREQUENCY_SEC + 1, TimeUnit.SECONDS)
+
+        and: "requests are sent after the cache entries are supposed to be invalidated"
+        atomEndpoint.defaultHandler = fakeAtomFeed.handler
+        fakeIdentityV2Service.resetCounts()
+        mcs = samlIssuers.collect { samlIssuer ->
+            def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+            def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+            deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+        }
+
+        then: "the IDP and Mapping Policy endpoints are called again for each issuer"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == samlIssuers.size()
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == samlIssuers.size()
+
+        and: "the requests are all successful"
+        mcs.every { it.receivedResponse.code as Integer == SC_OK }
+        mcs.every { it.handlings[0] }
+    }
+
+    @Unroll
+    @FailsWith(ConditionNotSatisfiedError)
+    def "when an atom feed entry with serviceCode '#serviceCode', resourceType '#resourceType', and type '#eventType' is received for the same issuer (#issuerMatch), the mapping policy is NOT removed from the cache"() {
+        given: "the same issuer will be used to generate each unique saml:response"
+        def samlIssuer = generateUniqueIssuer()
+        def url = reposeEndpoint + SAML_AUTH_URL
+        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+
+        and: "an atom feed entry will be received with the specific values for the specific test"
+        def atomFeedEntry = fakeAtomFeed.atomEntryForIdpUpdate(
+                serviceCode: serviceCode, resourceType: resourceType, eventType: eventType, issuer: issuerMatch ? samlIssuer : "pineapple")
+        def atomFeedHandlerWithEntry = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
+
+        when: "a request is sent for the first time"
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints are called"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
+
+        and: "the request is overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        when: "a request is sent again immediately after the first request"
+        fakeIdentityV2Service.resetCounts()
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints are not called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 0
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 0
+
+        and: "the request is overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        when: "the atom feed entry is made available and we wait until Repose logs that it processed the entry"
+        atomEndpoint.defaultHandler = atomFeedHandlerWithEntry
+        reposeLogSearch.awaitByString(ATOM_FEED_LOG_SEARCH_STRING, 1, FEED_POLLING_FREQUENCY_SEC + 1, TimeUnit.SECONDS)
+
+        and: "a request is sent after the cache entry is supposed to be invalidated"
+        atomEndpoint.defaultHandler = fakeAtomFeed.handler
+        fakeIdentityV2Service.resetCounts()
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints are still not called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 0
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 0
+
+        and: "the request is overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        where:
+        serviceCode     | resourceType  | eventType  | issuerMatch
+        "RandomService" | RESOURCE_TYPE | "UPDATE"   | true
+        SERVICE_CODE    | "POTATO_FARM" | "UPDATE"   | true
+        SERVICE_CODE    | RESOURCE_TYPE | "SURPRISE" | true
+        SERVICE_CODE    | RESOURCE_TYPE | "UPDATE"   | false
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
@@ -36,6 +36,7 @@ import static javax.servlet.http.HttpServletResponse.SC_OK
 class SamlCacheTtlTest extends ReposeValveTest {
     static final int CACHE_TTL_SEC = 2
     static final int CACHE_TTL_MILLIS = CACHE_TTL_SEC * 1_000
+    static final int SLEEP_PADDING_MILLIS = 500
 
     static MockIdentityV2Service fakeIdentityV2Service
 
@@ -94,7 +95,7 @@ class SamlCacheTtlTest extends ReposeValveTest {
         mc.handlings[0]
 
         when: "a request is sent after the cache entry is supposed to expire"
-        sleep(CACHE_TTL_MILLIS)
+        sleep(CACHE_TTL_MILLIS + SLEEP_PADDING_MILLIS)
         fakeIdentityV2Service.resetCounts()
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -142,7 +143,7 @@ class SamlCacheTtlTest extends ReposeValveTest {
         mc.handlings[0]
 
         when: "a request is sent after the cache entry is supposed to expire"
-        sleep(CACHE_TTL_MILLIS)
+        sleep(CACHE_TTL_MILLIS + SLEEP_PADDING_MILLIS)
         fakeIdentityV2Service.resetCounts()
         saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
@@ -1,0 +1,159 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.samlpolicy
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import org.rackspace.deproxy.Deproxy
+import org.spockframework.runtime.ConditionNotSatisfiedError
+import spock.lang.FailsWith
+
+import static features.filters.samlpolicy.util.SamlPayloads.*
+import static features.filters.samlpolicy.util.SamlUtilities.*
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
+/**
+ * This functional test exercises the cache TTL expiration.
+ */
+class SamlCacheTtlTest extends ReposeValveTest {
+    static final int CACHE_TTL_SEC = 2
+    static final int CACHE_TTL_MILLIS = CACHE_TTL_SEC * 1_000
+
+    static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+        reposeLogSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams + [cacheTtl: CACHE_TTL_SEC]
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy/cachettl", params)
+
+        deproxy = new Deproxy()
+
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        deproxy.addEndpoint(properties.targetPort, 'origin service', null, fakeIdentityV2Service.handler)
+        deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityV2Service.handler)
+
+        repose.start()
+        reposeLogSearch.awaitByString("Repose ready", 1, 30)
+
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+    }
+
+    def setup() {
+        fakeIdentityV2Service.resetCounts()
+    }
+
+    @FailsWith(ConditionNotSatisfiedError)
+    def "when the same saml:response is sent after the cache entry is supposed to expire, the mapping policy should be retrieved from Identity again"() {
+        given: "the same saml:response will be used in each request"
+        def url = reposeEndpoint + SAML_AUTH_URL
+        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(SAML_ONE_ASSERTION_SIGNED))
+
+        when: "a request is sent for the first time"
+        def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints were called"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
+
+        and: "the request was overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        when: "a request is sent again immediately after the first request"
+        fakeIdentityV2Service.resetCounts()
+        mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints are not called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 0
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 0
+
+        and: "the request was overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        when: "a request is sent after the cache entry is supposed to expire"
+        sleep(CACHE_TTL_MILLIS)
+        fakeIdentityV2Service.resetCounts()
+        mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints were called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
+
+        and: "the request was overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+    }
+
+    @FailsWith(ConditionNotSatisfiedError)
+    def "when a saml:response with the same Issuer as a previous one is sent after the cache entry is supposed to expire, the mapping policy should be retrieved from Identity again"() {
+        given: "the same saml:response will be used in each request"
+        def samlIssuer = generateUniqueIssuer()
+        def url = reposeEndpoint + SAML_AUTH_URL
+        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+
+        when: "a request is sent for the first time"
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion())
+        def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints were called"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
+
+        and: "the request was overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        when: "a request is sent again immediately after the first request"
+        fakeIdentityV2Service.resetCounts()
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion())
+        requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints are not called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 0
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 0
+
+        and: "the request was overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+
+        when: "a request is sent after the cache entry is supposed to expire"
+        sleep(CACHE_TTL_MILLIS)
+        fakeIdentityV2Service.resetCounts()
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion())
+        requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
+        mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
+
+        then: "the IDP and Mapping Policy endpoints were called again"
+        fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
+        fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
+
+        and: "the request was overall successful"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.handlings[0]
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
@@ -115,7 +115,7 @@ class SamlCacheTtlTest extends ReposeValveTest {
         def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
 
         when: "a request is sent for the first time"
-        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -129,7 +129,7 @@ class SamlCacheTtlTest extends ReposeValveTest {
 
         when: "a request is sent again immediately after the first request"
         fakeIdentityV2Service.resetCounts()
-        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -144,7 +144,7 @@ class SamlCacheTtlTest extends ReposeValveTest {
         when: "a request is sent after the cache entry is supposed to expire"
         sleep(CACHE_TTL_MILLIS)
         fakeIdentityV2Service.resetCounts()
-        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
@@ -73,11 +73,11 @@ class SamlCacheTtlTest extends ReposeValveTest {
         when: "a request is sent for the first time"
         def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
-        then: "the IDP and Mapping Policy endpoints were called"
+        then: "the IDP and Mapping Policy endpoints are called"
         fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
         fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
 
-        and: "the request was overall successful"
+        and: "the request is overall successful"
         mc.receivedResponse.code as Integer == SC_OK
         mc.handlings[0]
 
@@ -89,7 +89,7 @@ class SamlCacheTtlTest extends ReposeValveTest {
         fakeIdentityV2Service.getGetIdpFromIssuerCount() == 0
         fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 0
 
-        and: "the request was overall successful"
+        and: "the request is overall successful"
         mc.receivedResponse.code as Integer == SC_OK
         mc.handlings[0]
 
@@ -98,11 +98,11 @@ class SamlCacheTtlTest extends ReposeValveTest {
         fakeIdentityV2Service.resetCounts()
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
-        then: "the IDP and Mapping Policy endpoints were called again"
+        then: "the IDP and Mapping Policy endpoints are called again"
         fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
         fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
 
-        and: "the request was overall successful"
+        and: "the request is overall successful"
         mc.receivedResponse.code as Integer == SC_OK
         mc.handlings[0]
     }
@@ -115,21 +115,21 @@ class SamlCacheTtlTest extends ReposeValveTest {
         def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
 
         when: "a request is sent for the first time"
-        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion())
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
         def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         def mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
-        then: "the IDP and Mapping Policy endpoints were called"
+        then: "the IDP and Mapping Policy endpoints are called"
         fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
         fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
 
-        and: "the request was overall successful"
+        and: "the request is overall successful"
         mc.receivedResponse.code as Integer == SC_OK
         mc.handlings[0]
 
         when: "a request is sent again immediately after the first request"
         fakeIdentityV2Service.resetCounts()
-        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion())
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
@@ -137,22 +137,22 @@ class SamlCacheTtlTest extends ReposeValveTest {
         fakeIdentityV2Service.getGetIdpFromIssuerCount() == 0
         fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 0
 
-        and: "the request was overall successful"
+        and: "the request is overall successful"
         mc.receivedResponse.code as Integer == SC_OK
         mc.handlings[0]
 
         when: "a request is sent after the cache entry is supposed to expire"
         sleep(CACHE_TTL_MILLIS)
         fakeIdentityV2Service.resetCounts()
-        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion())
+        saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer))
         requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml))
         mc = deproxy.makeRequest(url: url, method: HTTP_POST, headers: headers, requestBody: requestBody)
 
-        then: "the IDP and Mapping Policy endpoints were called again"
+        then: "the IDP and Mapping Policy endpoints are called again"
         fakeIdentityV2Service.getGetIdpFromIssuerCount() == 1
         fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == 1
 
-        and: "the request was overall successful"
+        and: "the request is overall successful"
         mc.receivedResponse.code as Integer == SC_OK
         mc.handlings[0]
     }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
@@ -49,6 +49,27 @@ class SamlPayloads {
 
     static final String SAML_STATUS_SUCCESS = "urn:oasis:names:tc:SAML:2.0:status:Success"
 
+    static final String SAML_INVALID_SIGNATURE_VALUE = """\
+MtFONdlYWxzRDvs+GzMwiv02nfvKZBBAeLEmEVeCXTtt9xQK1ZosN01UQxio/dTUg8eK9KKAgEdp+Gxu/U8A7DpzLl/Xyikzw0dk
+fSYLMXexz12lRjvKdCbnLDoAB7CbNtu0MyDE89SR6rjggFiJmu1gEBkT9wtxlB1lrGgpVEk=""".replace("\n", "")
+
+    // this is the certificate for the test External issuer with CN: idp.external.com
+    static final String SAML_EXTERNAL_X509_CERTIFICATE = """\
+MIID1zCCAr+gAwIBAgIJANXRE4AvFkE/MA0GCSqGSIb3DQEBCwUAMIGAMQswCQYDVQQGEwJVUzEOMAwGA1UECAwFVGV4YXMxFDAS
+BgNVBAcMC1NhbiBBbnRvbmlvMRkwFwYDVQQKDBBFeHRlcm5hbCBDb21wYW55MRUwEwYDVQQLDAxFeHRlcm5hbCBPcmcxGTAXBgNV
+BAMMEGlkcC5leHRlcm5hbC5jb20wIBcNMTcwMTEyMDA1MjA0WhgPMjExNjEyMTkwMDUyMDRaMIGAMQswCQYDVQQGEwJVUzEOMAwG
+A1UECAwFVGV4YXMxFDASBgNVBAcMC1NhbiBBbnRvbmlvMRkwFwYDVQQKDBBFeHRlcm5hbCBDb21wYW55MRUwEwYDVQQLDAxFeHRl
+cm5hbCBPcmcxGTAXBgNVBAMMEGlkcC5leHRlcm5hbC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyVdLk8tyB
+7oPgfs5BWnttcB4QDfdKAIUvK67temK2HVlX7DQj4SHmP0Xgs45l/MwVcdI+yyqxf2kuPIrGgQ7TfsdE9b/ATePjsS8FhBYCFI0v
++HmV0x7tDwwQchYPKmNVwpNx9otqC/0pRjemOhtZuhmTe/V31TGWH/Pq5+89pIYbiT4TqV0RTuN15RbJ/rHfGiCyQSH85CW4308f
++qiHqnoD4S4q4xAZvZZEeJ/04a16WIoSOLI1/X63lHJ82VDh3POiuZVQYyyqC7EWcYmrNJzVvJ17GSRJR48oUiwijQUYSiX7l98X
+KAJfTnmuLy3J/xdvGGlOIyLdksJnE5UbAgMBAAGjUDBOMB0GA1UdDgQWBBRxOHOh+cErc+V0fu71BjZNw4FalTAfBgNVHSMEGDAW
+gBRxOHOh+cErc+V0fu71BjZNw4FalTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCP3v1/CmsaTLS4HKnGy+rURLC5
+hMApMIs9CERGfYfrRsC2WR1aRCGgORfPRi5+laxFxhqcK6XtW/kkipWsHLsY1beGtjji3ag6zxtCmjK/8Oi4q1c+LQx0Kf/6gie6
+wPI7bBYxuLgIrp6hG9wWhQWsx42ra6NLHTJXO5TxnN2RT0dbaD24d6OWY0yxB9wKwyLhND7Basrm34A1UYdlEy5mce9KywneFux6
+7Fe0Rksfq4BAWfRW49dIYY+kVHfHqf95aSQtEpqkmMr15yVDexpixo658oRd+XebSGlPn/1y5pe7gytj/g9OvBdkVCw67MtADjpv
+aVW9lDnpU4v6nCnn""".replace("\n", "")
+
     static final String SAML_ONE_ASSERTION_SIGNED = """\
 <saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_7fcd6173-e6e0-45a4-a2fd-74a4ef85bf30" IssueInstant="2015-12-04T15:47:15.057Z" Version="2.0">
     <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://idp.external.com</saml2:Issuer>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilities.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilities.groovy
@@ -164,15 +164,15 @@ class SamlUtilities {
      * encodeBase64(samlResponse(issuer() >> status() >> assertion()))
      * </pre>
      */
-    static Closure issuer(String issuer = SAML_EXTERNAL_ISSUER) {
-        return { MarkupBuilder builder ->
+    static Closure<MarkupBuilder> issuer(String issuer = SAML_EXTERNAL_ISSUER) {
+        { MarkupBuilder builder ->
             builder.'saml2:Issuer'(issuer)
             builder
         }
     }
 
-    static Closure status() {
-        return { MarkupBuilder builder ->
+    static Closure<MarkupBuilder> status() {
+        { MarkupBuilder builder ->
             builder.'saml2p:Status' {
                 'saml2p:StatusCode'(Value: SAML_STATUS_SUCCESS)
             }
@@ -184,8 +184,8 @@ class SamlUtilities {
      * Given a String containing an Assertion, returns a closure that can be used to generate a saml:response using
      * a MarkupBuilder.
      */
-    static Closure assertion(String assertion = ASSERTION_SIGNED) {
-        return { MarkupBuilder builder ->
+    static Closure<MarkupBuilder> assertion(String assertion = ASSERTION_SIGNED) {
+        { MarkupBuilder builder ->
             builder.mkp.yieldUnescaped assertion
             builder
         }
@@ -196,7 +196,7 @@ class SamlUtilities {
      * can be used to generate a saml:response using a MarkupBuilder.  An invalid signature can be added by including
      * "fakeSign: true" in the list of arguments.
      */
-    static Closure assertion(Map values) {
+    static Closure<MarkupBuilder> assertion(Map values) {
         def id = values.id ?: "_" + UUID.randomUUID().toString()
         def issueInstant = values.issueInstant ?: "2013-11-15T16:19:06.310Z"
         def issuer = values.issuer ?: SAML_EXTERNAL_ISSUER
@@ -215,7 +215,7 @@ class SamlUtilities {
             builder.'saml2:Assertion'(ID: id, IssueInstant: issueInstant, Version: "2.0") {
                 'saml2:Issuer'(issuer)
                 if (values.fakeSign) {
-                    invalidSignature()
+                    invalidSignature()(builder)
                 }
                 'saml2:Subject' {
                     'saml2:NameID'(Format: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", name)
@@ -242,7 +242,7 @@ class SamlUtilities {
         }
     }
 
-    static Closure invalidSignature() {
+    static Closure<MarkupBuilder> invalidSignature() {
         return { MarkupBuilder builder ->
             builder.'ds:Signature' {
                 'ds:SignedInfo' {
@@ -257,10 +257,10 @@ class SamlUtilities {
                         'ds:DigestValue'("H+PPZDnLGAC/C1WaJhOT+B79ojQ=")
                     }
                 }
-                'ds:SignatureValue'("MtFONdlYWxzRDv")
+                'ds:SignatureValue'(SAML_INVALID_SIGNATURE_VALUE)
                 'ds:KeyInfo' {
                     'ds:X509Data' {
-                        'ds:X509Certificate'("MIICajCCAdOgAwI")
+                        'ds:X509Certificate'(SAML_EXTERNAL_X509_CERTIFICATE)
                     }
                 }
             }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilitiesSelfTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilitiesSelfTest.groovy
@@ -82,9 +82,10 @@ class SamlUtilitiesSelfTest extends Specification {
         response.issuer.value == SAML_EXTERNAL_ISSUER
 
         where:
-        saml                                          | testDescription
-        SAML_ONE_ASSERTION_SIGNED.replace("    ", "") | "by tampering with the whitespace of a valid payload"
-        SAML_ASSERTION_INVALID_SIGNATURE              | "using a known bad payload"
+        saml                                                | testDescription
+        SAML_ONE_ASSERTION_SIGNED.replace("    ", "")       | "by tampering with the whitespace of a valid payload"
+        SAML_ASSERTION_INVALID_SIGNATURE                    | "using a known bad payload"
+        samlResponse(issuer() >> assertion(fakeSign: true)) | "generating a saml:response with an invalid signature in the Assertion"
     }
 
     @Unroll

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/services/atomfeed/AtomFeedServiceConnectionPoolTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/services/atomfeed/AtomFeedServiceConnectionPoolTest.groovy
@@ -81,8 +81,8 @@ class AtomFeedServiceConnectionPoolTest extends ReposeValveTest {
         startReposeWithConfigParams("atom-feed-id": atomFeedId)
 
         and: "we provide a valid atom feed entry with a handler that will capture the request headers"
-        String atomFeedEntry = fakeAtomFeed.createAtomEntry(id: "urn:uuid:$entryId")
-        def atomFeedHandler = fakeAtomFeed.handlerWithEntries([atomFeedEntry])
+        def atomFeedEntry = fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$entryId")
+        def atomFeedHandler = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
         HeaderCollection requestHeadersToAtomFeed = null
         def atomFeedHandlerWrapper = { Request request ->
             requestHeadersToAtomFeed = request.headers
@@ -112,8 +112,8 @@ class AtomFeedServiceConnectionPoolTest extends ReposeValveTest {
         startReposeWithConfigParams("atom-feed-id": atomFeedId)
 
         and: "an atom feed entry is available for consumption"
-        String atomFeedEntry = fakeAtomFeed.createAtomEntry(id: "urn:uuid:$entryId")
-        atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries([atomFeedEntry])
+        def atomFeedEntry = fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$entryId")
+        atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
 
         when: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("<atom:id>urn:uuid:$entryId</atom:id>", 2, 6, TimeUnit.SECONDS)
@@ -134,8 +134,8 @@ class AtomFeedServiceConnectionPoolTest extends ReposeValveTest {
         startReposeWithConfigParams("atom-feed-id": atomFeedId)
 
         and: "an atom feed entry is available for consumption"
-        String atomFeedEntry = fakeAtomFeed.createAtomEntry(id: "urn:uuid:$entryId")
-        def atomFeedHandler = fakeAtomFeed.handlerWithEntries([atomFeedEntry])
+        def atomFeedEntry = fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$entryId")
+        def atomFeedHandler = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
         def atomFeedHandlerWrapper = { Request request ->
             sleep(2_000) // configured timeout is 1 second
             atomFeedHandler(request)
@@ -146,8 +146,8 @@ class AtomFeedServiceConnectionPoolTest extends ReposeValveTest {
         reposeLogSearch.awaitByString("java.net.SocketTimeoutException: Read timed out", 1, 5, TimeUnit.SECONDS)
 
         and: "we provide a valid atom feed entry for the next attempt with a handler that will capture the request headers"
-        atomFeedEntry = fakeAtomFeed.createAtomEntry(id: "urn:uuid:${entryId + 4}")
-        atomFeedHandler = fakeAtomFeed.handlerWithEntries([atomFeedEntry])
+        atomFeedEntry = fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:${entryId + 4}")
+        atomFeedHandler = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
         HeaderCollection requestHeadersToAtomFeed = null
         atomFeedHandlerWrapper = { Request request ->
             requestHeadersToAtomFeed = request.headers
@@ -189,8 +189,8 @@ class AtomFeedServiceConnectionPoolTest extends ReposeValveTest {
         identityEndpoint.defaultHandler = fakeIdentityV2Service.handler
 
         and: "an atom feed entry is made available"
-        String atomFeedEntry = fakeAtomFeed.createAtomEntry(id: 'urn:uuid:429')
-        def atomFeedHandler = fakeAtomFeed.handlerWithEntries([atomFeedEntry])
+        def atomFeedEntry = fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:429")
+        def atomFeedHandler = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
         HeaderCollection requestHeadersToAtomFeed = null
         def atomFeedHandlerWrapper = { Request request ->
             requestHeadersToAtomFeed = request.headers

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/services/atomfeed/AtomFeedServiceReverseReadTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/services/atomfeed/AtomFeedServiceReverseReadTest.groovy
@@ -65,14 +65,14 @@ class AtomFeedServiceReverseReadTest extends ReposeValveTest {
 
     def "when an atom feed entry is received, it is passed to the filter"() {
         given: "there is an atom feed entry available for consumption"
-        String atomFeedEntry = fakeAtomFeed.createAtomEntry(id: 'urn:uuid:101')
-        atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries([atomFeedEntry])
+        def atomFeedEntry = fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:101")
+        atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
 
         when: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("<atom:id>urn:uuid:101</atom:id>", 1, 6, TimeUnit.SECONDS)
 
         then: "the Keystone V2 filter logs receiving the atom feed entry"
-        atomFeedEntry.eachLine { line ->
+        AtomFeedResponseSimulator.buildXmlToString(atomFeedEntry).eachLine { line ->
             assert reposeLogSearch.searchByString(line.trim()).size() == 1
             true
         }
@@ -82,7 +82,7 @@ class AtomFeedServiceReverseReadTest extends ReposeValveTest {
         given: "there is a list of atom feed entries available for consumption"
         List<String> ids = (201..210).collect {it as String}
         atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries(
-                ids.collect { fakeAtomFeed.createAtomEntry(id: "urn:uuid:$it") })
+                ids.collect { fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$it") })
 
         when: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("<atom:id>urn:uuid:2\\d{2}</atom:id>", ids.size(), 6, TimeUnit.SECONDS)
@@ -97,7 +97,7 @@ class AtomFeedServiceReverseReadTest extends ReposeValveTest {
         given: "there is a list of atom feed entries available for consumption"
         List<String> ids = (301..325).collect {it as String}
         atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries(
-                ids.collect { fakeAtomFeed.createAtomEntry(id: "urn:uuid:$it") })
+                ids.collect { fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$it") })
 
         when: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("<atom:id>urn:uuid:3\\d{2}</atom:id>", ids.size(), 6, TimeUnit.SECONDS)
@@ -110,7 +110,7 @@ class AtomFeedServiceReverseReadTest extends ReposeValveTest {
         when: "there are more entries on the next page"
         def moreIds = (401..425).collect {it as String}
         atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries(
-                moreIds.collect { fakeAtomFeed.createAtomEntry(id: "urn:uuid:$it") })
+                moreIds.collect { fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$it") })
 
         and: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("<atom:id>urn:uuid:4\\d{2}</atom:id>", moreIds.size(), 6, TimeUnit.SECONDS)

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/services/atomfeed/AtomFeedServiceTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/services/atomfeed/AtomFeedServiceTest.groovy
@@ -65,15 +65,15 @@ class AtomFeedServiceTest extends ReposeValveTest {
 
     def "when an atom feed entry is received, it is passed to the filter"() {
         given: "there is an atom feed entry available for consumption"
-        String atomFeedEntry = fakeAtomFeed.createAtomEntry(id: 'urn:uuid:101')
-        atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries([atomFeedEntry])
+        def atomFeedEntry = fakeAtomFeed.atomEntryForTokenInvalidation(id: 'urn:uuid:101')
+        atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntry(atomFeedEntry)
 
         when: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("</atom:entry>", 1, 11, TimeUnit.SECONDS)
         atomEndpoint.defaultHandler = fakeAtomFeed.handler
 
         then: "the Keystone V2 filter logs receiving the atom feed entry"
-        atomFeedEntry.eachLine { line ->
+        AtomFeedResponseSimulator.buildXmlToString(atomFeedEntry).eachLine { line ->
             assert reposeLogSearch.searchByString(line.trim()).size() == 1
             true
         }
@@ -83,7 +83,7 @@ class AtomFeedServiceTest extends ReposeValveTest {
         given: "there is a list of atom feed entries available for consumption"
         List<String> ids = (201..210).collect {it as String}
         atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries(
-                ids.collect { fakeAtomFeed.createAtomEntry(id: "urn:uuid:$it") })
+                ids.collect { fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$it") })
 
         when: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("</atom:entry>", ids.size(), 11, TimeUnit.SECONDS)
@@ -99,7 +99,7 @@ class AtomFeedServiceTest extends ReposeValveTest {
         given: "there is a list of atom feed entries available for consumption"
         List<String> ids = (301..325).collect {it as String}
         atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries(
-                ids.collect { fakeAtomFeed.createAtomEntry(id: "urn:uuid:$it") })
+                ids.collect { fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$it") })
 
         when: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("</atom:entry>", ids.size(), 11, TimeUnit.SECONDS)
@@ -113,7 +113,7 @@ class AtomFeedServiceTest extends ReposeValveTest {
         when: "there are more entries on the next page"
         def moreIds = (401..425).collect {it as String}
         atomEndpoint.defaultHandler = fakeAtomFeed.handlerWithEntries(
-                moreIds.collect { fakeAtomFeed.createAtomEntry(id: "urn:uuid:$it") })
+                moreIds.collect { fakeAtomFeed.atomEntryForTokenInvalidation(id: "urn:uuid:$it") })
 
         and: "we wait for the Keystone V2 filter to read the feed"
         reposeLogSearch.awaitByString("</atom:entry>", ids.size() + moreIds.size(), 11, TimeUnit.SECONDS)


### PR DESCRIPTION
Functional tests for the cache functionality in the SAML filter (not including live updating the cache configuration while Repose is running).

There will be more functional tests for the SAML functionality in a future PR.