### PR TITLE
REP-5115 Adds a task between building and testing of artifacts and their publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ ext {
     scalaMajDotMin = "$scalaMajor.$scalaMinor"
 }
 
+task('buildAndTestAll', description: 'Builds all the sub-projects as well as runs there tests.', group: 'release')
+
 task('publishToPackageRepo', group: 'publishing', description: 'Publishes the debian and rpm packages to the package repo.',
         dependsOn: [':repose-aggregator:artifacts:cli-utils:buildDeb',
                     ':repose-aggregator:artifacts:cli-utils:buildRpm',
@@ -54,7 +56,9 @@ task('publishToPackageRepo', group: 'publishing', description: 'Publishes the de
                     ':repose-aggregator:artifacts:valve:buildDeb',
                     ':repose-aggregator:artifacts:valve:buildRpm',
                     ':repose-aggregator:artifacts:web-application:buildDeb',
-                    ':repose-aggregator:artifacts:web-application:buildRpm',]) << {
+                    ':repose-aggregator:artifacts:web-application:buildRpm',
+                    ':buildAndTestAll',
+        ]) << {
     ssh.run {
         session(remotes.packageRepo) {
             put from: tasks.getByPath(':repose-aggregator:artifacts:cli-utils:buildDeb').outputs.files, into: '/home/repose-dev/RELEASES'
@@ -75,7 +79,7 @@ task('publishToPackageRepo', group: 'publishing', description: 'Publishes the de
     }
 }
 
-task('tagVersion', description: 'Tag the repository with the current version.', group: 'release') << {
+task('tagVersion', description: 'Tag the repository with the current version.', group: 'release', dependsOn: [buildAndTestAll]) << {
     scmFactory.create().tag(version)
 }
 
@@ -361,8 +365,10 @@ subprojects {
         sign configurations.archives
     }
 
+    def publishGate = project.tasks.getByPath(':buildAndTestAll')
+    publishGate.dependsOn build, check
+    publish.dependsOn publishGate
     project.tasks.getByPath(':release').dependsOn publish
-    publish.dependsOn build
 }
 
 dependencyRecommendations {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     scalaMajDotMin = "$scalaMajor.$scalaMinor"
 }
 
-task('buildAndTestAll', description: 'Builds all the sub-projects as well as runs there tests.', group: 'release')
+task('buildAll', description: 'Builds all the sub-projects.', group: 'release')
 
 task('publishToPackageRepo', group: 'publishing', description: 'Publishes the debian and rpm packages to the package repo.',
         dependsOn: [':repose-aggregator:artifacts:cli-utils:buildDeb',
@@ -57,7 +57,7 @@ task('publishToPackageRepo', group: 'publishing', description: 'Publishes the de
                     ':repose-aggregator:artifacts:valve:buildRpm',
                     ':repose-aggregator:artifacts:web-application:buildDeb',
                     ':repose-aggregator:artifacts:web-application:buildRpm',
-                    ':buildAndTestAll',
+                    ':buildAll',
         ]) << {
     ssh.run {
         session(remotes.packageRepo) {
@@ -79,7 +79,7 @@ task('publishToPackageRepo', group: 'publishing', description: 'Publishes the de
     }
 }
 
-task('tagVersion', description: 'Tag the repository with the current version.', group: 'release', dependsOn: [buildAndTestAll]) << {
+task('tagVersion', description: 'Tag the repository with the current version.', group: 'release', dependsOn: [buildAll]) << {
     scmFactory.create().tag(version)
 }
 
@@ -365,9 +365,8 @@ subprojects {
         sign configurations.archives
     }
 
-    def publishGate = project.tasks.getByPath(':buildAndTestAll')
-    publishGate.dependsOn build, check
-    publish.dependsOn publishGate
+    buildAll.dependsOn build
+    publish.dependsOn buildAll
     project.tasks.getByPath(':release').dependsOn publish
 }
 

--- a/repose-aggregator/build.gradle
+++ b/repose-aggregator/build.gradle
@@ -93,10 +93,10 @@ task('publishDocs', dependsOn: asciidoctor, group: 'release', description: 'Adds
     }
 }
 
-project.tasks.getByPath(':release').dependsOn publishDocs
-
 asciidoctor.dependsOn copyXsds
 build.dependsOn asciidoctor
+publishDocs.dependsOn project.tasks.getByPath(':buildAndTestAll')
+project.tasks.getByPath(':release').dependsOn publishDocs
 
 /**
  * @return -1 if v1 is a lower version than v2, 0 if they are equal, and 1 if v1 is a greater version than v2

--- a/repose-aggregator/build.gradle
+++ b/repose-aggregator/build.gradle
@@ -95,7 +95,7 @@ task('publishDocs', dependsOn: asciidoctor, group: 'release', description: 'Adds
 
 asciidoctor.dependsOn copyXsds
 build.dependsOn asciidoctor
-publishDocs.dependsOn project.tasks.getByPath(':buildAndTestAll')
+publishDocs.dependsOn project.tasks.getByPath(':buildAll')
 project.tasks.getByPath(':release').dependsOn publishDocs
 
 /**


### PR DESCRIPTION
This adds a central task when publishing that requires all artifacts build and test before anything gets released. This adds a check that will prevent some partial releases.