### PR TITLE
(bug): Really bad yaml fails YAML parser and returns http 200 with empty body

### DIFF
--- a/repose-aggregator/src/docs/asciidoc/release-notes.adoc
+++ b/repose-aggregator/src/docs/asciidoc/release-notes.adoc
@@ -1,10 +1,11 @@
 = Release Notes
 
-== Future Release
+== In Progress Work
 
 * https://repose.atlassian.net/browse/REP-5939[REP-5939] - Added support for, and began publishing, a CentOS-based Docker image.
 * https://repose.atlassian.net/browse/REP-5766[REP-5766] - Updated Dockerfile to run Repose as the `repose` user.
 * https://repose.atlassian.net/browse/REP-5767[REP-5767] - Updated Dockerfiles to simplify usage of `JAVA_OPTS`.
+* https://repose.atlassian.net/browse/REP-5985[REP-5985] - Updated the Jackson version from v2.4.0 to v2.8.9 to correct some library mismatch issues.
 
 == 8.6.3.0 (2017-08-15)
 

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/attributemappingvalidation/AttributeMappingPolicyValidationFilterTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/filters/attributemappingvalidation/AttributeMappingPolicyValidationFilterTest.groovy
@@ -328,6 +328,25 @@ class AttributeMappingPolicyValidationFilterTest extends ReposeValveTest {
         mc.handlings.size() == 0
     }
 
