### PR TITLE
REP-3664 Fixing the flaky test in AtomFeedServiceImplTest

### DIFF
--- a/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/build.gradle
+++ b/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/build.gradle
@@ -29,4 +29,5 @@ dependencies {
     testCompile group: 'org.apache.logging.log4j', name: 'log4j-core', classifier: 'tests'
     testCompile "com.typesafe.akka:akka-testkit_$scalaMajDotMin"
     testCompile "com.typesafe.akka:akka-http-core-experimental_$scalaMajDotMin"
+    testCompile "org.springframework:spring-test"
 }


### PR DESCRIPTION
The story is here:
https://repose.atlassian.net/browse/REP-5754

I left my findings in comments on the investigation subtask for any interested parties.

To "fix" the issue, I simply stopped relying on logs to verify behavior for this particular test. Using the logs was never the best solution, but since Akka is an asynchronous system, and since it's a closed system within the Atom Feed service (i.e., not publically accessible), testing it any other way would be a challenge. Well, challenge accepted. Gogo reflection!