### PR TITLE
REP-4816 SAML Attribute Mapping Tests

### DIFF
--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlAttributeMappingTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlAttributeMappingTest.groovy
@@ -1,0 +1,206 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.samlpolicy
+
+import features.filters.samlpolicy.util.SamlUtilities
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import groovy.json.JsonSlurper
+import org.rackspace.deproxy.Deproxy
+
+import static features.filters.samlpolicy.util.SamlPayloads.*
+import static features.filters.samlpolicy.util.SamlUtilities.*
+import static framework.mocks.MockIdentityV2Service.createMappingJsonWithValues
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
+/**
+ * This functional test ensures the attribute mappings are being set correctly on the request and the response.
+ */
+class SamlAttributeMappingTest extends ReposeValveTest {
+    static samlUtilities = new SamlUtilities()
+    static xmlSlurper = new XmlSlurper()
+    static jsonSlurper = new JsonSlurper()
+    static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+        reposeLogSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy", params)
+
+        deproxy = new Deproxy()
+
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        deproxy.addEndpoint(properties.targetPort, 'origin service', null, fakeIdentityV2Service.handler)
+        deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityV2Service.handler)
+
+        repose.start()
+        reposeLogSearch.awaitByString("Repose ready", 1, 30)
+
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+    }
+
+    def setup() {
+        fakeIdentityV2Service.resetCounts()
+        fakeIdentityV2Service.resetHandlers()
+    }
+
+    def "the saml:response will be translated before being sent to the origin service"() {
+        given: "a mapping policy with a literal value and a path-based value in addition to the standard attributes"
+        def extAttribLiteral = "banana"
+        def extAttribLiteralValue = "phone"
+        def extAttribPath = "adventure"
+        def extAttribPathValue = "Mordor"
+        def mappingPolicy = createMappingJsonWithValues(
+                userExtAttribs: [(extAttribLiteral): extAttribLiteralValue, (extAttribPath): "{0}"],
+                remote: [[path: $/\/saml2p:Response\/saml2:Assertion\/saml2:Subject\/saml2:NameID\/@SPProvidedID/$]])
+
+        and: "a saml:response with a value at the path specified by the mapping policy"
+        def samlIssuer = generateUniqueIssuer()
+        def attribName = "Frodo Baggins"
+        def attribRole = "nova:cool_cat"
+        def attribDomain = "193083"
+        def attribEmail = "frodo.baggins@nowhere.abc"
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(
+                issuer: samlIssuer,
+                name: attribName,
+                attributes: [roles: [attribRole], domain: [attribDomain], email: [attribEmail]],
+                spProvidedId: extAttribPathValue,
+                fakeSign: true))
+
+        and: "an Identity mock that will return the mapping policy"
+        String idpId = generateUniqueIdpId()
+        fakeIdentityV2Service.getIdpFromIssuerHandler = fakeIdentityV2Service.createGetIdpFromIssuerHandler(id: idpId)
+        fakeIdentityV2Service.getMappingPolicyForIdpHandler = fakeIdentityV2Service
+                .createGetMappingPolicyForIdp(mappings: [(idpId): mappingPolicy])
+
+        when: "a request is sent to Repose"
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+
+        and: "the saml:response received by the origin service is unmarshalled"
+        def response = samlUtilities.unmarshallResponse(mc.handlings[0].request.body as String)
+        def attributes = response.assertions[0].attributeStatements[0].attributes
+
+        then: "the request has two assertions"
+        response.assertions.size() == 2
+
+        and: "the default attributes are set correctly"
+        attributes.find { it.name == "roles" }.attributeValues[0].value == attribRole
+        attributes.find { it.name == "domain" }.attributeValues[0].value == attribDomain
+        attributes.find { it.name == "email" }.attributeValues[0].value == attribEmail
+
+        and: "the extended attributes are set correctly"
+        attributes.find { it.name == "user/$extAttribLiteral" as String }.attributeValues[0].value == extAttribLiteralValue
+        attributes.find { it.name == "user/$extAttribPath" as String }.attributeValues[0].value == extAttribPathValue
+    }
+
+    def "the access response (JSON) from the origin service will be translated before being sent to the client"() {
+        given: "a mapping policy with a literal value and a path-based value in addition to the standard attributes"
+        def extAttribLiteral = "potato"
+        def extAttribLiteralValue = "salad"
+        def extAttribPath = "pie"
+        def extAttribPathValue = "eye"
+        def mappingPolicy = createMappingJsonWithValues(
+                userExtAttribs: [(extAttribLiteral): extAttribLiteralValue, (extAttribPath): "{0}"],
+                remote: [[path: $/\/saml2p:Response\/saml2:Assertion\/saml2:Subject\/saml2:NameID\/@SPProvidedID/$]])
+
+        and: "a saml:response with a value at the path specified by the mapping policy"
+        def samlIssuer = generateUniqueIssuer()
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(
+                issuer: samlIssuer,
+                spProvidedId: extAttribPathValue,
+                fakeSign: true))
+
+        and: "an Identity mock that will return the mapping policy"
+        String idpId = generateUniqueIdpId()
+        fakeIdentityV2Service.getIdpFromIssuerHandler = fakeIdentityV2Service.createGetIdpFromIssuerHandler(id: idpId)
+        fakeIdentityV2Service.getMappingPolicyForIdpHandler = fakeIdentityV2Service
+                .createGetMappingPolicyForIdp(mappings: [(idpId): mappingPolicy])
+
+        when: "a request is sent to Repose requesting a JSON response"
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_JSON],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+
+        then: "the client receives JSON successfully"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.receivedResponse.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_JSON
+
+        when: "the response sent to the client is parsed into JSON"
+        def json = jsonSlurper.parseText(mc.receivedResponse.body as String)
+
+        then: "the extended attributes are set correctly"
+        json.access.'RAX-AUTH:extendedAttributes'.user."$extAttribLiteral" == extAttribLiteralValue
+        json.access.'RAX-AUTH:extendedAttributes'.user."$extAttribPath" == extAttribPathValue
+    }
+
+    def "the access response (XML) from the origin service will be translated before being sent to the client"() {
+        given: "a mapping policy with a fixed value and a dynamic value in addition to the standard attributes"
+        def extAttribLiteral = "blues"
+        def extAttribLiteralValue = "clues"
+        def extAttribPath = "Swiper"
+        def extAttribPathValue = "no swiping plz"
+        def mappingPolicy = createMappingJsonWithValues(
+                userExtAttribs: [(extAttribLiteral): extAttribLiteralValue, (extAttribPath): "{0}"],
+                remote: [[path: $/\/saml2p:Response\/saml2:Assertion\/saml2:Subject\/saml2:NameID\/@SPProvidedID/$]])
+
+        and: "a saml:response with a value at the path specified by the mapping policy"
+        def samlIssuer = generateUniqueIssuer()
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(
+                issuer: samlIssuer,
+                spProvidedId: extAttribPathValue,
+                fakeSign: true))
+
+        and: "an Identity mock that will return the mapping policy"
+        String idpId = generateUniqueIdpId()
+        fakeIdentityV2Service.getIdpFromIssuerHandler = fakeIdentityV2Service.createGetIdpFromIssuerHandler(id: idpId)
+        fakeIdentityV2Service.getMappingPolicyForIdpHandler = fakeIdentityV2Service
+                .createGetMappingPolicyForIdp(mappings: [(idpId): mappingPolicy])
+
+        when: "a request is sent to Repose requesting an XML response"
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_XML],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+
+        then: "the client receives XML successfully"
+        mc.receivedResponse.code as Integer == SC_OK
+        mc.receivedResponse.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+
+        when: "the response sent to the client is parsed into XML"
+        def access = xmlSlurper.parseText(mc.receivedResponse.body as String)
+
+        and: "we get the 'user' group in the extended attributes"
+        def userGroup = access.'RAX-AUTH:extendedAttributes'.'*'.find { it.@name == "user" }
+
+        then: "the extended attributes are set correctly"
+        userGroup.'*'.find { it.@name == extAttribLiteral }.value[0].text() == extAttribLiteralValue
+        userGroup.'*'.find { it.@name == extAttribPath }.value[0].text() == extAttribPathValue
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlAttributeMappingTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlAttributeMappingTest.groovy
@@ -29,8 +29,6 @@ import org.opensaml.saml.saml2.core.Response as SamlResponse
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.Request
 import org.rackspace.deproxy.Response