+    def "should fail to validate bad YAML (dimitry style)"() {
+        given:
+        String body =
+            """
+            |- just: write some
+            |- yaml:
+            |  - [here, and]
+            |  - {it: updates, in: real-time}
+            |sdfsdds
+            """.stripMargin()
+
+        when:
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, method: "PUT", headers: ["content-type": TEXT_YAML], requestBody: body)
+
+        then:
+        mc.receivedResponse.code == "400"
+        mc.handlings.size() == 0
+    }
+
     def "YAML comments should be preserved"() {
         given:
         String comment = "Find me"

--- a/versions.properties
+++ b/versions.properties
@@ -1,4 +1,4 @@
-jacksonVersion=2.4.0
+jacksonVersion=2.8.9
 com.fasterxml.jackson.core:jackson-annotations=$jacksonVersion
 com.fasterxml.jackson.core:jackson-core=$jacksonVersion
 com.fasterxml.jackson.core:jackson-databind=$jacksonVersion


### PR DESCRIPTION
Sending an awful looking invalid string bombs the yaml parser:

```
PUT /idm/cloud/v2.0/RAX-AUTH/federation/identity-providers/0601ba56aeda441ca105059c04286485/mapping HTTP/1.1
Host: localhost:8080
x-auth-token: AAD1PcpjilLpMJhPODlDMS9srFcMy6WRhoB3GXFBkUQoN_H4ZIAakcZKkFvkIij23AIDNfl3WfAq0k60LAI0QlIQlaz3swBlQ0wuhZ96SHItoYQqVs086wqUShb8vZO7Hea5nxwCMvem_w
content-type: text/yaml
Cache-Control: no-cache
Postman-Token: 312c3402-cb69-4b34-56aa-3b871dc35995

- just: write some
- yaml: 
  - [here, and]
  - {it: updates, in: real-time}
sdfsdds
```


Logs:

```
WARN  org.eclipse.jetty.servlet.ServletHandler - Error for /my/super/awesome/request/mapping
java.lang.NoSuchMethodError: com.fasterxml.jackson.core.JsonParseException.<init>(Lcom/fasterxml/jackson/core/JsonParser;Ljava/lang/String;Ljava/lang/Throwable;)V
	at com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException.<init>(JacksonYAMLParseException.java:14) ~[?:?]
	at com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.YAMLException.<init>(YAMLException.java:20) ~[?:?]
	at com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException.<init>(MarkedYAMLException.java:21) ~[?:?]
	at com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException.from(MarkedYAMLException.java:27) ~[?:?]
	at com.fasterxml.jackson.dataformat.yaml.YAMLParser.nextToken(YAMLParser.java:343) ~[?:?]
	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeArray(JsonNodeDeserializer.java:256) ~[repose-valve.jar:8.6.3.0]
	at com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:64) ~[repose-valve.jar:8.6.3.0]
	at com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:14) ~[repose-valve.jar:8.6.3.0]
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3051) ~[repose-valve.jar:8.6.3.0]
	at com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:1787) ~[repose-valve.jar:8.6.3.0]
	at com.rackspace.identity.components.AttributeMapper$.parseYamlNode(AttributeMapper.scala:334) ~[?:?]
	at org.openrepose.filters.attributemapping.AttributeMappingPolicyValidationFilter$$anonfun$validatePolicy$1.apply(AttributeMappingPolicyValidationFilter.scala:100) ~[?:?]
	at org.openrepose.filters.attributemapping.AttributeMappingPolicyValidationFilter$$anonfun$validatePolicy$1.apply(AttributeMappingPolicyValidationFilter.scala:97) ~[?:?]
	at scala.util.Try$.apply(Try.scala:192) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.attributemapping.AttributeMappingPolicyValidationFilter.validatePolicy(AttributeMappingPolicyValidationFilter.scala:97) ~[?:?]
	at org.openrepose.filters.attributemapping.AttributeMappingPolicyValidationFilter$$anonfun$1.apply(AttributeMappingPolicyValidationFilter.scala:55) ~[?:?]
	at org.openrepose.filters.attributemapping.AttributeMappingPolicyValidationFilter$$anonfun$1.apply(AttributeMappingPolicyValidationFilter.scala:54) ~[?:?]
	at scala.util.Success.flatMap(Try.scala:231) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.attributemapping.AttributeMappingPolicyValidationFilter.doFilter(AttributeMappingPolicyValidationFilter.scala:54) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.herp.HerpFilter.doFilter(HerpFilter.scala:95) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at javax.servlet.FilterChain$doFilter.call(Unknown Source) ~[?:?]
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) ~[?:?]
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:110) ~[?:?]
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:130) ~[?:?]
	at Script1.run(Script1.groovy:2) ~[?:?]
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.eval(GroovyScriptEngineImpl.java:344) ~[?:?]
	at org.codehaus.groovy.jsr223.GroovyCompiledScript.eval(GroovyCompiledScript.java:41) ~[?:?]
	at javax.script.CompiledScript.eval(CompiledScript.java:92) ~[?:1.8.0_131]
	at org.openrepose.filters.scripting.ScriptingFilter$CompiledScriptRunner.run(ScriptingFilter.scala:116) ~[?:?]
	at org.openrepose.filters.scripting.ScriptingFilter$$anonfun$1.apply(ScriptingFilter.scala:83) ~[?:?]
	at scala.util.Try$.apply(Try.scala:192) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.scripting.ScriptingFilter.doFilter(ScriptingFilter.scala:83) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.cors.CorsFilter.doFilter(CorsFilter.scala:89) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.ratelimiting.RateLimitingFilter.doFilter(RateLimitingFilter.java:108) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.slf4jlogging.Slf4jHttpLoggingFilter.doFilter(Slf4jHttpLoggingFilter.scala:67) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.uriuser.UriUserFilter.doFilter(UriUserFilter.scala:75) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.ipuser.IpUserFilter.doFilter(IpUserFilter.scala:87) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.headertranslation.HeaderTranslationFilter.doFilter(HeaderTranslationFilter.scala:104) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.translation.TranslationFilter.doFilter(TranslationFilter.java:187) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.filters.contenttypestripper.ContentTypeStripperFilter.doFilter(ContentTypeStripperFilter.scala:48) ~[?:?]
	at org.openrepose.powerfilter.PowerFilterChain.doReposeFilter(PowerFilterChain.java:209) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.doFilter(PowerFilterChain.java:324) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilterChain.startFilterChain(PowerFilterChain.java:113) ~[repose-valve.jar:8.6.3.0]
	at org.openrepose.powerfilter.PowerFilter.doFilter(PowerFilter.java:418) ~[repose-valve.jar:8.6.3.0]
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:344) ~[repose-valve.jar:8.6.3.0]
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:261) ~[repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1636) ~[repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:564) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1111) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:498) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1045) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:98) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.server.Server.handle(Server.java:461) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:284) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:244) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:534) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:607) [repose-valve.jar:8.6.3.0]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:536) [repose-valve.jar:8.6.3.0]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]
```