### PR TITLE
REP-4816 SAML Connection Headers Test

### DIFF
--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/connectionheaders/http-connection-pool.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/connectionheaders/http-connection-pool.cfg.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+    <pool id="default"
+          default="true"
+          chunked-encoding="true"
+          http.conn-manager.max-total="10"
+          http.conn-manager.max-per-route="2"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="8192"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+
+    <pool id="saml-keystone" default="false">
+        <headers>
+            <header name="jet" value="fuel"/>
+        </headers>
+    </pool>
+
+    <pool id="saml-mapping-policy" default="false">
+        <headers>
+            <header name="shape" value="polygon"/>
+        </headers>
+    </pool>
+
+</http-connection-pools>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/connectionheaders/saml-policy.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/connectionheaders/saml-policy.cfg.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml-policy xmlns="http://docs.openrepose.org/repose/samlpolicy/v1.0">
+    <policy-acquisition>
+        <keystone-credentials uri="http://localhost:${identityPort}"
+                              username="admin_username"
+                              password="admin_password"
+                              connection-pool-id="saml-keystone"/>
+        <policy-endpoint uri="http://localhost:${identityPort}" connection-pool-id="saml-mapping-policy"/>
+        <cache ttl="3600"/>
+    </policy-acquisition>
+    <signature-credentials keystore-filename="single.jks"
+                           keystore-password="password"
+                           key-name="server"
+                           key-password="password"/>
+</saml-policy>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/notracing/system-model.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/notracing/system-model.cfg.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+        <nodes>
+            <node id="node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+        <filters>
+            <filter name="saml-policy"/>
+        </filters>
+        <destinations>
+            <endpoint id="service" protocol="http" hostname="localhost" root-path="/" port="${targetPort}" default="true"/>
+        </destinations>
+    </repose-cluster>
+    <tracing-header enabled="false"/>
+</system-model>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/tracingplain/system-model.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/samlpolicy/tracingplain/system-model.cfg.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  ~ Repose
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  ~ _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <repose-cluster id="repose">
+        <nodes>
+            <node id="node" hostname="localhost" http-port="${reposePort}"/>
+        </nodes>
+        <filters>
+            <filter name="saml-policy"/>
+        </filters>
+        <destinations>
+            <endpoint id="service" protocol="http" hostname="localhost" root-path="/" port="${targetPort}" default="true"/>
+        </destinations>
+    </repose-cluster>
+    <tracing-header secondary-plain-text="true"/>
+</system-model>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlConnectionHeadersTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlConnectionHeadersTest.groovy
@@ -1,0 +1,146 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.samlpolicy
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import org.rackspace.deproxy.Deproxy
+
+import static features.filters.samlpolicy.util.SamlPayloads.*
+import static features.filters.samlpolicy.util.SamlUtilities.*
+import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
+import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
+/**
+ * This functional test exercises the connection pool config.
+ */
+class SamlConnectionHeadersTest extends ReposeValveTest {
+    static final String TRACING_HEADER = "X-Trans-Id"
+
+    static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+        reposeLogSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy/connectionheaders", params)
+
+        deproxy = new Deproxy()
+
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        deproxy.addEndpoint(properties.targetPort, 'origin service', null, fakeIdentityV2Service.handler)
+        deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityV2Service.handler)
+
+        repose.start()
+        reposeLogSearch.awaitByString("Repose ready", 1, 30)
+
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+    }
+
+    def "the call to Identity to generate an admin token includes the expected headers"() {
+        given: "a new token in the mock which will force the filter to re-request a token if it already has"
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the generate token endpoint"
+        def adminHandlings = mc.orphanedHandlings.findAll { it.request.path.contains("/v2.0/tokens") && it.request.method == "POST" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the generate token endpoint was called once"
+        adminHandlings.size() == 1
+
+        and: "the generate token call includes the header from the connection pool config"
+        adminHandlings[0].request.headers.getFirstValue("jet") == "fuel"
+
+        and: "the generate token call includes the tracing header"
+        adminHandlings[0].request.headers.getCountByName(TRACING_HEADER) == 1
+
+        and: "the generate token call's tracing header matches the one sent to the origin service"
+        adminHandlings[0].request.headers.getFirstValue(TRACING_HEADER) == mc.handlings[0].request.headers.getFirstValue(TRACING_HEADER)
+    }
+
+    def "the call to Identity to get the IDP ID for a given Issuer includes the expected headers"() {
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the Issuer to IDP ID endpoint"
+        def issuerHandlings = mc.orphanedHandlings.findAll { isSamlIdpIssuerCallPath(it.request.path) && it.request.method == "GET" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the Issuer to IDP ID endpoint was called once"
+        issuerHandlings.size() == 1
+
+        and: "the Issuer to IDP ID call includes the header from the connection pool config"
+        issuerHandlings[0].request.headers.getFirstValue("shape") == "polygon"
+
+        and: "the Issuer to IDP ID call includes the tracing header"
+        issuerHandlings[0].request.headers.getCountByName(TRACING_HEADER) == 1
+
+        and: "the Issuer to IDP ID call's tracing header matches the one sent to the origin service"
+        issuerHandlings[0].request.headers.getFirstValue(TRACING_HEADER) == mc.handlings[0].request.headers.getFirstValue(TRACING_HEADER)
+    }
+
+    def "the call to Identity to get the Mapping Policy for a given IDP ID includes the expected headers"() {
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the Mapping Policy to Issuer endpoint"
+        def mappingPolicyHandlings = mc.orphanedHandlings.findAll { isSamlIdpMappingPolicyCallPath(it.request.path) && it.request.method == "GET" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the Mapping Policy to Issuer endpoint was called once"
+        mappingPolicyHandlings.size() == 1
+
+        and: "the Mapping Policy to Issuer call includes the header from the connection pool config"
+        mappingPolicyHandlings[0].request.headers.getFirstValue("shape") == "polygon"
+
+        and: "the Mapping Policy to Issuer call includes the tracing header"
+        mappingPolicyHandlings[0].request.headers.getCountByName(TRACING_HEADER) == 1
+
+        and: "the Mapping Policy to Issuer call's tracing header matches the one sent to the origin service"
+        mappingPolicyHandlings[0].request.headers.getFirstValue(TRACING_HEADER) == mc.handlings[0].request.headers.getFirstValue(TRACING_HEADER)
+    }
+
+    def sendSamlRequest() {
+        def samlIssuer = generateUniqueIssuer()
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
+
+        deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlNoTracingHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlNoTracingHeaderTest.groovy
@@ -1,0 +1,128 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.samlpolicy
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import org.rackspace.deproxy.Deproxy
+
+import static features.filters.samlpolicy.util.SamlPayloads.*
+import static features.filters.samlpolicy.util.SamlUtilities.*
+import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
+import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
+/**
+ * This functional test verifies we can turn the tracing header off for the requests being made by the SAML filter.
+ */
+class SamlNoTracingHeaderTest extends ReposeValveTest {
+    static final String TRACING_HEADER = "X-Trans-Id"
+
+    static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+        reposeLogSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy/notracing", params)
+
+        deproxy = new Deproxy()
+
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        deproxy.addEndpoint(properties.targetPort, 'origin service', null, fakeIdentityV2Service.handler)
+        deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityV2Service.handler)
+
+        repose.start()
+        reposeLogSearch.awaitByString("Repose ready", 1, 30)
+
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+    }
+
+    def "the call to Identity to generate an admin token does not include the tracing header"() {
+        given: "a new token in the mock which will force the filter to re-request a token if it already has"
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the generate token endpoint"
+        def adminHandlings = mc.orphanedHandlings.findAll { it.request.path.contains("/v2.0/tokens") && it.request.method == "POST" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the generate token endpoint was called once"
+        adminHandlings.size() == 1
+
+        and: "the generate token call does not include the tracing header"
+        adminHandlings[0].request.headers.getCountByName(TRACING_HEADER) == 0
+    }
+
+    def "the call to Identity to get the IDP ID for a given Issuer does not include the tracing header"() {
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the Issuer to IDP ID endpoint"
+        def issuerHandlings = mc.orphanedHandlings.findAll { isSamlIdpIssuerCallPath(it.request.path) && it.request.method == "GET" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the Issuer to IDP ID endpoint was called once"
+        issuerHandlings.size() == 1
+
+        and: "the Issuer to IDP ID call does not include the tracing header"
+        issuerHandlings[0].request.headers.getCountByName(TRACING_HEADER) == 0
+    }
+
+    def "the call to Identity to get the Mapping Policy for a given IDP ID does not include the tracing header"() {
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the Mapping Policy to Issuer endpoint"
+        def mappingPolicyHandlings = mc.orphanedHandlings.findAll { isSamlIdpMappingPolicyCallPath(it.request.path) && it.request.method == "GET" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the Mapping Policy to Issuer endpoint was called once"
+        mappingPolicyHandlings.size() == 1
+
+        and: "the Mapping Policy to Issuer call does not include the tracing header"
+        mappingPolicyHandlings[0].request.headers.getCountByName(TRACING_HEADER) == 0
+    }
+
+    def sendSamlRequest() {
+        def samlIssuer = generateUniqueIssuer()
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
+
+        deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+    }
+}

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlTracingPlainHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlTracingPlainHeaderTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+
+package features.filters.samlpolicy
+
+import framework.ReposeValveTest
+import framework.mocks.MockIdentityV2Service
+import org.rackspace.deproxy.Deproxy
+
+import static features.filters.samlpolicy.util.SamlPayloads.*
+import static features.filters.samlpolicy.util.SamlUtilities.*
+import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
+import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
+import static javax.servlet.http.HttpServletResponse.SC_OK
+
+/**
+ * This functional test verifies the plain text version of the tracing header can be added to the connections being
+ * made from this filter.
+ */
+class SamlTracingPlainHeaderTest extends ReposeValveTest {
+    static final String TRACING_PLAIN_HEADER = "X-Request-Id"
+
+    static MockIdentityV2Service fakeIdentityV2Service
+
+    def setupSpec() {
+        reposeLogSearch.cleanLog()
+
+        def params = properties.defaultTemplateParams
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy", params)
+        repose.configurationProvider.applyConfigs("features/filters/samlpolicy/tracingplain", params)
+
+        deproxy = new Deproxy()
+
+        fakeIdentityV2Service = new MockIdentityV2Service(properties.identityPort, properties.targetPort)
+        deproxy.addEndpoint(properties.targetPort, 'origin service', null, fakeIdentityV2Service.handler)
+        deproxy.addEndpoint(properties.identityPort, 'identity service', null, fakeIdentityV2Service.handler)
+
+        repose.start()
+        reposeLogSearch.awaitByString("Repose ready", 1, 30)
+
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+    }
+
+    def "the call to Identity to generate an admin token includes the plain tracing header"() {
+        given: "a new token in the mock which will force the filter to re-request a token if it already has"
+        fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
+
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the generate token endpoint"
+        def adminHandlings = mc.orphanedHandlings.findAll { it.request.path.contains("/v2.0/tokens") && it.request.method == "POST" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the generate token endpoint was called once"
+        adminHandlings.size() == 1
+
+        and: "the generate token call includes the plain tracing header"
+        adminHandlings[0].request.headers.getCountByName(TRACING_PLAIN_HEADER) == 1
+
+        and: "the generate token call's plain tracing header matches the one sent to the origin service"
+        adminHandlings[0].request.headers.getFirstValue(TRACING_PLAIN_HEADER) == mc.handlings[0].request.headers.getFirstValue(TRACING_PLAIN_HEADER)
+    }
+
+    def "the call to Identity to get the IDP ID for a given Issuer includes the plain tracing header"() {
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the Issuer to IDP ID endpoint"
+        def issuerHandlings = mc.orphanedHandlings.findAll { isSamlIdpIssuerCallPath(it.request.path) && it.request.method == "GET" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the Issuer to IDP ID endpoint was called once"
+        issuerHandlings.size() == 1
+
+        and: "the Issuer to IDP ID call includes the plain tracing header"
+        issuerHandlings[0].request.headers.getCountByName(TRACING_PLAIN_HEADER) == 1
+
+        and: "the Issuer to IDP ID call's plain tracing header matches the one sent to the origin service"
+        issuerHandlings[0].request.headers.getFirstValue(TRACING_PLAIN_HEADER) == mc.handlings[0].request.headers.getFirstValue(TRACING_PLAIN_HEADER)
+    }
+
+    def "the call to Identity to get the Mapping Policy for a given IDP ID includes the plain tracing header"() {
+        when: "a request is sent to Repose"
+        def mc = sendSamlRequest()
+
+        and: "we look for orphaned handlings matching the Mapping Policy to Issuer endpoint"
+        def mappingPolicyHandlings = mc.orphanedHandlings.findAll { isSamlIdpMappingPolicyCallPath(it.request.path) && it.request.method == "GET" }
+
+        then: "the origin service receives the request and the client receives the response"
+        mc.handlings[0]
+        mc.receivedResponse.code as Integer == SC_OK
+
+        and: "the Mapping Policy to Issuer endpoint was called once"
+        mappingPolicyHandlings.size() == 1
+
+        and: "the Mapping Policy to Issuer call includes the plain tracing header"
+        mappingPolicyHandlings[0].request.headers.getCountByName(TRACING_PLAIN_HEADER) == 1
+
+        and: "the Mapping Policy to Issuer call's plain tracing header matches the one sent to the origin service"
+        mappingPolicyHandlings[0].request.headers.getFirstValue(TRACING_PLAIN_HEADER) == mc.handlings[0].request.headers.getFirstValue(TRACING_PLAIN_HEADER)
+    }
+
+    def sendSamlRequest() {
+        def samlIssuer = generateUniqueIssuer()
+        def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
+
+        deproxy.makeRequest(
+                url: reposeEndpoint + SAML_AUTH_URL,
+                method: HTTP_POST,
+                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
+    }
+}


### PR DESCRIPTION
Added functional tests to verify the SAML filter allows you to:
1. configure headers to add to the requests being made to Identity for the token call
2. configure headers to add to the requests being made to Identity for the issuer/mapping policy calls
3. configure the tracing header for the calls going to Identity (token/issuer/mapping policy) including turning it on, turning it off, and enabling the plain text tracing header.