### PR TITLE
REP-4816 SAML origin service response test

### DIFF
--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlAttributeMappingTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlAttributeMappingTest.groovy
@@ -35,6 +35,8 @@ import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.createIdpJsonWithValues
 import static framework.mocks.MockIdentityV2Service.createMappingJsonWithValues
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.ACCEPT
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON
 import static javax.ws.rs.core.MediaType.APPLICATION_XML

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlAttributeMappingTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlAttributeMappingTest.groovy
@@ -35,6 +35,9 @@ import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.createIdpJsonWithValues
 import static framework.mocks.MockIdentityV2Service.createMappingJsonWithValues
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON
+import static javax.ws.rs.core.MediaType.APPLICATION_XML
 
 /**
  * This functional test ensures the attribute mappings are being set correctly on the request and the response.
@@ -101,7 +104,7 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the origin service receives the request"
@@ -151,12 +154,12 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_JSON],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED, (ACCEPT): APPLICATION_JSON],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client receives JSON successfully"
         mc.receivedResponse.code as Integer == SC_OK
-        mc.receivedResponse.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_JSON
+        mc.receivedResponse.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_JSON
 
         when: "the response sent to the client is parsed as JSON"
         def json = jsonSlurper.parseText(mc.receivedResponse.body as String)
@@ -193,12 +196,12 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_XML],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED, (ACCEPT): APPLICATION_XML],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client receives XML successfully"
         mc.receivedResponse.code as Integer == SC_OK
-        mc.receivedResponse.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.receivedResponse.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
 
         when: "the response sent to the client is parsed as XML"
         def access = xmlSlurper.parseText(mc.receivedResponse.body as String)
@@ -249,7 +252,7 @@ class SamlAttributeMappingTest extends ReposeValveTest {
             new Response(
                     SC_OK,
                     null,
-                    [(CONTENT_TYPE): CONTENT_TYPE_JSON],
+                    [(CONTENT_TYPE): APPLICATION_JSON],
                     createIdpJsonWithValues(issuer: issuer, id: issuerToIdpId.get(issuer)))
         }
         Map idpIdToMapping = [idpIds, mappingPolicies].transpose().collectEntries()
@@ -261,7 +264,7 @@ class SamlAttributeMappingTest extends ReposeValveTest {
             deproxy.makeRequest(
                     url: reposeEndpoint + SAML_AUTH_URL,
                     method: HTTP_POST,
-                    headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_JSON],
+                    headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED, (ACCEPT): APPLICATION_JSON],
                     requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
         }
 
@@ -301,7 +304,7 @@ class SamlAttributeMappingTest extends ReposeValveTest {
             deproxy.makeRequest(
                     url: reposeEndpoint + SAML_AUTH_URL,
                     method: HTTP_POST,
-                    headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_JSON],
+                    headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED, (ACCEPT): APPLICATION_JSON],
                     requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
         }
 
@@ -342,7 +345,7 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_JSON],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED, (ACCEPT): APPLICATION_JSON],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the origin service receives the request and the client receives the response"
@@ -389,7 +392,7 @@ class SamlAttributeMappingTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_JSON],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED, (ACCEPT): APPLICATION_JSON],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the origin service receives the request and the client receives the response"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlBasicValidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlBasicValidationTest.groovy
@@ -28,6 +28,7 @@ import spock.lang.Unroll
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static javax.servlet.http.HttpServletResponse.*
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 import static javax.ws.rs.core.MediaType.APPLICATION_XML
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlBasicValidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlBasicValidationTest.groovy
@@ -28,6 +28,8 @@ import spock.lang.Unroll
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static javax.servlet.http.HttpServletResponse.*
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
+import static javax.ws.rs.core.MediaType.APPLICATION_XML
 
 /**
  * This functional test goes through the shared validation logic between Flow 1.0 and 2.0 including the requirements
@@ -62,7 +64,7 @@ class SamlBasicValidationTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm(formParams))
 
         then: "the request is successfully processed"
@@ -71,7 +73,7 @@ class SamlBasicValidationTest extends ReposeValveTest {
         and: "the origin service received the request as valid XML"
         mc.handlings[0]
         mc.handlings[0].request.headers.getCountByName(CONTENT_TYPE) == 1
-        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
 
         and: "the request body received by the origin service can be parsed as XML"
         xmlSlurper.parseText(mc.handlings[0].request.body as String)
@@ -99,10 +101,10 @@ class SamlBasicValidationTest extends ReposeValveTest {
         mc.handlings.isEmpty()
 
         where:
-        contentType          | bodySummary       | requestBody
-        CONTENT_TYPE_XML     | "valid form data" | asUrlEncodedForm((PARAM_SAML_RESPONSE): SAML_ONE_ASSERTION_SIGNED_BASE64)
-        CONTENT_TYPE_XML     | "xml"             | SAML_ONE_ASSERTION_SIGNED
-        CONTENT_TYPE_INVALID | "xml"             | SAML_ONE_ASSERTION_SIGNED
+        contentType         | bodySummary       | requestBody
+        APPLICATION_XML     | "valid form data" | asUrlEncodedForm((PARAM_SAML_RESPONSE): SAML_ONE_ASSERTION_SIGNED_BASE64)
+        APPLICATION_XML     | "xml"             | SAML_ONE_ASSERTION_SIGNED
+        APPLICATION_INVALID | "xml"             | SAML_ONE_ASSERTION_SIGNED
     }
 
     def "a request using the wrong form parameter name should be rejected"() {
@@ -110,7 +112,7 @@ class SamlBasicValidationTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_EXTRANEOUS): SAML_ONE_ASSERTION_SIGNED_BASE64))
 
         then: "the request is rejected"
@@ -126,7 +128,7 @@ class SamlBasicValidationTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED])
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED])
 
         then: "the request is rejected"
         mc.receivedResponse.code as Integer == SC_BAD_REQUEST
@@ -142,7 +144,7 @@ class SamlBasicValidationTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: httpMethod,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): SAML_ONE_ASSERTION_SIGNED_BASE64))
 
         then: "the request is rejected"
@@ -161,7 +163,7 @@ class SamlBasicValidationTest extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): paramValue))
 
         then: "the request is rejected"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
@@ -27,6 +27,7 @@ import org.rackspace.deproxy.Deproxy
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**
  * This functional test verifies that the cache can be turned off.
@@ -61,7 +62,7 @@ class SamlCacheDisabledTest extends ReposeValveTest {
     def "when the same saml:response is sent multiple times (same Issuer), the mapping policy should be retrieved from Identity each time"() {
         given: "the same saml:response will be used in each request"
         def url = reposeEndpoint + SAML_AUTH_URL
-        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def headers = [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED]
         def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(SAML_ONE_ASSERTION_SIGNED))
 
         and: "we will make several requests"
@@ -88,7 +89,7 @@ class SamlCacheDisabledTest extends ReposeValveTest {
         given: "the same issuer will be used to generate each unique saml:response"
         def samlIssuer = generateUniqueIssuer()
         def url = reposeEndpoint + SAML_AUTH_URL
-        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def headers = [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED]
 
         and: "we will make several requests"
         def numOfRequests = 21

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheDisabledTest.groovy
@@ -27,6 +27,7 @@ import org.rackspace.deproxy.Deproxy
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**
  * This functional test exercises the cache feed invalidation.
@@ -77,7 +78,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         given: "the same issuer will be used to generate each unique saml:response"
         def samlIssuer = generateUniqueIssuer()
         def url = reposeEndpoint + SAML_AUTH_URL
-        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def headers = [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED]
 
         and: "an atom feed entry will be received with the same issuer as the saml:response contains"
         def atomFeedEntry = fakeAtomFeed.atomEntryForIdpUpdate(eventType: eventType, issuer: samlIssuer)
@@ -137,7 +138,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         given: "a list of issuers that will be used in the saml:responses"
         def samlIssuers = (1..5).collect { generateUniqueIssuer() }
         def url = reposeEndpoint + SAML_AUTH_URL
-        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def headers = [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED]
 
         and: "an atom feed will be received with entries containing the same issuers plus one more"
         def atomFeedHandlerWithEntries = fakeAtomFeed.handlerWithEntries(
@@ -201,7 +202,7 @@ class SamlCacheFeedInvalidationTest extends ReposeValveTest {
         given: "the same issuer will be used to generate each unique saml:response"
         def samlIssuer = generateUniqueIssuer()
         def url = reposeEndpoint + SAML_AUTH_URL
-        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def headers = [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED]
 
         and: "an atom feed entry will be received with the specific values for the specific test"
         def atomFeedEntry = fakeAtomFeed.atomEntryForIdpUpdate(

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheFeedInvalidationTest.groovy
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
@@ -65,7 +65,7 @@ class SamlCacheTtlTest extends ReposeValveTest {
     def "when the same saml:response is sent after the cache entry is supposed to expire, the mapping policy should be retrieved from Identity again"() {
         given: "the same saml:response will be used in each request"
         def url = reposeEndpoint + SAML_AUTH_URL
-        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def headers = [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED]
         def requestBody = asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(SAML_ONE_ASSERTION_SIGNED))
 
         when: "a request is sent for the first time"
@@ -109,7 +109,7 @@ class SamlCacheTtlTest extends ReposeValveTest {
         given: "the same saml:response will be used in each request"
         def samlIssuer = generateUniqueIssuer()
         def url = reposeEndpoint + SAML_AUTH_URL
-        def headers = [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED]
+        def headers = [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED]
 
         when: "a request is sent for the first time"
         def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlCacheTtlTest.groovy
@@ -27,6 +27,8 @@ import org.rackspace.deproxy.Deproxy
 import static features.filters.samlpolicy.util.SamlPayloads.*
 import static features.filters.samlpolicy.util.SamlUtilities.*
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**
  * This functional test exercises the cache TTL expiration.

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlConnectionHeadersTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlConnectionHeadersTest.groovy
@@ -29,6 +29,7 @@ import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
 import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlConnectionHeadersTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlConnectionHeadersTest.groovy
@@ -64,7 +64,7 @@ class SamlConnectionHeadersTest extends ReposeValveTest {
         fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
 
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the generate token endpoint"
         def adminHandlings = mc.orphanedHandlings.findAll { it.request.path.contains("/v2.0/tokens") && it.request.method == "POST" }
@@ -88,7 +88,7 @@ class SamlConnectionHeadersTest extends ReposeValveTest {
 
     def "the call to Identity to get the IDP ID for a given Issuer includes the expected headers"() {
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the Issuer to IDP ID endpoint"
         def issuerHandlings = mc.orphanedHandlings.findAll { isSamlIdpIssuerCallPath(it.request.path) && it.request.method == "GET" }
@@ -112,7 +112,7 @@ class SamlConnectionHeadersTest extends ReposeValveTest {
 
     def "the call to Identity to get the Mapping Policy for a given IDP ID includes the expected headers"() {
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the Mapping Policy to Issuer endpoint"
         def mappingPolicyHandlings = mc.orphanedHandlings.findAll { isSamlIdpMappingPolicyCallPath(it.request.path) && it.request.method == "GET" }
@@ -134,7 +134,7 @@ class SamlConnectionHeadersTest extends ReposeValveTest {
         mappingPolicyHandlings[0].request.headers.getFirstValue(TRACING_HEADER) == mc.handlings[0].request.headers.getFirstValue(TRACING_HEADER)
     }
 
-    def sendSamlRequest() {
+    def sendSamlRequestWithUniqueIssuer() {
         def samlIssuer = generateUniqueIssuer()
         def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlConnectionHeadersTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlConnectionHeadersTest.groovy
@@ -29,6 +29,7 @@ import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
 import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**
  * This functional test exercises the connection pool config.
@@ -140,7 +141,7 @@ class SamlConnectionHeadersTest extends ReposeValveTest {
         deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
     }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow10Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow10Test.groovy
@@ -38,6 +38,10 @@ import static framework.mocks.MockIdentityV2Service.createIdentityFaultXmlWithVa
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON
+import static javax.ws.rs.core.MediaType.APPLICATION_XML
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN
 
 /**
  * This functional test goes through the validation logic unique to Flow 1.0.
@@ -89,7 +93,7 @@ class SamlFlow10Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: body)
 
         then: "the client gets back a good response"
@@ -98,7 +102,7 @@ class SamlFlow10Test extends ReposeValveTest {
         and: "the origin service receives the request with the correct header values"
         mc.handlings[0]
         mc.handlings[0].request.headers.getCountByName(CONTENT_TYPE) == 1
-        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
         mc.handlings[0].request.headers.getCountByName(IDENTITY_API_VERSION) == 1
         mc.handlings[0].request.headers.getFirstValue(IDENTITY_API_VERSION) == headerValue
         fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == 1
@@ -118,7 +122,7 @@ class SamlFlow10Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a good response"
@@ -126,7 +130,7 @@ class SamlFlow10Test extends ReposeValveTest {
 
         and: "the origin service receives the request with the correct header values"
         mc.handlings[0]
-        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
         mc.handlings[0].request.headers.getFirstValue(IDENTITY_API_VERSION) == "1.0"
         fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == 1
 
@@ -146,7 +150,7 @@ class SamlFlow10Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a good response"
@@ -154,7 +158,7 @@ class SamlFlow10Test extends ReposeValveTest {
 
         and: "the origin service receives the request with the correct header values"
         mc.handlings[0]
-        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
         mc.handlings[0].request.headers.getFirstValue(IDENTITY_API_VERSION) == "1.0"
         fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == 1
 
@@ -179,7 +183,7 @@ class SamlFlow10Test extends ReposeValveTest {
 
     def "the response to the client should not be translated by Repose when the saml:response has a Flow 1.0 Issuer"() {
         when: "the request is sent to Repose asking for a JSON response"
-        def mc = sendSamlRequestForLegacyIssuer((ACCEPT): CONTENT_TYPE_JSON)
+        def mc = sendSamlRequestForLegacyIssuer((ACCEPT): APPLICATION_JSON)
 
         then: "the origin service receives the request and the client receives the response"
         mc.handlings[0]
@@ -208,7 +212,7 @@ class SamlFlow10Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_JSON],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED, (ACCEPT): APPLICATION_JSON],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the origin service receives the request and the client receives the response"
@@ -238,7 +242,7 @@ class SamlFlow10Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED, (ACCEPT): CONTENT_TYPE_XML],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED, (ACCEPT): APPLICATION_XML],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the origin service receives the request and the client receives the response"
@@ -260,11 +264,11 @@ class SamlFlow10Test extends ReposeValveTest {
         given: "the origin service will return an Identity fault as JSON"
         fakeIdentityV2Service.generateTokenFromSamlResponseHandler = { Request request, boolean shouldReturnXml ->
             def values = [name: fault, code: code, message: message]
-            new DeproxyResponse(code, null, [(CONTENT_TYPE): CONTENT_TYPE_JSON], createIdentityFaultJsonWithValues(values))
+            new DeproxyResponse(code, null, [(CONTENT_TYPE): APPLICATION_JSON], createIdentityFaultJsonWithValues(values))
         }
 
         when: "the request is sent to Repose asking for a JSON response"
-        def mc = sendSamlRequestForLegacyIssuer((ACCEPT): CONTENT_TYPE_JSON)
+        def mc = sendSamlRequestForLegacyIssuer((ACCEPT): APPLICATION_JSON)
 
         then: "the client receives the response code sent by the origin service"
         mc.receivedResponse.code as Integer == code
@@ -289,11 +293,11 @@ class SamlFlow10Test extends ReposeValveTest {
         given: "the origin service will return an Identity fault as XML"
         fakeIdentityV2Service.generateTokenFromSamlResponseHandler = { Request request, boolean shouldReturnXml ->
             def values = [name: fault, code: code, message: message]
-            new DeproxyResponse(code, null, [(CONTENT_TYPE): CONTENT_TYPE_XML], createIdentityFaultXmlWithValues(values))
+            new DeproxyResponse(code, null, [(CONTENT_TYPE): APPLICATION_XML], createIdentityFaultXmlWithValues(values))
         }
 
         when: "the request is sent to Repose asking for an XML response"
-        def mc = sendSamlRequestForLegacyIssuer((ACCEPT): CONTENT_TYPE_XML)
+        def mc = sendSamlRequestForLegacyIssuer((ACCEPT): APPLICATION_XML)
 
         then: "the client receives the response code sent by the origin service"
         mc.receivedResponse.code as Integer == code
@@ -311,7 +315,7 @@ class SamlFlow10Test extends ReposeValveTest {
         given: "the origin service will return a text/plain response"
         def responseBody = "This is a response. It is not very long."
         fakeIdentityV2Service.generateTokenFromSamlResponseHandler = { Request request, boolean shouldReturnXml ->
-            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): CONTENT_TYPE_TEXT], responseBody)
+            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): TEXT_PLAIN], responseBody)
         }
 
         when:
@@ -342,7 +346,7 @@ class SamlFlow10Test extends ReposeValveTest {
         mc.receivedResponse.body as String == responseBody
 
         where:
-        contentType << [CONTENT_TYPE_JSON, CONTENT_TYPE_XML]
+        contentType << [APPLICATION_JSON, APPLICATION_XML]
     }
 
     def sendSamlRequestForLegacyIssuer(Map headers = [:]) {
@@ -351,7 +355,7 @@ class SamlFlow10Test extends ReposeValveTest {
         deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED] + headers,
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED] + headers,
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
     }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow10Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow10Test.groovy
@@ -38,6 +38,8 @@ import static framework.mocks.MockIdentityV2Service.createIdentityFaultXmlWithVa
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.ACCEPT
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON
 import static javax.ws.rs.core.MediaType.APPLICATION_XML

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
@@ -46,6 +46,10 @@ import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND
 import static javax.servlet.http.HttpServletResponse.SC_OK
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON
+import static javax.ws.rs.core.MediaType.APPLICATION_XML
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN
 
 /**
  * This functional test goes through the validation logic unique to Flow 2.0.
@@ -85,7 +89,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a good response"
@@ -93,7 +97,7 @@ class SamlFlow20Test extends ReposeValveTest {
 
         and: "the origin service received the request with the correct header values"
         mc.handlings[0]
-        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
         mc.handlings[0].request.headers.getFirstValue(IDENTITY_API_VERSION) == "2.0"
         fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == 1
 
@@ -129,7 +133,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client does not get back a server-side error"
@@ -147,7 +151,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a bad response"
@@ -166,7 +170,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a good response"
@@ -174,7 +178,7 @@ class SamlFlow20Test extends ReposeValveTest {
 
         and: "the origin service received the request with the correct header values"
         mc.handlings[0]
-        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
         mc.handlings[0].request.headers.getFirstValue(IDENTITY_API_VERSION) == "2.0"
         fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == 1
     }
@@ -191,7 +195,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a bad response"
@@ -221,7 +225,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a good response"
@@ -229,7 +233,7 @@ class SamlFlow20Test extends ReposeValveTest {
 
         and: "the origin service received the request with the correct header values"
         mc.handlings[0]
-        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
         mc.handlings[0].request.headers.getFirstValue(IDENTITY_API_VERSION) == "2.0"
         fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == 1
 
@@ -282,7 +286,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a bad response"
@@ -321,7 +325,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a good response"
@@ -329,7 +333,7 @@ class SamlFlow20Test extends ReposeValveTest {
 
         and: "the origin service received the request with the correct header values"
         mc.handlings[0]
-        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == CONTENT_TYPE_XML
+        mc.handlings[0].request.headers.getFirstValue(CONTENT_TYPE) == APPLICATION_XML
         mc.handlings[0].request.headers.getFirstValue(IDENTITY_API_VERSION) == "2.0"
         fakeIdentityV2Service.getGenerateTokenFromSamlResponseCount() == 1
     }
@@ -346,7 +350,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the client gets back a bad response"
@@ -367,7 +371,7 @@ class SamlFlow20Test extends ReposeValveTest {
     def "a saml:response with an Issuer that Identity doesn't know about should be rejected with a 401"() {
         given: "the IDP call will return an empty list"
         fakeIdentityV2Service.getIdpFromIssuerHandler = { String issuerParam, Request request ->
-            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): CONTENT_TYPE_JSON], IDP_NO_RESULTS)
+            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): APPLICATION_JSON], IDP_NO_RESULTS)
         }
 
         when:
@@ -386,7 +390,7 @@ class SamlFlow20Test extends ReposeValveTest {
             new DeproxyResponse(
                     SC_NOT_FOUND,
                     null,
-                    [(CONTENT_TYPE): CONTENT_TYPE_JSON],
+                    [(CONTENT_TYPE): APPLICATION_JSON],
                     createIdentityFaultJsonWithValues(
                             name: "itemNotFound",
                             code: SC_NOT_FOUND,
@@ -409,7 +413,7 @@ class SamlFlow20Test extends ReposeValveTest {
             new DeproxyResponse(
                     SC_OK,
                     null,
-                    [(CONTENT_TYPE): CONTENT_TYPE_JSON],
+                    [(CONTENT_TYPE): APPLICATION_JSON],
                     createMappingJsonWithValues(rules: [[potato: [fries: [yummy: "yes"], hashBrowns: [:]]]]))
         }
 
@@ -429,7 +433,7 @@ class SamlFlow20Test extends ReposeValveTest {
             new DeproxyResponse(
                     SC_OK,
                     null,
-                    [(CONTENT_TYPE): CONTENT_TYPE_JSON],
+                    [(CONTENT_TYPE): APPLICATION_JSON],
                     "Hi, Principal Skinner! Hi, Super Nintendo Chalmers.")
         }
 
@@ -449,7 +453,7 @@ class SamlFlow20Test extends ReposeValveTest {
             new DeproxyResponse(
                     SC_INTERNAL_SERVER_ERROR,
                     null,
-                    [(CONTENT_TYPE): CONTENT_TYPE_JSON],
+                    [(CONTENT_TYPE): APPLICATION_JSON],
                     createIdentityFaultJsonWithValues(
                             name: "identityFault",
                             code: SC_INTERNAL_SERVER_ERROR,
@@ -475,7 +479,7 @@ class SamlFlow20Test extends ReposeValveTest {
             fullRequestPath = request.path
 
             def body = createIdpJsonWithValues(issuer: issuerParam)
-            def headers = [(CONTENT_TYPE): CONTENT_TYPE_JSON]
+            def headers = [(CONTENT_TYPE): APPLICATION_JSON]
             new DeproxyResponse(SC_OK, null, headers, body)
         }
 
@@ -487,7 +491,7 @@ class SamlFlow20Test extends ReposeValveTest {
         deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the requested issuer should match what was in the saml:response"
@@ -502,7 +506,7 @@ class SamlFlow20Test extends ReposeValveTest {
         String requestedIdpId = null
         fakeIdentityV2Service.getMappingPolicyForIdpHandler = { String idpId, Request request ->
             requestedIdpId = idpId
-            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): CONTENT_TYPE_JSON], DEFAULT_MAPPING_POLICY)
+            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): APPLICATION_JSON], DEFAULT_MAPPING_POLICY)
         }
 
         and: "we're going to ensure the IDP ID returned is unique"
@@ -517,7 +521,7 @@ class SamlFlow20Test extends ReposeValveTest {
         deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the requested IDP ID should match what was returned from the first Identity call"
@@ -549,7 +553,7 @@ class SamlFlow20Test extends ReposeValveTest {
         def mc = deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
 
         then: "the origin service receives the request and the client receives the response"
@@ -571,11 +575,11 @@ class SamlFlow20Test extends ReposeValveTest {
         given: "the origin service will return an Identity fault as JSON"
         fakeIdentityV2Service.generateTokenFromSamlResponseHandler = { Request request, boolean shouldReturnXml ->
             def values = [name: fault, code: code, message: message]
-            new DeproxyResponse(code, null, [(CONTENT_TYPE): CONTENT_TYPE_JSON], createIdentityFaultJsonWithValues(values))
+            new DeproxyResponse(code, null, [(CONTENT_TYPE): APPLICATION_JSON], createIdentityFaultJsonWithValues(values))
         }
 
         when: "the request is sent to Repose asking for a JSON response"
-        def mc = sendSamlRequestWithUniqueIssuer((ACCEPT): CONTENT_TYPE_JSON)
+        def mc = sendSamlRequestWithUniqueIssuer((ACCEPT): APPLICATION_JSON)
 
         then: "the client receives the response code sent by the origin service"
         mc.receivedResponse.code as Integer == code
@@ -600,11 +604,11 @@ class SamlFlow20Test extends ReposeValveTest {
         given: "the origin service will return an Identity fault as XML"
         fakeIdentityV2Service.generateTokenFromSamlResponseHandler = { Request request, boolean shouldReturnXml ->
             def values = [name: fault, code: code, message: message]
-            new DeproxyResponse(code, null, [(CONTENT_TYPE): CONTENT_TYPE_XML], createIdentityFaultXmlWithValues(values))
+            new DeproxyResponse(code, null, [(CONTENT_TYPE): APPLICATION_XML], createIdentityFaultXmlWithValues(values))
         }
 
         when: "the request is sent to Repose asking for an XML response"
-        def mc = sendSamlRequestWithUniqueIssuer((ACCEPT): CONTENT_TYPE_XML)
+        def mc = sendSamlRequestWithUniqueIssuer((ACCEPT): APPLICATION_XML)
 
         then: "the client receives the response code sent by the origin service"
         mc.receivedResponse.code as Integer == code
@@ -622,7 +626,7 @@ class SamlFlow20Test extends ReposeValveTest {
         given: "the origin service will return a text/plain response"
         def responseBody = "This is a response. It is not very long."
         fakeIdentityV2Service.generateTokenFromSamlResponseHandler = { Request request, boolean shouldReturnXml ->
-            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): CONTENT_TYPE_TEXT], responseBody)
+            new DeproxyResponse(SC_OK, null, [(CONTENT_TYPE): TEXT_PLAIN], responseBody)
         }
 
         when:
@@ -649,7 +653,7 @@ class SamlFlow20Test extends ReposeValveTest {
         mc.receivedResponse.code as Integer == SC_INTERNAL_SERVER_ERROR
 
         where:
-        contentType << [CONTENT_TYPE_JSON, CONTENT_TYPE_XML]
+        contentType << [APPLICATION_JSON, APPLICATION_XML]
     }
 
     def sendSamlRequestWithUniqueIssuer(Map headers = [:]) {
@@ -659,7 +663,7 @@ class SamlFlow20Test extends ReposeValveTest {
         deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED] + headers,
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED] + headers,
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
     }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlFlow20Test.groovy
@@ -41,6 +41,8 @@ import static framework.mocks.MockIdentityV2Service.createIdentityFaultXmlWithVa
 import static framework.mocks.MockIdentityV2Service.createIdpJsonWithValues
 import static framework.mocks.MockIdentityV2Service.createMappingJsonWithValues
 import static javax.servlet.http.HttpServletResponse.*
+import static javax.ws.rs.core.HttpHeaders.ACCEPT
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON
 import static javax.ws.rs.core.MediaType.APPLICATION_XML

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlKeystoneCredentialsTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlKeystoneCredentialsTest.groovy
@@ -70,7 +70,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
 
     def "the admin token will only be generated once (as long as it remains valid)"() {
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         then: "the origin service receives the request and the client receives the response"
         mc.handlings[0]
@@ -81,7 +81,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
 
         when: "another request is sent to Repose"
         fakeIdentityV2Service.resetCounts()
-        mc = sendSamlRequest()
+        mc = sendSamlRequestWithUniqueIssuer()
 
         then: "the origin service receives the request and the client receives the response"
         mc.handlings[0]
@@ -93,7 +93,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
 
     def "the admin token will be generated again when the issuer call returns a 401"() {
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         then: "the origin service receives the request and the client receives the response"
         mc.handlings[0]
@@ -107,7 +107,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
 
         and: "another request is sent to Repose"
         fakeIdentityV2Service.resetCounts()
-        mc = sendSamlRequest()
+        mc = sendSamlRequestWithUniqueIssuer()
 
         then: "the origin service receives the request and the client receives the response"
         mc.handlings[0]
@@ -125,7 +125,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
         fakeIdentityV2Service.getIdpFromIssuerHandler = fakeIdentityV2Service.createGetIdpFromIssuerHandler(skipAuthCheck: true)
 
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         then: "the origin service receives the request and the client receives the response"
         mc.handlings[0]
@@ -139,7 +139,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
 
         and: "another request is sent to Repose"
         fakeIdentityV2Service.resetCounts()
-        mc = sendSamlRequest()
+        mc = sendSamlRequestWithUniqueIssuer()
 
         then: "the origin service receives the request and the client receives the response"
         mc.handlings[0]
@@ -166,7 +166,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
         }
 
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         then: "the request does not get to the origin service"
         mc.handlings.isEmpty()
@@ -175,7 +175,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
         mc.receivedResponse.code as Integer == SC_INTERNAL_SERVER_ERROR
     }
 
-    def sendSamlRequest() {
+    def sendSamlRequestWithUniqueIssuer() {
         def samlIssuer = generateUniqueIssuer()
         def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlKeystoneCredentialsTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlKeystoneCredentialsTest.groovy
@@ -32,7 +32,8 @@ import static framework.mocks.MockIdentityV2Service.createIdentityFaultJsonWithV
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR
 import static javax.servlet.http.HttpServletResponse.SC_OK
-
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON
 
 /**
  * This functional test exercises the keystone credentials logic.
@@ -157,7 +158,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
             new Response(
                     SC_FORBIDDEN,
                     null,
-                    [(CONTENT_TYPE): CONTENT_TYPE_JSON],
+                    [(CONTENT_TYPE): APPLICATION_JSON],
                     createIdentityFaultJsonWithValues(
                             name: "forbidden",
                             code: SC_FORBIDDEN,
@@ -181,7 +182,7 @@ class SamlKeystoneCredentialsTest extends ReposeValveTest {
         deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
     }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlKeystoneCredentialsTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlKeystoneCredentialsTest.groovy
@@ -32,6 +32,7 @@ import static framework.mocks.MockIdentityV2Service.createIdentityFaultJsonWithV
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlNoTracingHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlNoTracingHeaderTest.groovy
@@ -29,6 +29,7 @@ import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
 import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlNoTracingHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlNoTracingHeaderTest.groovy
@@ -64,7 +64,7 @@ class SamlNoTracingHeaderTest extends ReposeValveTest {
         fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
 
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the generate token endpoint"
         def adminHandlings = mc.orphanedHandlings.findAll { it.request.path.contains("/v2.0/tokens") && it.request.method == "POST" }
@@ -82,7 +82,7 @@ class SamlNoTracingHeaderTest extends ReposeValveTest {
 
     def "the call to Identity to get the IDP ID for a given Issuer does not include the tracing header"() {
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the Issuer to IDP ID endpoint"
         def issuerHandlings = mc.orphanedHandlings.findAll { isSamlIdpIssuerCallPath(it.request.path) && it.request.method == "GET" }
@@ -100,7 +100,7 @@ class SamlNoTracingHeaderTest extends ReposeValveTest {
 
     def "the call to Identity to get the Mapping Policy for a given IDP ID does not include the tracing header"() {
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the Mapping Policy to Issuer endpoint"
         def mappingPolicyHandlings = mc.orphanedHandlings.findAll { isSamlIdpMappingPolicyCallPath(it.request.path) && it.request.method == "GET" }
@@ -116,7 +116,7 @@ class SamlNoTracingHeaderTest extends ReposeValveTest {
         mappingPolicyHandlings[0].request.headers.getCountByName(TRACING_HEADER) == 0
     }
 
-    def sendSamlRequest() {
+    def sendSamlRequestWithUniqueIssuer() {
         def samlIssuer = generateUniqueIssuer()
         def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlNoTracingHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlNoTracingHeaderTest.groovy
@@ -29,6 +29,7 @@ import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
 import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**
  * This functional test verifies we can turn the tracing header off for the requests being made by the SAML filter.
@@ -122,7 +123,7 @@ class SamlNoTracingHeaderTest extends ReposeValveTest {
         deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
     }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlTracingPlainHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlTracingPlainHeaderTest.groovy
@@ -29,6 +29,7 @@ import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
 import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlTracingPlainHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlTracingPlainHeaderTest.groovy
@@ -29,6 +29,7 @@ import static features.filters.samlpolicy.util.SamlUtilities.*
 import static framework.mocks.MockIdentityV2Service.isSamlIdpIssuerCallPath
 import static framework.mocks.MockIdentityV2Service.isSamlIdpMappingPolicyCallPath
 import static javax.servlet.http.HttpServletResponse.SC_OK
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED
 
 /**
  * This functional test verifies the plain text version of the tracing header can be added to the connections being
@@ -132,7 +133,7 @@ class SamlTracingPlainHeaderTest extends ReposeValveTest {
         deproxy.makeRequest(
                 url: reposeEndpoint + SAML_AUTH_URL,
                 method: HTTP_POST,
-                headers: [(CONTENT_TYPE): CONTENT_TYPE_FORM_URLENCODED],
+                headers: [(CONTENT_TYPE): APPLICATION_FORM_URLENCODED],
                 requestBody: asUrlEncodedForm((PARAM_SAML_RESPONSE): encodeBase64(saml)))
     }
 }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlTracingPlainHeaderTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/SamlTracingPlainHeaderTest.groovy
@@ -65,7 +65,7 @@ class SamlTracingPlainHeaderTest extends ReposeValveTest {
         fakeIdentityV2Service.admin_token = UUID.randomUUID().toString()
 
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the generate token endpoint"
         def adminHandlings = mc.orphanedHandlings.findAll { it.request.path.contains("/v2.0/tokens") && it.request.method == "POST" }
@@ -86,7 +86,7 @@ class SamlTracingPlainHeaderTest extends ReposeValveTest {
 
     def "the call to Identity to get the IDP ID for a given Issuer includes the plain tracing header"() {
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the Issuer to IDP ID endpoint"
         def issuerHandlings = mc.orphanedHandlings.findAll { isSamlIdpIssuerCallPath(it.request.path) && it.request.method == "GET" }
@@ -107,7 +107,7 @@ class SamlTracingPlainHeaderTest extends ReposeValveTest {
 
     def "the call to Identity to get the Mapping Policy for a given IDP ID includes the plain tracing header"() {
         when: "a request is sent to Repose"
-        def mc = sendSamlRequest()
+        def mc = sendSamlRequestWithUniqueIssuer()
 
         and: "we look for orphaned handlings matching the Mapping Policy to Issuer endpoint"
         def mappingPolicyHandlings = mc.orphanedHandlings.findAll { isSamlIdpMappingPolicyCallPath(it.request.path) && it.request.method == "GET" }
@@ -126,7 +126,7 @@ class SamlTracingPlainHeaderTest extends ReposeValveTest {
         mappingPolicyHandlings[0].request.headers.getFirstValue(TRACING_PLAIN_HEADER) == mc.handlings[0].request.headers.getFirstValue(TRACING_PLAIN_HEADER)
     }
 
-    def sendSamlRequest() {
+    def sendSamlRequestWithUniqueIssuer() {
         def samlIssuer = generateUniqueIssuer()
         def saml = samlResponse(issuer(samlIssuer) >> status() >> assertion(issuer: samlIssuer, fakeSign: true))
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
@@ -30,9 +30,6 @@ class SamlPayloads {
     static final String SAML_EXTERNAL_ISSUER = "http://idp.external.com"
     static final String SAML_REPOSE_ISSUER = "http://openrepose.org/filters/SAMLTranslation"
 
-    static final String CONTENT_TYPE = "Content-Type"
-    static final String ACCEPT = "Accept"
-
     static final String APPLICATION_INVALID = "application/potato"
 
     static final String IDENTITY_API_VERSION = "Identity-API-Version"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
@@ -37,6 +37,7 @@ class SamlPayloads {
     static final String CONTENT_TYPE_XML = "application/xml"
     static final String CONTENT_TYPE_INVALID = "application/potato"
     static final String CONTENT_TYPE_JSON = "application/json"
+    static final String CONTENT_TYPE_TEXT = "text/plain"
 
     static final String IDENTITY_API_VERSION = "Identity-API-Version"
     static final String X_AUTH_TOKEN = "X-Auth-Token"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlPayloads.groovy
@@ -33,11 +33,7 @@ class SamlPayloads {
     static final String CONTENT_TYPE = "Content-Type"
     static final String ACCEPT = "Accept"
 
-    static final String CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded"
-    static final String CONTENT_TYPE_XML = "application/xml"
-    static final String CONTENT_TYPE_INVALID = "application/potato"
-    static final String CONTENT_TYPE_JSON = "application/json"
-    static final String CONTENT_TYPE_TEXT = "text/plain"
+    static final String APPLICATION_INVALID = "application/potato"
 
     static final String IDENTITY_API_VERSION = "Identity-API-Version"
     static final String X_AUTH_TOKEN = "X-Auth-Token"

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilities.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/samlpolicy/util/SamlUtilities.groovy
@@ -85,34 +85,6 @@ class SamlUtilities {
         str.bytes.encodeBase64().toString()
     }
 
-    /**
-     * Method to convert the format of the SAML Attributes to the format that's expected in the "access" JSON.
-     *
-     * For example (formatted for convenience):
-     * input:
-     * [A/b: [1, 2],
-     *  A/c: [3],
-     *  Z/d: [6, 7],
-     *  Y/e: [0, 8, 9],
-     *  Y/f: [10],
-     *  Y/g: [11, 12]]
-     *
-     * output:
-     * [A: [b: [1, 2], c: 3],
-     *  Z: [d: [6, 7]],
-     *  Y: [e: [0, 8, 9], f: 10, g: [11, 12]]]
-     *
-     * Where the groups are "A", "Z", and "Y", the attribute names are "b", "c", "d", "e", "f", and "g", and the
-     * numbers are the attribute values.
-     */
-    static Map normalizeGroupingForExtendedAttributes(Map<String, List<String>> extendedAttributes) {
-        extendedAttributes
-                .groupBy { it.key.split("/")[0] }
-                .collectEntries { group, attributes ->
-            [(group), attributes.collectEntries { groupAndName, v -> [(groupAndName.split("/")[1]), v?.size() == 1 ? v[0] : v]}]
-        }
-    }
-
     static String generateUniqueIssuer() {
         "http://unique.external.idp.com/${UUID.randomUUID().toString()}"
     }

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/framework/mocks/MockIdentityV2Service.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/framework/mocks/MockIdentityV2Service.groovy
@@ -953,7 +953,7 @@ class MockIdentityV2Service {
         writer.toString()
     }
 
