### PR TITLE
Temporary RPM Verification Fix

### DIFF
--- a/repose-aggregator/tests/release-verification/src/docker/rpm/Dockerfile
+++ b/repose-aggregator/tests/release-verification/src/docker/rpm/Dockerfile
@@ -36,7 +36,7 @@ COPY *.rpm /release-verification/
 RUN rm /release-verification/DELETE-ME.rpm
 
 RUN sh /release-verification/scripts/node_install.sh
-RUN npm install libxmljs
+RUN npm install --unsafe-perm libxmljs
 
 RUN sh /release-verification/scripts/fake_keystone_prepare.sh
 RUN cp /release-verification/fake-services/fake-keystone2/package.json /opt/fake-keystone/package.json


### PR DESCRIPTION
From a comment I left elsewhere:

> The --unsafe-perm flag is used to support building the libxmljs library.
> Since there is no guarantee that libxmljs has been pre-compiled for the Docker image OS,
> node-gyp falls back to building the library. Since the Docker user is root, gyp
> creates a temporary directory for the build which breaks the Makefile. The flag
> makes things work again.

I'm not a huge fan of node, and I hope we move away from it in the future, but this fix should keep us working for now.