### PR TITLE
REP-6211 Multivalue Test Fix

### DIFF
--- a/repose-aggregator/components/filters/saml-policy-translation-filter/src/test/scala/org/openrepose/filters/samlpolicy/SamlPolicyTranslationFilterTest.scala
+++ b/repose-aggregator/components/filters/saml-policy-translation-filter/src/test/scala/org/openrepose/filters/samlpolicy/SamlPolicyTranslationFilterTest.scala
@@ -1263,14 +1263,15 @@ class SamlPolicyTranslationFilterTest extends FunSpec with BeforeAndAfterEach wi
         |    </user>
         |    <serviceCatalog/>
         |    <RAX-AUTH:extendedAttributes xmlns="http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1.0"
-        |                                 xmlns:RAX-AUTH="http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1.0">
+        |                                 xmlns:RAX-AUTH="http://docs.rackspace.com/identity/api/ext/RAX-AUTH/v1.0"
+        |                                 xmlns:mapping="http://docs.rackspace.com/identity/api/ext/MappingRules">
         |        <group name="user">
         |            <attribute name="foo">
         |                <value>2017-01-25T21:50:56.399-06:00</value>
         |            </attribute>
         |        </group>
         |        <group name="test">
-        |            <attribute name="policy">
+        |            <attribute multiValue="true" name="policy">
         |                <value>TestPolicy</value>
         |                <value>TestPolicy2</value>
         |                <value>TestPolicy YEA!</value>
@@ -1749,6 +1750,7 @@ object SamlPolicyTranslationFilterTest {
       |        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
       |    </saml2p:Status>
       |    <saml2:Assertion xmlns="http://docs.rackspace.com/identity/api/ext/MappingRules"
+      |                     xmlns:mapping="http://docs.rackspace.com/identity/api/ext/MappingRules"
       |                     xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
       |                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       |                     ID="_406fb7fe-a519-4919-a42c-f67794a670a5__RAX__"
@@ -1780,7 +1782,7 @@ object SamlPolicyTranslationFilterTest {
       |            <saml2:Attribute Name="user/foo">
       |                <saml2:AttributeValue xsi:type="xs:dateTime">2017-01-25T21:50:56.399-06:00</saml2:AttributeValue>
       |            </saml2:Attribute>
-      |            <saml2:Attribute Name="test/policy">
+      |            <saml2:Attribute Name="test/policy" mapping:multiValue="true">
       |                <saml2:AttributeValue xsi:type="xs:string">TestPolicy</saml2:AttributeValue>
       |                <saml2:AttributeValue xsi:type="xs:string">TestPolicy2</saml2:AttributeValue>
       |                <saml2:AttributeValue xsi:type="xs:string">TestPolicy YEA!</saml2:AttributeValue>


### PR DESCRIPTION
This should fix the failing tests in #1826.

I put this together to show exactly why those tests are failing and how they could be fixed.

Jorge's description of the change:
>  # Old Behavior
> 
> There was no way to tell whether or not a SAML attribute should be
> rendered as an array or not. For example given the flowing SAML
> attributes:
> 
> ```xml
>  <saml2:Attribute Name="faws/canAddAWSAccount">
>    <saml2:AttributeValue xsi:type="xs:string">true</saml2:AttributeValue>
>  </saml2:Attribute>
>  <saml2:Attribute Name="faws/991049284483">
>    <saml2:AttributeValue xsi:type="xs:string">fanatical_aws:admin</saml2:AttributeValue>
>  </saml2:Attribute>
>  <saml2:Attribute Name="faws/042423532529">
>     <saml2:AttributeValue xsi:type="xs:string">fanatical_aws:observer</saml2:AttributeValue>
>     <saml2:AttributeValue xsi:type="xs:string">RackspaceReadOnly</saml2:AttributeValue>
>  </saml2:Attribute>
> ```
> 
> They would be rendered to JSON as follows:
> 
> ```json
>  {
>   "RAX-AUTH:extendedAttributes": {
>     "faws": {
>       "canAddAWSAccount":"true",
>       "991049284483": "fanatical_aws:admin",
>       "042423532529": [
>         "fanatical_aws:observer",
>         "RackspaceReadOnly"
>        ]
>      }
>    }
>  }
> ``` 
> 
> The rule was that if an attribute contained a single value it would be
> rendered as a single value string, if it contained multiple values it
> would be rendered as an array.  Unfortunately, `991049284483` was also
> meant to be an array.
> 
> # New Behavior
> 
> We annotate attributes that should be multi-value with a
> `mapping:multiValue` extension.
> 
> ```xml
>  <saml2:Attribute Name="faws/canAddAWSAccount" mapping:multiValue="false">
>    <saml2:AttributeValue xsi:type="xs:string">true</saml2:AttributeValue>
>  </saml2:Attribute>
>  <saml2:Attribute Name="faws/991049284483" mapping:multiValue="true">
>    <saml2:AttributeValue xsi:type="xs:string">fanatical_aws:admin</saml2:AttributeValue>
>  </saml2:Attribute>
>  <saml2:Attribute Name="faws/042423532529" mapping:multiValue="true">
>     <saml2:AttributeValue xsi:type="xs:string">fanatical_aws:observer</saml2:AttributeValue>
>     <saml2:AttributeValue xsi:type="xs:string">RackspaceReadOnly</saml2:AttributeValue>
>  </saml2:Attribute>
> ```
> 
> Because it is a proper optional attribute extension, it should be
> ignored by whoever processes the SAML assertion but it aids in the
> conversion of the extended attributes to JSON.  So new JSON looks like
> this:
> 
> ```json
>  {
>   "RAX-AUTH:extendedAttributes": {
>     "faws": {
>       "canAddAWSAccount":"true",
>       "991049284483": [
>         "fanatical_aws:admin"
>        ],
>       "042423532529": [
>         "fanatical_aws:observer",
>         "RackspaceReadOnly"
>        ]
>      }
>    }
>  }
> ```
> 
> Note that a side effect of the change is that the multiValue attribute
> must also make its way to the XML version of the
> `RAX-AUTH:exnededAttributes` extension.
> 
> ```xml
> <RAX-AUTH:extendedAttributes>
>    <group name="faws">
>       <attribute name="canAddAWSAccount">
>          <value>true</value>
>       </attribute>
>       <attribute name="991049284483" multiValue="true">
>          <value>fanatical_aws:admin</value>
>       </attribute>
>       <attribute name="042423532529" multiValue="true">
>          <value>fanatical_aws:observer</value>
>          <value>RackspaceReadOnly</value>
>       </attribute>
>    </group>
> </RAX-AUTH:extendedAttributes>