### PR TITLE
REP-5397 Upgrading the Docker Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,7 @@ buildscript {
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
         classpath 'org.ajoberstar:gradle-git:1.3.2'
         classpath 'com.bmuschko:gradle-vagrant-plugin:2.0'
-        // TODO: Update to 3.0.4 to resolve Mac OS X junix issue (https://github.com/docker-java/docker-java/issues/537)
-        classpath 'com.bmuschko:gradle-docker-plugin:3.0.3'
+        classpath 'com.bmuschko:gradle-docker-plugin:3.0.6'
     }
 }
 

--- a/repose-aggregator/tests/release-verification/build.gradle
+++ b/repose-aggregator/tests/release-verification/build.gradle
@@ -167,13 +167,10 @@ task vagrantSmokeTest {
                  'vagrantSshSmokeTestRpm']
 }
 
-// This forces the usage of a more recent unix-socket-factory which makes Mac OS X happy
-// It also forces the usage of jackson dependencies which were not being brought in as expected
-// TODO: Remove unix-socket-factory after upgrading to gradle-docker-plugin 3.0.4
+// This forces the usage of jackson dependencies which were not being brought in as expected
 configurations {
     dockerJava {
         resolutionStrategy {
-            force 'de.gesellix:unix-socket-factory:2016-04-06T22-21-19'
             force 'com.fasterxml.jackson.core:jackson-databind:2.6.4'
             force 'com.fasterxml.jackson.core:jackson-core:2.6.4'
             force 'com.fasterxml.jackson.core:jackson-annotations:2.6.4'


### PR DESCRIPTION
This seems to work for me locally on OS X.

If https://jenkins-proto.openrepose.org/job/release-verification-test/2/ passes, this change is good to go!

EDIT: If that job passes the Debian verification, it's good to go. The RPM verification process on master has an outstanding issue addressed by: https://github.com/rackerlabs/repose/pull/1723. 