### PR TITLE
REP-5765 Reporting Scoverage on a per-project basis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -397,6 +397,12 @@ subprojects {
         sign configurations.archives
     }
 
+    sonarqube {
+        properties {
+            property "sonar.scoverage.reportPath", "$buildDir/reports/scoverage/scoverage.xml"
+        }
+    }
+
     if (project.hasProperty("minCoverageRatio")) {
         def minCoverageRatio = (project.findProperty("minCoverageRatio") ?: "0.75") as double
 
@@ -448,7 +454,6 @@ sonarqube {
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.jacoco.reportPath", "$rootDir/repose-aggregator/build/jacoco/jacocoTest.exec"
         property "sonar.jacoco.itReportPath", "$rootDir/repose-aggregator/build/jacoco/jacocoIntegrationTest.exec"
-        property "sonar.scoverage.reportPath", "$rootDir/repose-aggregator/build/scoverage-aggregate/scoverage.xml"
     }
 }
 


### PR DESCRIPTION
This is the appropriate way to do this, even though the Sonar Scoverage plugin may not work for us and our end solution may necessitate further changes.

So this is more correct than what we currently have, but doesn't solve our problem?