### PR TITLE
REP-5019 getParameter Not Returning SAMLResponse

### DIFF
--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -295,22 +295,23 @@ object HttpServletRequestWrapper {
   private def parseParameterString(s: String): Map[String, Array[String]] = {
     val parsedParameterMap = mutable.Map.empty[String, Array[String]]
 
-    // TODO: Given an empty string, this returns a "" -> "" mapping
-    s.split(QueryPairDelimiter) foreach { queryPair =>
-      val keyValuePair = queryPair.split(QueryKeyValueDelimiter, 2)
+    if (s.nonEmpty) {
+      s.split(QueryPairDelimiter) foreach { queryPair =>
+        val keyValuePair = queryPair.split(QueryKeyValueDelimiter, 2)
 
-      // TODO: UTF-8 is not always the correct encoding
-      /**
-        * Note: Decoding using UTF-8 is consistent with the processing performed by [[HttpComponentRequestProcessor]]
-        * on request parameters. However, if the JVM default encoding is not UTF-8, decoding may not work as expected.
-        * Perhaps the default JVM encoding should be used instead?
-        */
-      val key = URLDecoder.decode(keyValuePair(0), StandardCharsets.UTF_8.toString)
-      if (keyValuePair.length == 2) {
-        val value = URLDecoder.decode(keyValuePair(1), StandardCharsets.UTF_8.toString)
-        parsedParameterMap += (key -> parsedParameterMap.getOrElse(key, Array.empty[String]).:+(value))
-      } else {
-        parsedParameterMap += (key -> parsedParameterMap.getOrElse(key, Array.empty[String]).:+(""))
+        // TODO: UTF-8 is not always the correct encoding
+        /**
+          * Note: Decoding using UTF-8 is consistent with the processing performed by [[HttpComponentRequestProcessor]]
+          * on request parameters. However, if the JVM default encoding is not UTF-8, decoding may not work as expected.
+          * Perhaps the default JVM encoding should be used instead?
+          */
+        val key = URLDecoder.decode(keyValuePair(0), StandardCharsets.UTF_8.toString)
+        if (keyValuePair.length == 2) {
+          val value = URLDecoder.decode(keyValuePair(1), StandardCharsets.UTF_8.toString)
+          parsedParameterMap += (key -> parsedParameterMap.getOrElse(key, Array.empty[String]).:+(value))
+        } else {
+          parsedParameterMap += (key -> parsedParameterMap.getOrElse(key, Array.empty[String]).:+(""))
+        }
       }
     }
 

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapper.scala
@@ -258,6 +258,7 @@ class HttpServletRequestWrapper(originalRequest: HttpServletRequest, val inputSt
           case None =>
             // As per Servlet Spec 3.1 section 3.1.1, form parameters are only available until the input stream is read.
             try {
+              // TODO: UTF-8 is not always the correct encoding
               updatedParameterMap ++= parseParameterString(
                 new String(RawInputStreamReader.instance.readFully(getInputStream, getContentLength), StandardCharsets.UTF_8))
             } catch {
@@ -294,9 +295,11 @@ object HttpServletRequestWrapper {
   private def parseParameterString(s: String): Map[String, Array[String]] = {
     val parsedParameterMap = mutable.Map.empty[String, Array[String]]
 
+    // TODO: Given an empty string, this returns a "" -> "" mapping
     s.split(QueryPairDelimiter) foreach { queryPair =>
       val keyValuePair = queryPair.split(QueryKeyValueDelimiter, 2)
 
+      // TODO: UTF-8 is not always the correct encoding
       /**
         * Note: Decoding using UTF-8 is consistent with the processing performed by [[HttpComponentRequestProcessor]]
         * on request parameters. However, if the JVM default encoding is not UTF-8, decoding may not work as expected.

--- a/repose-aggregator/commons/commons-utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
+++ b/repose-aggregator/commons/commons-utilities/src/test/scala/org/openrepose/commons/utils/servlet/http/HttpServletRequestWrapperTest.scala
@@ -19,13 +19,14 @@
  */
 package org.openrepose.commons.utils.servlet.http
 
-import java.io.{BufferedReader, IOException}
+import java.io.{BufferedReader, ByteArrayInputStream, IOException}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util
 import javax.servlet.ServletInputStream
 import javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 import org.junit.runner.RunWith
+import org.openrepose.commons.utils.io.stream.ServletInputStreamWrapper
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import org.springframework.mock.web.MockHttpServletRequest
@@ -1128,6 +1129,23 @@ class HttpServletRequestWrapperTest extends FunSpec with BeforeAndAfterEach with
 
         val output: String = Source.fromInputStream(localWrappedRequest.getInputStream).mkString
         output.length shouldBe 0
+      }
+
+      it(s"should not create an empty parameter provided an empty $method body") {
+        val localRequest = new MockHttpServletRequest()
+        localRequest.setContentType(APPLICATION_FORM_URLENCODED)
+        localRequest.setContent("some=stuff".getBytes(UTF_8))
+        localRequest.setMethod(method)
+
+        val localWrappedRequest = new HttpServletRequestWrapper(
+          localRequest,
+          new ServletInputStreamWrapper(new ByteArrayInputStream(Array.emptyByteArray))
+        )
+
+        // If this value changes to 1, it is probably because we started getting the parameters from
+        // the wrapped request. Just update this test to expect a size of 1 instead, and verify that
+        // the 1 parameter is "some=stuff".
+        localWrappedRequest.getParameterMap should have size 0
       }
 
       it(s"should not provide form values on $method if the getReader method has been called on the wrapper") {

--- a/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
+++ b/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
@@ -111,8 +111,6 @@ public class PowerFilterChain implements FilterChain {
         filterChainAvailable = isCurrentFilterChainAvailable();
         wrappedRequest.setAttribute("filterChainAvailableForRequest", filterChainAvailable);
         wrappedRequest.setAttribute("http://openrepose.org/requestUrl", wrappedRequest.getRequestURL().toString());
-        // TODO: This may now read the input stream. It must reset it if it does.
-        wrappedRequest.setAttribute("http://openrepose.org/queryParams", wrappedRequest.getParameterMap());
 
         splitRequestHeaders(wrappedRequest);
 

--- a/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
+++ b/repose-aggregator/core/repose-core/src/main/java/org/openrepose/powerfilter/PowerFilterChain.java
@@ -111,6 +111,7 @@ public class PowerFilterChain implements FilterChain {
         filterChainAvailable = isCurrentFilterChainAvailable();
         wrappedRequest.setAttribute("filterChainAvailableForRequest", filterChainAvailable);
         wrappedRequest.setAttribute("http://openrepose.org/requestUrl", wrappedRequest.getRequestURL().toString());
+        // TODO: This may now read the input stream. It must reset it if it does.
         wrappedRequest.setAttribute("http://openrepose.org/queryParams", wrappedRequest.getParameterMap());
 
         splitRequestHeaders(wrappedRequest);


### PR DESCRIPTION
The issue was that the PowerFilterChain was setting a request attribute with the value of the parameter map. Since `getParameterMap` now reads the body for certain requests, we need to make sure that the body gets reset when it does. The request attribute in question is used in the HERP filter.

As I wrote that description, I was left wondering why we do that in the first place rather than using the parameter map in the request that we have when processing in the HERP filter. Does anyone remember?

I also left in some TODOs that I intend to work on for other things I noticed while digging around.