### PR TITLE
REP-5645 Performance tests now with random quiet periods

### DIFF
--- a/repose-aggregator/tests/performance-tests/Jenkinsfile
+++ b/repose-aggregator/tests/performance-tests/Jenkinsfile
@@ -27,6 +27,8 @@ stage("Performance Test") {
     def performanceJenkinsJob = "performance-test"
     def performanceTestParam = "perf_test"
     def extraOptionsParam = "extra_options"
+    def tenMinutesInSeconds = 600
+    def random = new Random()
 
     def jobsToRun = [:]
 
@@ -34,7 +36,9 @@ stage("Performance Test") {
         def perfTest = perfTests[index]
         jobsToRun[perfTest] = {
             retry(3) {
-                build(job: performanceJenkinsJob, parameters: [
+                build(job: performanceJenkinsJob,
+                      quietPeriod: random.nextInt(tenMinutesInSeconds),
+                      parameters: [
                         [$class: "StringParameterValue", name: performanceTestParam, value: perfTest],
                         [$class: "StringParameterValue", name: extraOptionsParam, value: params.extraOptions]])
             }


### PR DESCRIPTION
Sets the quiet period to a random length between 15 seconds and 10 minutes. Note that we may still hit rate limiting, but it should be pretty unlikely at this point.