### PR TITLE
Fixing immediate npm issue

### DIFF
--- a/repose-aggregator/tests/release-verification/src/scripts/fake_keystone_install_docker.sh
+++ b/repose-aggregator/tests/release-verification/src/scripts/fake_keystone_install_docker.sh
@@ -6,6 +6,14 @@ cd /opt/fake-keystone
 echo `pwd`
 
 # download and install the Fake Keystone app dependencies
-npm install
+#
+# The --unsafe-perm flag is used to support building the libxmljs library.
+# Since there is no guarantee that libxmljs has been pre-compiled for the Docker image OS,
+# node-gyp falls back to building the library. Since the Docker user is root, gyp
+# creates a temporary directory for the build which breaks the Makefile. The flag
+# makes things work again.
+#
+# TODO: If this fails, it does so silently. WRONG!
+npm install --unsafe-perm
 
 chmod 755 /opt/fake-keystone

--- a/repose-aggregator/tests/release-verification/src/scripts/fake_origin_install_docker.sh
+++ b/repose-aggregator/tests/release-verification/src/scripts/fake_origin_install_docker.sh
@@ -6,6 +6,14 @@ cd /opt/fake-origin
 echo `pwd`
 
 # download and install the Fake Origin app dependencies
-npm install
+#
+# The --unsafe-perm flag is used to support building the libxmljs library.
+# Since there is no guarantee that libxmljs has been pre-compiled for the Docker image OS,
+# node-gyp falls back to building the library. Since the Docker user is root, gyp
+# creates a temporary directory for the build which breaks the Makefile. The flag
+# makes things work again.
+#
+# TODO: If this fails, it does so silently. WRONG!
+npm install --unsafe-perm
 
 chmod 755 /opt/fake-origin


### PR DESCRIPTION
This is in response to the automatic release verification failure for the 8.4.1.0 release.

Looking at the verification process again reminded me of how much there is to fix there. The big problem is that the Dockerfile calls a number of scripts, and some of the scripts will succeed even if a command in the script fails. That is what we saw when `npm install` failed -- the logs made it look like the verification script failed, but that's only because Repose was returning 5xx responses since the mock Keystone service was never started (because its dependencies were never satisfied due to `npm install` failing).