-    static String createIdentityFaultJsonWithValues(Map values = [:]) {
+    static Closure<String> createIdentityFaultJsonWithValues = { Map values = [:] ->
         def name = values.name ?: "identityFault"
         def code = values.code ?: 500
         def message = values.message ?: "Internal server error."
@@ -968,6 +968,23 @@ class MockIdentityV2Service {
         }
 
         json.toString()
+    }
+
+    static Closure<String> createIdentityFaultXmlWithValues = { Map values = [:] ->
+        def name = values.name ?: "identityFault"
+        def code = values.code ?: 500
+        def message = values.message ?: "Internal server error."
+
+        def writer = new StringWriter()
+        def xmlBuilder = new MarkupBuilder(writer)
+        xmlBuilder.doubleQuotes = true
+        xmlBuilder.mkp.xmlDeclaration(version: "1.0", encoding: "UTF-8", standalone: "yes")
+
+        xmlBuilder."$name"(code: code, xmlns: "http://docs.openstack.org/identity/api/v2.0") {
+            delegate.message(message)
+        }
+
+        writer.toString()
     }
 
     static final String UNAUTHORIZED_JSON = createIdentityFaultJsonWithValues(


### PR DESCRIPTION
I added a few test cases to the Flow 1.0 and Flow 2.0 validation tests around:
- Identity returning non-200 results (in both JSON and XML)
- a 200 response in a valid format that's neither JSON nor XML
- a 200 response that can't be parsed as the claimed format (in both JSON and XML)

The results are mostly the same except for the "can't be parsed" case where it'll still be a 200 in the Flow 1.0 case (since we really don't care) and a 502 in the Flow 2.0 case (since something went wrong when parsing something).

I also moved away from using my own content type strings and started using the `javax.ws.rs.core.MediaType` strings, and I started using a shared method to do execute the saml call where I could (i.e. tests without too many special cases).