-import org.spockframework.runtime.ConditionNotSatisfiedError
-import spock.lang.FailsWith
 
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
@@ -70,7 +68,6 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         fakeIdentityV2Service.resetHandlers()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "the saml:response will be translated before being sent to the origin service"() {
         given: "a mapping policy with a literal value and a path-based value in addition to the standard attributes"
         def extAttribLiteral = "banana"
@@ -127,7 +124,6 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         attributes.find { it.name == "user/$extAttribPath" as String }.attributeValues[0].value == extAttribPathValue
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "the access response (JSON) from the origin service will be translated before being sent to the client"() {
         given: "a mapping policy with a literal value and a path-based value in addition to the standard attributes"
         def extAttribLiteral = "potato"
@@ -170,7 +166,6 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         json.access.'RAX-AUTH:extendedAttributes'.user."$extAttribPath" == extAttribPathValue
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "the access response (XML) from the origin service will be translated before being sent to the client"() {
         given: "a mapping policy with a fixed value and a dynamic value in addition to the standard attributes"
         def extAttribLiteral = "blues"
@@ -216,7 +211,6 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         userGroup.'*'.find { it.@name == extAttribPath }.value[0].text() == extAttribPathValue
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "the correct translation will be used on the request and response when cached"() {
         given: "mapping policies with a literal value and a path-based value for three issuers"
         def numOfIssuers = 3
@@ -339,7 +333,6 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         jsons.collect { it.access.'RAX-AUTH:extendedAttributes'.user."$extAttribPath" } == extAttribPathValuesRoundTwo
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "the extended attributes section is not added to the request/response when the mapping policy does not include any"() {
         given: "a mapping policy with only the defaults set and a saml:response with a unique issuer"
         def samlIssuer = generateUniqueIssuer()
@@ -373,7 +366,6 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         !json.access.'RAX-AUTH:extendedAttributes'
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "when the specified path for an extended attribute is not present in the saml:response, it is not added to the request/response"() {
         given: "a mapping policy with a literal value and a path-based value (that won't be in the saml:response)"
         def extAttribLiteral = "Captain"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlBasicValidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlBasicValidationTest.groovy
@@ -174,8 +174,8 @@ class SamlBasicValidationTest extends ReposeValveTest {
         where:
         reason                    | paramValue                                                        | expectedResponse
         "invalid base64 encoding" | SAML_ONE_ASSERTION_SIGNED_BASE64 + "!@#%^*)*)@"                   | "SAMLResponse is not in valid Base64 scheme"
-        "invalid XML"             | encodeBase64("legit saml response kthxbai")                       | "" // TODO: figure out what the error is going to be
-        "invalid SAML"            | encodeBase64("<banana/>")                                         | "" // TODO: figure out what the error is going to be
+        "invalid XML"             | encodeBase64("legit saml response kthxbai")                       | "SAMLResponse was not able to be parsed"
+        "invalid SAML"            | encodeBase64("<banana/>")                                         | "No issuer present in SAML Response"
         "missing Issuer element"  | encodeBase64(samlResponse(status() >> assertion()))               | "No issuer present in SAML Response"
         "empty Issuer element"    | encodeBase64(samlResponse(issuer("") >> status() >> assertion())) | "No issuer present in SAML Response"
     }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlBasicValidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlBasicValidationTest.groovy
@@ -23,8 +23,6 @@ package features.filters.samlpolicy
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityV2Service
 import org.rackspace.deproxy.Deproxy
-import org.spockframework.runtime.ConditionNotSatisfiedError
-import spock.lang.FailsWith
 import spock.lang.Unroll
 
 import static features.filters.samlpolicy.util.SamlPayloads.*
@@ -59,7 +57,6 @@ class SamlBasicValidationTest extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a valid request will make it to the origin service and back to the client successfully with form parameters: #formParams.keySet()"() {
         when: "we make a POST request"
         def mc = deproxy.makeRequest(
@@ -87,7 +84,6 @@ class SamlBasicValidationTest extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a request with Content-Type '#contentType' and a body with #bodySummary should be rejected"() {
         when: "we make a POST request"
         def mc = deproxy.makeRequest(
@@ -141,7 +137,6 @@ class SamlBasicValidationTest extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a request using the HTTP method #httpMethod should be rejected"() {
         when: "we make a request with the given HTTP method"
         def mc = deproxy.makeRequest(
@@ -161,7 +156,6 @@ class SamlBasicValidationTest extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a request should be rejected when the SAMLResponse contents are invalid due to #reason"() {
         when: "we make a POST request"
         def mc = deproxy.makeRequest(

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
@@ -23,8 +23,6 @@ package features.filters.samlpolicy
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityV2Service
 import org.rackspace.deproxy.Deproxy
-import org.spockframework.runtime.ConditionNotSatisfiedError
-import spock.lang.FailsWith
 
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
@@ -60,7 +58,6 @@ class SamlCacheDisabledTest extends ReposeValveTest {
         fakeIdentityV2Service.resetCounts()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "when the same saml:response is sent multiple times (same Issuer), the mapping policy should be retrieved from Identity each time"() {
         given: "the same saml:response will be used in each request"
         def url = reposeEndpoint + SAML_AUTH_URL
@@ -87,7 +84,6 @@ class SamlCacheDisabledTest extends ReposeValveTest {
         fakeIdentityV2Service.getGetMappingPolicyForIdpCount() == numOfRequests
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "when multiple unique saml:responses are sent with the same Issuer, the mapping policy should be retrieved from Identity each time"() {
         given: "the same issuer will be used to generate each unique saml:response"
         def samlIssuer = generateUniqueIssuer()

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
@@ -25,8 +25,6 @@ import framework.ReposeValveTest
 import framework.mocks.MockIdentityV2Service
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.Endpoint
-import org.spockframework.runtime.ConditionNotSatisfiedError
-import spock.lang.FailsWith
 import spock.lang.Unroll
 
 import java.util.concurrent.TimeUnit
@@ -75,7 +73,6 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "when an atom feed entry with serviceCode 'CloudIdentity', resourceType 'IDP', and type '#eventType' is received for an issuer, the mapping policy is removed from the cache"() {
         given: "the same issuer will be used to generate each unique saml:response"
         def samlIssuer = generateUniqueIssuer()
@@ -136,7 +133,6 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         eventType << ["CREATE", "UPDATE", "DELETE"]
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "when an atom feed is received with multiple entries containing multiple issuers, the correct mapping policies are removed from the cache"() {
         given: "a list of issuers that will be used in the saml:responses"
         def samlIssuers = (1..5).collect { generateUniqueIssuer() }
@@ -201,7 +197,6 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "when an atom feed entry with serviceCode '#serviceCode', resourceType '#resourceType', and type '#eventType' is received for the same issuer (#issuerMatch), the mapping policy is NOT removed from the cache"() {
         given: "the same issuer will be used to generate each unique saml:response"
         def samlIssuer = generateUniqueIssuer()

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
@@ -23,8 +23,6 @@ package features.filters.samlpolicy
 import framework.ReposeValveTest
 import framework.mocks.MockIdentityV2Service
 import org.rackspace.deproxy.Deproxy
-import org.spockframework.runtime.ConditionNotSatisfiedError
-import spock.lang.FailsWith
 
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
@@ -64,7 +62,6 @@ class SamlCacheTtlTest extends ReposeValveTest {
         fakeIdentityV2Service.resetCounts()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "when the same saml:response is sent after the cache entry is supposed to expire, the mapping policy should be retrieved from Identity again"() {
         given: "the same saml:response will be used in each request"
         def url = reposeEndpoint + SAML_AUTH_URL
@@ -108,7 +105,6 @@ class SamlCacheTtlTest extends ReposeValveTest {
         mc.handlings[0]
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "when a saml:response with the same Issuer as a previous one is sent after the cache entry is supposed to expire, the mapping policy should be retrieved from Identity again"() {
         given: "the same saml:response will be used in each request"
         def samlIssuer = generateUniqueIssuer()

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow10Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow10Test.groovy
@@ -25,8 +25,6 @@ import framework.ReposeValveTest
 import framework.mocks.MockIdentityV2Service
 import org.opensaml.saml.saml2.core.Response
 import org.rackspace.deproxy.Deproxy
-import org.spockframework.runtime.ConditionNotSatisfiedError
-import spock.lang.FailsWith
 import spock.lang.Unroll
 
 import static features.filters.samlpolicy.util.SamlPayloads.*
@@ -65,7 +63,6 @@ class SamlFlow10Test extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with an Issuer that #isIt in the configured policy-bypass-issuers list will get an 'Identity-API-Version' value of #headerValue in the request to the origin service"() {
         given:
         def body = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(
@@ -99,7 +96,6 @@ class SamlFlow10Test extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with a Flow 1.0 Issuer will still be successfully processed despite having #flow20ValidationIssue"() {
         when:
         def mc = deproxy.makeRequest(
@@ -131,7 +127,6 @@ class SamlFlow10Test extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response that #signedState will not be altered and will maintain signature validity through Repose"() {
         when:
         def mc = deproxy.makeRequest(

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
@@ -36,6 +36,7 @@ import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.DEFAULT_MAPPING_POLICY
 import static framework.mocks.MockIdentityV2Service.IDP_NO_RESULTS
+import static framework.mocks.MockIdentityV2Service.createGetIdpFromIssuerHandler
 import static framework.mocks.MockIdentityV2Service.createIdentityFaultJsonWithValues
 import static framework.mocks.MockIdentityV2Service.createIdpJsonWithValues
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
@@ -500,11 +501,7 @@ class SamlFlow20Test extends ReposeValveTest {
 
         and: "we're going to ensure the IDP ID returned is unique"
         String idpId = generateUniqueIdpId()
-        fakeIdentityV2Service.getIdpFromIssuerHandler = { String issuerParam, Request request ->
-            def body = createIdpJsonWithValues(issuer: issuerParam, id: idpId)
-            def headers = [(CONTENT_TYPE): CONTENT_TYPE_JSON]
-            new DeproxyResponse(SC_OK, null, headers, body)
-        }
+        fakeIdentityV2Service.getIdpFromIssuerHandler = createGetIdpFromIssuerHandler(id: idpId)
 
         and: "the Issuer is unique which will force the call to Identity (avoiding the cache)"
         def samlIssuer = generateUniqueIssuer()

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
@@ -36,7 +36,6 @@ import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.DEFAULT_MAPPING_POLICY
 import static framework.mocks.MockIdentityV2Service.IDP_NO_RESULTS
-import static framework.mocks.MockIdentityV2Service.createGetIdpFromIssuerHandler
 import static framework.mocks.MockIdentityV2Service.createIdentityFaultJsonWithValues
 import static framework.mocks.MockIdentityV2Service.createIdpJsonWithValues
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
@@ -501,7 +500,7 @@ class SamlFlow20Test extends ReposeValveTest {
 
         and: "we're going to ensure the IDP ID returned is unique"
         String idpId = generateUniqueIdpId()
-        fakeIdentityV2Service.getIdpFromIssuerHandler = createGetIdpFromIssuerHandler(id: idpId)
+        fakeIdentityV2Service.getIdpFromIssuerHandler = fakeIdentityV2Service.createGetIdpFromIssuerHandler(id: idpId)
 
         and: "the Issuer is unique which will force the call to Identity (avoiding the cache)"
         def samlIssuer = generateUniqueIssuer()

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
@@ -26,6 +26,7 @@ import framework.mocks.MockIdentityV2Service
 import groovy.xml.MarkupBuilder
 import org.opensaml.saml.saml2.core.Response
 import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.Request
 import org.rackspace.deproxy.Response as DeproxyResponse
 import org.spockframework.runtime.ConditionNotSatisfiedError
 import spock.lang.FailsWith
@@ -33,7 +34,10 @@ import spock.lang.Unroll
 
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
+import static framework.mocks.MockIdentityV2Service.DEFAULT_MAPPING_POLICY
 import static framework.mocks.MockIdentityV2Service.IDP_NO_RESULTS
+import static framework.mocks.MockIdentityV2Service.createIdentityFaultJsonWithValues
+import static framework.mocks.MockIdentityV2Service.createIdpJsonWithValues
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND
@@ -89,9 +93,6 @@ class SamlFlow20Test extends ReposeValveTest {
         mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
         mc.handlings[0].request.headers.getFirstValue(IDENTITY_API_VERSION) == "2.0"
         fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == 1
-
-        //and: "the response from the origin service is appropriately updated by the filter"
-        // TODO: what is Flow 2.0 going to do to the response?
 
         when: "the saml:response received by the origin service is unmarshalled"
         Response response = samlUtilities.unmarshallResponse(mc.handlings[0].request.body as String)
@@ -367,12 +368,12 @@ class SamlFlow20Test extends ReposeValveTest {
         "one"     | "two"     | "three"
     }
 
-    @Unroll
     @FailsWith(ConditionNotSatisfiedError)
-    def "a saml:response with an Issuer that Identity doesn't know about (returns #description) should be rejected with a 401"() {
-        given: "the IDP call will return the given response for this test"
-        // TODO: verify this is what Identity would send for this case
-        fakeIdentityV2Service.getIdpFromIssuerHandler = getIdpFromIssuerHandler
+    def "a saml:response with an Issuer that Identity doesn't know about should be rejected with a 401"() {
+        given: "the IDP call will return an empty list"
+        fakeIdentityV2Service.getIdpFromIssuerHandler = { String issuerParam, Request request ->
+            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): CONTENT_TYPE_JSON], IDP_NO_RESULTS)
+        }
 
         and: "the Issuer is unique which will force the call to Identity (avoiding the cache)"
         def samlIssuer = generateUniqueIssuer()
@@ -387,37 +388,136 @@ class SamlFlow20Test extends ReposeValveTest {
 
         then: "the client gets back a bad response"
         mc.receivedResponse.code as Integer == SC_UNAUTHORIZED
+
+        and: "the request doesn't get to the origin service"
+        mc.handlings.isEmpty()
+    }
+
+    @FailsWith(ConditionNotSatisfiedError)
+    def "a saml:response with an Issuer that Identity has a blank mapping policy for should be rejected with a 401"() {
+        given: "the mapping policy call will return a blank mapping policy"
+        fakeIdentityV2Service.getMappingPolicyForIdpHandler = { String idpId, Request request ->
+            new DeproxyResponse(
+                    SC_OK,
+                    null,
+                    [(CONTENT_TYPE): CONTENT_TYPE_JSON],
+                    /{"policy":{"name":"name"}}/)  // TODO: verify this is an example of an empty policy
+        }
+
+        and: "the Issuer is unique which will force the call to Identity (avoiding the cache)"
+        def samlIssuer = generateUniqueIssuer()
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
+
+        when:
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+
+        then: "the client gets back a bad response"
+        mc.receivedResponse.code as Integer == SC_UNAUTHORIZED
+
+        and: "the request doesn't get to the origin service"
+        mc.handlings.isEmpty()
+    }
+
+    @Unroll
+    @FailsWith(ConditionNotSatisfiedError)
+    def "when Identity returns a #code from the mapping policy endpoint, Repose should return a 500"() {
+        given: "the mapping policy call will not be successful"
+        fakeIdentityV2Service.getMappingPolicyForIdpHandler = { String idpId, Request request ->
+            new DeproxyResponse(
+                    code,
+                    null,
+                    [(CONTENT_TYPE): CONTENT_TYPE_JSON],
+                    createIdentityFaultJsonWithValues(name: fault, code: code, message: message))
+        }
+
+        and: "the Issuer is unique which will force the call to Identity (avoiding the cache)"
+        def samlIssuer = generateUniqueIssuer()
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
+
+        when:
+        def mc = deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+
+        then: "the client gets back a bad response"
+        mc.receivedResponse.code as Integer == SC_INTERNAL_SERVER_ERROR
 
         and: "the request doesn't get to the origin service"
         mc.handlings.isEmpty()
 
         where:
-        description     | getIdpFromIssuerHandler
-        "a 404"         | { new DeproxyResponse(SC_NOT_FOUND) }
-        "an empty list" | { new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): CONTENT_TYPE_JSON], IDP_NO_RESULTS) }
+        code                      | fault           | message
+        SC_NOT_FOUND              | "itemNotFound"  | "Identity Provider with id/name was not found."
+        SC_INTERNAL_SERVER_ERROR  | "identityFault" | "The default IDP policy is not properly configured."
     }
 
     @FailsWith(ConditionNotSatisfiedError)
-    def "a saml:response with an Issuer that Identity doesn't have a mapping policy for should be rejected with a 401"() {
-        given: "the mapping policy call will return a 404"
-        // TODO: verify this is what Identity would send for this case
-        fakeIdentityV2Service.getMappingPolicyForIdpHandler = { new DeproxyResponse(SC_NOT_FOUND) }
+    def "Identity is queried with the correct Issuer when looking for the identity provider ID"() {
+        given: "we're going to capture the requested issuer and path to Identity for the issuer to IDP ID call"
+        String requestedIssuerParam = null
+        String fullRequestPath = null
+        fakeIdentityV2Service.getIdpFromIssuerHandler = { String issuerParam, Request request ->
+            requestedIssuerParam = issuerParam
+            fullRequestPath = request.path
+
+            def body = createIdpJsonWithValues(issuer: issuerParam)
+            def headers = [(CONTENT_TYPE): CONTENT_TYPE_JSON]
+            new DeproxyResponse(SC_OK, null, headers, body)
+        }
 
         and: "the Issuer is unique which will force the call to Identity (avoiding the cache)"
         def samlIssuer = generateUniqueIssuer()
         def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
 
         when:
-        def mc = deproxy.makeRequest(
+        deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
                 headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
-        then: "the client gets back a bad response"
-        mc.receivedResponse.code as Integer == SC_UNAUTHORIZED
+        then: "the requested issuer should match what was in the saml:response"
+        requestedIssuerParam == samlIssuer
 
-        and: "the request doesn't get to the origin service"
-        mc.handlings.isEmpty()
+        and: "the raw path should not contain the issuer since it should have been URL encoded"
+        !fullRequestPath.contains(samlIssuer)
+    }
+
+    @FailsWith(ConditionNotSatisfiedError)
+    def "Identity is queried with the correct IDP ID when looking for the identity provider mapping policy"() {
+        given: "we're going to capture the requested IDP ID to Identity for the IDP ID to mapping policy call"
+        String requestedIdpId = null
+        fakeIdentityV2Service.getMappingPolicyForIdpHandler = { String idpId, Request request ->
+            requestedIdpId = idpId
+            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): CONTENT_TYPE_JSON], DEFAULT_MAPPING_POLICY)
+        }
+
+        and: "we're going to ensure the IDP ID returned is unique"
+        String idpId = generateUniqueIdpId()
+        fakeIdentityV2Service.getIdpFromIssuerHandler = { String issuerParam, Request request ->
+            def body = createIdpJsonWithValues(issuer: issuerParam, id: idpId)
+            def headers = [(CONTENT_TYPE): CONTENT_TYPE_JSON]
+            new DeproxyResponse(SC_OK, null, headers, body)
+        }
+
+        and: "the Issuer is unique which will force the call to Identity (avoiding the cache)"
+        def samlIssuer = generateUniqueIssuer()
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
+
+        when:
+        deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+
+        then: "the requested IDP ID should match what was returned from the first Identity call"
+        requestedIdpId == idpId
     }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
@@ -28,8 +28,6 @@ import org.opensaml.saml.saml2.core.Response
 import org.rackspace.deproxy.Deproxy
 import org.rackspace.deproxy.Request
 import org.rackspace.deproxy.Response as DeproxyResponse
-import org.spockframework.runtime.ConditionNotSatisfiedError
-import spock.lang.FailsWith
 import spock.lang.Unroll
 
 import static features.filters.samlpolicy.util.SamlPayloads.*
@@ -77,7 +75,6 @@ class SamlFlow20Test extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response that is #signatureStatus will still be successfully processed as long as its Assertion is signed"() {
         when:
         def mc = deproxy.makeRequest(
@@ -137,7 +134,6 @@ class SamlFlow20Test extends ReposeValveTest {
         // TODO: this test if possible to a specific response code and response body.
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with an unsigned assertion should be rejected"() {
         given: "a saml:response with an unsigned assertion"
         def saml = samlResponse(issuer() >> status() >> assertion(fakeSign: false))
@@ -157,7 +153,6 @@ class SamlFlow20Test extends ReposeValveTest {
         mc.handlings.isEmpty()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with an assertion that has an invalid signature will still be processed successfully"() {
         given: "a saml:response with an assertion containing an invalid signature"
         def saml = samlResponse(issuer() >> status() >> assertion(ASSERTION_SIGNED.replace("    ", "")))
@@ -180,7 +175,6 @@ class SamlFlow20Test extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with three assertions that are not all signed should be rejected - with signatures: #sigOne, #sigTwo, #sigThree"() {
         given: "a saml:response with three assertions that will each be signed depending on the test"
         def assertionOne = sigOne ? assertion(ASSERTION_SIGNED) : assertion(fakeSign: false)
@@ -211,7 +205,6 @@ class SamlFlow20Test extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with three signed assertions should be successful even if the signatures aren't valid - with valid signatures: #sigOne, #sigTwo, #sigThree"() {
         given: "a saml:response with three assertions that will each have a valid or invalid signature depending on the test"
         def assertionOne = sigOne ? ASSERTION_SIGNED : ASSERTION_SIGNED.replace("    ", "")
@@ -257,7 +250,6 @@ class SamlFlow20Test extends ReposeValveTest {
         false  | false  | false
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with an assertion missing the Issuer element should be rejected"() {
         given: "a saml:response with an assertion missing the Issuer element"
         def saml = samlResponse { MarkupBuilder builder ->
@@ -296,7 +288,6 @@ class SamlFlow20Test extends ReposeValveTest {
         mc.handlings.isEmpty()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with an assertion containing an empty Issuer will still be processed successfully"() {
         given:
         def saml = samlResponse { MarkupBuilder builder ->
@@ -339,7 +330,6 @@ class SamlFlow20Test extends ReposeValveTest {
     }
 
     @Unroll
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with three assertions containing inconsistent Issuers should be rejected - with issuers: #issuerOne, #issuerTwo, #issuerThree"() {
         given:
         def saml = samlResponse(issuer() >> status() >>
@@ -369,7 +359,6 @@ class SamlFlow20Test extends ReposeValveTest {
         "one"     | "two"     | "three"
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with an Issuer that Identity doesn't know about should be rejected with a 401"() {
         given: "the IDP call will return an empty list"
         fakeIdentityV2Service.getIdpFromIssuerHandler = { String issuerParam, Request request ->
@@ -394,7 +383,6 @@ class SamlFlow20Test extends ReposeValveTest {
         mc.handlings.isEmpty()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "a saml:response with an Issuer that Identity doesn't have a mapping policy for should be rejected with a 401"() {
         given: "the mapping policy call will a 404"
         fakeIdentityV2Service.getMappingPolicyForIdpHandler = { String idpId, Request request ->
@@ -426,7 +414,6 @@ class SamlFlow20Test extends ReposeValveTest {
         mc.handlings.isEmpty()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "when Identity returns an invalid mapping policy, Repose should return a 502"() {
         given: "the Identity mock will return an invalid mapping policy"
         fakeIdentityV2Service.getMappingPolicyForIdpHandler = { String idpId, Request request ->
@@ -455,7 +442,6 @@ class SamlFlow20Test extends ReposeValveTest {
         mc.handlings.isEmpty()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "when Identity returns a 500 from the mapping policy endpoint, Repose should return a 502"() {
         given: "the mapping policy call will not be successful"
         fakeIdentityV2Service.getMappingPolicyForIdpHandler = { String idpId, Request request ->
@@ -487,7 +473,6 @@ class SamlFlow20Test extends ReposeValveTest {
         mc.handlings.isEmpty()
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "Identity is queried with the correct Issuer when looking for the identity provider ID"() {
         given: "we're going to capture the requested issuer and path to Identity for the issuer to IDP ID call"
         String requestedIssuerParam = null
@@ -519,7 +504,6 @@ class SamlFlow20Test extends ReposeValveTest {
         !fullRequestPath.contains(samlIssuer)
     }
 
-    @FailsWith(ConditionNotSatisfiedError)
     def "Identity is queried with the correct IDP ID when looking for the identity provider mapping policy"() {
         given: "we're going to capture the requested IDP ID to Identity for the IDP ID to mapping policy call"
         String requestedIdpId = null

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
@@ -20,8 +20,6 @@
 
 package features.filters.samlpolicy.util
 
-import org.openrepose.commons.utils.http.CommonHttpHeader
-
 /**
  * WARNING! The white space in the these payloads matters. Do not re-format them.
  */
@@ -32,7 +30,9 @@ class SamlPayloads {
     static final String SAML_EXTERNAL_ISSUER = "http://idp.external.com"
     static final String SAML_REPOSE_ISSUER = "http://openrepose.org/filters/SAMLTranslation"
 
-    static final String CONTENT_TYPE = CommonHttpHeader.CONTENT_TYPE.toString()
+    static final String CONTENT_TYPE = "Content-Type"
+    static final String ACCEPT = "Accept"
+
     static final String CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded"
     static final String CONTENT_TYPE_XML = "application/xml"
     static final String CONTENT_TYPE_INVALID = "application/potato"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilities.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilities.groovy
@@ -204,6 +204,8 @@ class SamlUtilities {
         def id = values.id ?: "_" + UUID.randomUUID().toString()
         def issueInstant = values.issueInstant ?: "2013-11-15T16:19:06.310Z"
         def issuer = values.issuer ?: SAML_EXTERNAL_ISSUER
+        def nameFormat = values.nameFormat ?: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+        def nameSpProvidedIdAttrib = values.spProvidedId ? [SPProvidedID: values.spProvidedId] : [:]
         def name = values.name ?: "john.doe"
         def notOnOrAfter = values.notOnOrAfter ?: "2113-11-17T16:19:06.298Z"
         def authnInstant = values.authnInstant ?: "2113-11-15T16:19:04.055Z"
@@ -222,7 +224,7 @@ class SamlUtilities {
                     invalidSignature()(builder)
                 }
                 'saml2:Subject' {
-                    'saml2:NameID'(Format: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified", name)
+                    'saml2:NameID'([Format: nameFormat] + nameSpProvidedIdAttrib, name)
                     'saml2:SubjectConfirmation'(Method: "urn:oasis:names:tc:SAML:2.0:cm:bearer") {
                         'saml2:SubjectConfirmationData'(NotOnOrAfter: notOnOrAfter)
                     }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilities.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilities.groovy
@@ -117,6 +117,10 @@ class SamlUtilities {
         "http://unique.external.idp.com/${UUID.randomUUID().toString()}"
     }
 
+    static String generateUniqueIdpId() {
+        UUID.randomUUID().toString().replace("-", "")
+    }
+
     /**
      * Convenience method to let you create a SAML Response using the MarkupBuilder DSL.
      * For example:

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/framework/mocks/MockIdentityV2Service.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/framework/mocks/MockIdentityV2Service.groovy
@@ -773,11 +773,11 @@ class MockIdentityV2Service {
         new Response(SC_OK, null, headers, body)
     }
 
-    String createIdpJsonWithValues(Map values = [:]) {
+    static String createIdpJsonWithValues(Map values = [:]) {
         def json = new JsonBuilder()
 
         json {
-            "RAX-AUTH:identityProviders"([
+            'RAX-AUTH:identityProviders'([
                     {
                         name values.name ?: "External IDP"
                         federationType values.federationType ?: "DOMAIN"
@@ -898,6 +898,23 @@ class MockIdentityV2Service {
         }
 
         writer.toString()
+    }
+
+    static String createIdentityFaultJsonWithValues(Map values = [:]) {
+        def name = values.name ?: "identityFault"
+        def code = values.code ?: 500
+        def message = values.message ?: "Internal server error."
+
+        def json = new JsonBuilder()
+
+        json {
+            "$name" {
+                delegate.code code
+                delegate.message message
+            }
+        }
+
+        json.toString()
     }
 
     // Successful generate token response in xml
@@ -1686,6 +1703,8 @@ class MockIdentityV2Service {
 {
     "RAX-AUTH:identityProviders": []
 }"""
+
+    static final String DEFAULT_MAPPING_VALUE = "{D}"
 
     static final String DEFAULT_MAPPING_POLICY = """\
 {


### PR DESCRIPTION
These are the start of the attribute mapping tests and subsequently the extended attributes testing, the translations going to the request and the response and how the cache may impact all of that.