### PR TITLE
REP-5766 Updated Dockerfiles to run Repose as repose user

### DIFF
--- a/repose-aggregator/artifacts/docker/src/docker/centos/Dockerfile
+++ b/repose-aggregator/artifacts/docker/src/docker/centos/Dockerfile
@@ -18,10 +18,11 @@ RUN yum update -q -y && yum install -q -y repose-valve-$REPOSE_VERSION repose-fi
 WORKDIR /etc/repose
 VOLUME /etc/repose
 
-# Create the log file so that we can safely tail it as part of the CMD instruction.
+# Switch user to repose
 USER repose
+
+# Create the log file so that we can safely tail it as part of the CMD instruction.
 RUN touch /var/log/repose/current.log
-USER root
 
 # Expose the default Repose service port for host port forwarding.
 # If the port in the user's system model differs from this port, the user will have to map it manually using the

--- a/repose-aggregator/artifacts/docker/src/docker/ubuntu/Dockerfile
+++ b/repose-aggregator/artifacts/docker/src/docker/ubuntu/Dockerfile
@@ -16,10 +16,11 @@ RUN apt-get update -qq && apt-get install -y repose-valve=$REPOSE_VERSION repose
 WORKDIR /etc/repose
 VOLUME /etc/repose
 
-# Create the log file so that we can safely tail it as part of the CMD instruction.
+# Switch user to repose
 USER repose
+
+# Create the log file so that we can safely tail it as part of the CMD instruction.
 RUN touch /var/log/repose/current.log
-USER root
 
 # Expose the default Repose service port for host port forwarding.
 # If the port in the user's system model differs from this port, the user will have to map it manually using the

--- a/repose-aggregator/src/docs/asciidoc/release-notes.adoc
+++ b/repose-aggregator/src/docs/asciidoc/release-notes.adoc
@@ -3,6 +3,7 @@
 == Future Release
 
 * https://repose.atlassian.net/browse/REP-5939[REP-5939] - Added support for, and began publishing, a CentOS-based Docker image.
+* https://repose.atlassian.net/browse/REP-5766[REP-5766] - Updated Dockerfile to run Repose as the `repose` user.
 
 == 8.6.3.0 (2017-08-15)
 


### PR DESCRIPTION
This is based on the other Docker work from #1793 . This PR can be merged first.