### PR TITLE
Adding the version information back into the footer

### DIFF
--- a/repose-aggregator/src/docs/asciidoc/_backends/haml/html5/document.html.haml
+++ b/repose-aggregator/src/docs/asciidoc/_backends/haml/html5/document.html.haml
@@ -108,6 +108,10 @@
     - unless nofooter
       #footer
         #footer-text
+          - if attr? 'project-version'
+            = precede %(#{attr 'version-label'} #{attr 'project-version'}) do
+              - if (attr? :revnumber) || (attr? 'last-update-label')
+                %br
           - if attr? :revnumber
             = precede %(#{attr 'version-label'} #{attr :revnumber}) do
               - if attr? 'last-update-label'


### PR DESCRIPTION
It just occurred to me that when I updated the HAML backend, I did not maintain my alteration which puts a version number in the footer.

This PR restores that functionality.