### PR TITLE
REP-4643 Docker Release Verificaton Updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
         classpath 'org.ajoberstar:gradle-git:1.3.2'
         classpath 'com.bmuschko:gradle-vagrant-plugin:2.0'
-        classpath 'com.bmuschko:gradle-docker-plugin:3.0.6'
+        classpath 'com.bmuschko:gradle-docker-plugin:3.0.7'
     }
 }
 

--- a/repose-aggregator/artifacts/docker/build.gradle
+++ b/repose-aggregator/artifacts/docker/build.gradle
@@ -36,7 +36,6 @@ task buildImage(type: DockerBuildImage) {
     finalizedBy 'removeImage'
     inputDir = file("$projectDir/src/docker")
     buildArgs = ['REPOSE_VERSION': reposeVersion]
-    // TODO: Set "forcerm" to true once the Docker Gradle plugin supports it
 }
 
 task tagImageVersion(type: DockerTagImage) {

--- a/repose-aggregator/tests/release-verification/build.gradle
+++ b/repose-aggregator/tests/release-verification/build.gradle
@@ -195,7 +195,6 @@ task buildDebSmokeTestImage(type: DockerBuildImage) {
     inputDir = file(debDir)
     tag = 'repose:deb-release-verification'
     buildArgs = ['REPOSE_VERSION': releaseVersion]
-    // TODO: Set "forcerm" to true once the Docker Gradle plugin supports it
 }
 
 task buildRpmImage(type: DockerBuildImage) {
@@ -211,7 +210,6 @@ task buildRpmSmokeTestImage(type: DockerBuildImage) {
     inputDir = file(rpmDir)
     tag = 'repose:rpm-release-verification'
     buildArgs = ['REPOSE_VERSION': releaseVersion]
-    // TODO: Set "forcerm" to true once the Docker Gradle plugin supports it
 }
 
 task createDebContainer(type: DockerCreateContainer) {

--- a/repose-aggregator/tests/release-verification/src/docker/deb/Dockerfile
+++ b/repose-aggregator/tests/release-verification/src/docker/deb/Dockerfile
@@ -6,9 +6,6 @@ FROM ubuntu:xenial
 
 MAINTAINER The Repose Team <reposecore@rackspace.com>
 
-# This build-arg is used to pass the Repose version number which will be set up in this image.
-ARG REPOSE_VERSION
-
 # The service ports -- one for accepting HTTP traffic to Repose, and the other for connecting a JDWP debugger
 # Note that these are not exposed to the host by default, but can be using the Docker CLI -p or -P flag.
 EXPOSE 8080 10037
@@ -39,6 +36,9 @@ RUN sh /release-verification/scripts/fake_origin_prepare.sh
 RUN cp /release-verification/fake-services/fake-origin/package.json /opt/fake-origin/package.json
 RUN cp /release-verification/fake-services/fake-origin/app.js /opt/fake-origin/app.js
 RUN sh /release-verification/scripts/fake_origin_install_docker.sh
+
+# This build-arg is used to pass the Repose version number which will be set up in this image.
+ARG REPOSE_VERSION
 
 RUN apt-get update -qq && sh /release-verification/scripts/repose_install_deb.sh $REPOSE_VERSION
 RUN cp --force /release-verification/etc_repose/* /etc/repose/


### PR DESCRIPTION
Just a few small changes that came out of https://repose.atlassian.net/browse/REP-4839 . I left a comment on that story with all of my thoughts and rationale. That comment explains why we don't really need `forcerm`.