### PR TITLE
Fixing release verification by calling the right scripts

### DIFF
--- a/repose-aggregator/tests/release-verification/src/scripts/verify.sh
+++ b/repose-aggregator/tests/release-verification/src/scripts/verify.sh
@@ -5,10 +5,10 @@ echo "Starting Mock Services"
 echo "-------------------------------------------------------------------------------------------------------------------"
 sh /release-verification/scripts/fake_keystone_run.sh
 sh /release-verification/scripts/fake_origin_run.sh
-sh /release-verification/scripts/repose_run_docker.sh
+sh /release-verification/scripts/repose_run.sh
 
 echo "~~~TRUNCATED~~~" > /release-verification/validation.log 2>&1
-/bin/bash /release-verification/scripts/isReposeReady_docker.sh /release-verification/var-log-repose-current.log
+/bin/bash /release-verification/scripts/isReposeReady.sh /release-verification/var-log-repose-current.log
 if [ $? -eq 0 ]; then
    curl -vs http://localhost:8080/resource/this-is-an-id > /release-verification/validation.log 2>&1
 fi


### PR DESCRIPTION
Apparently I missed these when some names changed during the Vagrant removal work.