### PR TITLE
Re-enable Docker Image Publishing

### DIFF
--- a/repose-aggregator/artifacts/docker/build.gradle
+++ b/repose-aggregator/artifacts/docker/build.gradle
@@ -122,4 +122,4 @@ static boolean isLatestVersion(String v) {
 
 pushImageLatest.onlyIf { isLatestVersion(reposeVersion) }
 
-//project.tasks.getByPath(':release').dependsOn pushImageVersion, pushImageLatest
+project.tasks.getByPath(':release').dependsOn pushImageVersion, pushImageLatest


### PR DESCRIPTION
Ignore the incorrect branch name. This just re-enables Docker image publishing. We should be good to go on that front with the most recent Puppet changes.