### PR TITLE
Fixing 8.8.1.0 release notes HTML

### DIFF
--- a/versions/8.8.1.0/release-notes.html
+++ b/versions/8.8.1.0/release-notes.html
@@ -840,6 +840,23 @@ table.CodeRay td.code>pre{padding:0}
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
 <li><a href="#_8_8_1_0_2018_02_15">8.8.1.0 (2018-02-15)</a></li>
+<li><a href="#_8_8_0_0_2018_02_05">8.8.0.0 (2018-02-05)</a></li>
+<li><a href="#_8_7_3_0_2017_11_17">8.7.3.0 (2017-11-17)</a></li>
+<li><a href="#_8_7_2_0_2017_11_01">8.7.2.0 (2017-11-01)</a></li>
+<li><a href="#_8_7_1_0_2017_10_25">8.7.1.0 (2017-10-25)</a></li>
+<li><a href="#_8_7_0_2_2017_10_04">8.7.0.2 (2017-10-04)</a></li>
+<li><a href="#_8_7_0_1_2017_09_28">8.7.0.1 (2017-09-28)</a></li>
+<li><a href="#_8_7_0_0_2017_09_26">8.7.0.0 (2017-09-26)</a></li>
+<li><a href="#_8_6_3_0_2017_08_15">8.6.3.0 (2017-08-15)</a></li>
+<li><a href="#_8_6_2_0_2017_06_13">8.6.2.0 (2017-06-13)</a></li>
+<li><a href="#_8_6_1_1_2017_06_08">8.6.1.1 (2017-06-08)</a></li>
+<li><a href="#_8_6_0_0_2017_06_02">8.6.0.0 (2017-06-02)</a></li>
+<li><a href="#_8_5_0_1_2017_04_14">8.5.0.1 (2017-04-14)</a></li>
+<li><a href="#_8_4_1_0_2017_02_24">8.4.1.0 (2017-02-24)</a></li>
+<li><a href="#_8_4_0_2_2017_02_21">8.4.0.2 (2017-02-21)</a></li>
+<li><a href="#_8_4_0_1_2017_02_04">8.4.0.1 (2017-02-04)</a></li>
+<li><a href="#_8_3_0_1_2016_12_13">8.3.0.1 (2016-12-13)</a></li>
+<li><a href="#_prior_releases">Prior Releases</a></li>
 </ul>
 </div>
 </div>
@@ -855,12 +872,6 @@ table.CodeRay td.code>pre{padding:0}
 <li>
 <p><a href="https://repose.atlassian.net/browse/REP-6578">REP-6578</a> - Updated <a href="filters/tenant-culling.html">Tenant Culling</a> filter to utilize the tenant to roles map now being populated by the <a href="filters/keystone-v2.html">Keystone v2</a> filter.</p>
 </li>
-</ul>
-</div>
-<div class="exampleblock">
-<div class="content">
-<div class="ulist">
-<ul>
 <li>
 <p><a href="https://repose.atlassian.net/browse/REP-6470">REP-6470</a> - Updated dependencies:</p>
 <div class="ulist">
@@ -894,80 +905,280 @@ table.CodeRay td.code>pre{padding:0}
 </li>
 </ul>
 </div>
-<div class="paragraph">
-<p>== 8.8.0.0 (2018-02-05)
-* <a href="https://repose.atlassian.net/browse/REP-5616">REP-5616</a>, <a href="https://repose.atlassian.net/browse/REP-6436">REP-6436</a>, <a href="https://repose.atlassian.net/browse/REP-6274">REP-6274</a> - Updated dependencies:
-<strong> Jetty: 9.2.0.v20140526 → 9.4.8.v20171121
-</strong>* <a href="https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/VERSION.txt" class="bare">https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/VERSION.txt</a>
-<strong> Gradle: 3.4 → 4.5
-</strong>* <a href="https://github.com/gradle/gradle/releases/tag/v4.5.0" class="bare">https://github.com/gradle/gradle/releases/tag/v4.5.0</a>
-<strong> JSONPath: 2.4.0 → 2.5.0
-</strong>* <a href="https://github.com/josephpconley/play-jsonpath/blob/master/README.md" class="bare">https://github.com/josephpconley/play-jsonpath/blob/master/README.md</a>
-* <a href="https://repose.atlassian.net/browse/REP-5401">REP-5401</a> - Added support for environment variable substitution in configuration files.
-* <a href="https://repose.atlassian.net/browse/REP-6390">REP-6390</a> - Internal changes to the <a href="filters/keystone-v2.html">Keystone v2 Filter</a> in anticipation of splitting the authorization portion off into it&#8217;s own filter.
-* <a href="https://repose.atlassian.net/browse/REP-6400">REP-6400</a> - Added the new <a href="filters/keystone-v2-authorization.html">Keystone v2 Authorization Filter</a> which captures the authorization functionality of the <a href="filters/keystone-v2.html">Keystone v2 Filter</a>.
-* <a href="https://repose.atlassian.net/browse/REP-6382">REP-6382</a> - Lots of little versioned docs updates.</p>
 </div>
-<div class="paragraph">
-<p>== 8.7.3.0 (2017-11-17)
-* <a href="https://repose.atlassian.net/browse/REP-6159">REP-6159</a> - Added the new <a href="filters/regex-rbac.html">RegEx Role Based Access Control (RBAC) Filter</a>.
-* <a href="https://repose.atlassian.net/browse/REP-6313">REP-6313</a> - Updated <a href="filters/keystone-v2.html">Keystone v2 Filter</a> to automatically ignore configured roles.
-* <a href="https://repose.atlassian.net/browse/REP-6338">REP-6338</a> <a href="https://repose.atlassian.net/browse/REP-6325">REP-6325</a> <a href="https://repose.atlassian.net/browse/REP-6321">REP-6321</a> - Multiple  documentation improvements.</p>
 </div>
-<div class="paragraph">
-<p>== 8.7.2.0 (2017-11-01)
-* <a href="https://repose.atlassian.net/browse/REP-6294">REP-6294</a> - Updated dependencies:
-<strong> Attribute Mapper: 2.1.1 → 2.2.0
-</strong>* <a href="https://github.com/rackerlabs/attributeMapping/blob/attribute-mapper-2.2.0/RELEASE.md">Attribute Mapper v2.2.0 release notes</a></p>
+<div class="sect1">
+<h2 id="_8_8_0_0_2018_02_05"><a class="anchor" href="#_8_8_0_0_2018_02_05"></a>8.8.0.0 (2018-02-05)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5616">REP-5616</a>, <a href="https://repose.atlassian.net/browse/REP-6436">REP-6436</a>, <a href="https://repose.atlassian.net/browse/REP-6274">REP-6274</a> - Updated dependencies:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Jetty: 9.2.0.v20140526 → 9.4.8.v20171121</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/VERSION.txt" class="bare">https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/VERSION.txt</a></p>
+</li>
+</ul>
 </div>
-<div class="paragraph">
-<p>== 8.7.1.0 (2017-10-25)
-* <a href="https://repose.atlassian.net/browse/REP-6133">REP-6133</a> - Updated the published Docker images to turn off local logging by default to be more in line with the expectations of a <a href="https://12factor.net/logs">Twelve-Factor App</a>.
-* <a href="https://repose.atlassian.net/browse/REP-6135">REP-6135</a> - Updated the published Docker images to support running the container using an arbitrarily assigned user ID as is expected by the <a href="https://docs.openshift.com/container-platform/3.6/creating_images/guidelines.html#openshift-container-platform-specific-guidelines">OpenShift Container Platform</a>.
-* <a href="https://repose.atlassian.net/browse/REP-6179">REP-6179</a> - Converted more old Wiki Docs over to the new <a href="http://www.openrepose.org/versions/latest/">Versioned Docs</a>.
-* <a href="https://repose.atlassian.net/browse/REP-6186">REP-6186</a> - Updated the automated Release Verification to force the use of Java 8 since some GNU/Linux distributions are already providing Java 9 by default.
-* <a href="https://repose.atlassian.net/browse/REP-6252">REP-6252</a>, <a href="https://repose.atlassian.net/browse/REP-6211">REP-6211</a> - Updated dependencies:
-<strong> Gradle LinkChecker Plugin: 0.2.0 → 0.3.0
-</strong>* <a href="https://github.com/rackerlabs/gradle-linkchecker-plugin/blob/0.3.0/RELEASE.adoc">Gradle LinkChecker Plugin v0.3.0 release notes</a>
-<strong> API Checker: 2.4.1 → 2.5.1
-</strong>* <a href="https://github.com/rackerlabs/api-checker/blob/api-checker-2.5.1/RELEASE.md">API Checker v2.5.1 release notes</a>
-<strong> Attribute Mapper: 2.0.1 → 2.1.1
-</strong>* <a href="https://github.com/rackerlabs/attributeMapping/blob/attribute-mapper-2.1.1/RELEASE.md">Attribute Mapper v2.1.1 release notes</a>
-<strong> Saxon: 9.7.0-15 → 9.8.0-4
-</strong>* <a href="http://www.saxonica.com/products/latest.xml">Saxon 9.8.0.4 release notes</a></p>
+</li>
+<li>
+<p>Gradle: 3.4 → 4.5</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/gradle/gradle/releases/tag/v4.5.0" class="bare">https://github.com/gradle/gradle/releases/tag/v4.5.0</a></p>
+</li>
+</ul>
 </div>
-<div class="paragraph">
-<p>== 8.7.0.2 (2017-10-04)
-* <a href="https://repose.atlassian.net/browse/REP-6162">REP-6162</a> - Updated the Keystone v2 get IDP call to support the field name change from <code>approvedDomains</code> to <code>approvedDomainIds</code>.</p>
+</li>
+<li>
+<p>JSONPath: 2.4.0 → 2.5.0</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/josephpconley/play-jsonpath/blob/master/README.md" class="bare">https://github.com/josephpconley/play-jsonpath/blob/master/README.md</a></p>
+</li>
+</ul>
 </div>
-<div class="paragraph">
-<p>== 8.7.0.1 (2017-09-28)
-* <a href="https://repose.atlassian.net/browse/REP-6115">REP-6115</a> - Updated dependencies:
-<strong> Attribute Mapper: 2.0.0 → 2.0.1
-</strong>* <a href="https://github.com/rackerlabs/attributeMapping/blob/attribute-mapper-2.0.1/RELEASE.md">Attribute Mapper v2.0.1 release notes</a></p>
+</li>
+</ul>
 </div>
-<div class="paragraph">
-<p>== 8.7.0.0 (2017-09-26)
-* <a href="https://repose.atlassian.net/browse/REP-5939">REP-5939</a> - Added support for, and began publishing, a CentOS-based Docker image.
-* <a href="https://repose.atlassian.net/browse/REP-5766">REP-5766</a> - Updated Dockerfile to run Repose as the <code>repose</code> user.
-* <a href="https://repose.atlassian.net/browse/REP-5767">REP-5767</a> - Updated Dockerfiles to simplify usage of <code>JAVA_OPTS</code>.
-* <a href="https://repose.atlassian.net/browse/REP-5985">REP-5985</a> - Updated the Jackson version from v2.4.0 to v2.8.9 to correct some library mismatch issues.
-* <a href="https://repose.atlassian.net/browse/REP-5315">REP-5315</a> - Updated Spring-managed bean names in JMX to be consistent with metric beans.
-* <a href="https://repose.atlassian.net/browse/REP-5885">REP-5885</a> - Fixed the bug where an <code>Error</code> during processing would result in a <code>200</code> response from Repose.
-* <a href="https://repose.atlassian.net/browse/REP-6050">REP-6050</a> - Update Contact Us page information across all the documentation.
-* <a href="https://repose.atlassian.net/browse/REP-5261">REP-5261</a> - Confirmed the Translation filter will allow 100,000 Entity Expansions and updated the documentation accordingly.
-* <a href="https://repose.atlassian.net/browse/REP-6098">REP-6098</a> - Updated the SAML Policy Translation filter to allow multiple locations for default values in an effort to support multiple Identity Providers (IDP&#8217;s).
-* <a href="https://repose.atlassian.net/browse/REP-6001">REP-6001</a> - Updated dependencies:
-<strong> API Checker: 2.3.0 → 2.4.1
-</strong>* <a href="https://github.com/rackerlabs/api-checker/blob/api-checker-2.4.1/RELEASE.md">API Checker v2.4.1 release notes</a>
-<strong> Attribute Mapper: 1.3.0 → 2.0.0
-</strong>* <a href="https://github.com/rackerlabs/attributeMapping/blob/attribute-mapper-2.0.0/RELEASE.md">Attribute Mapper v2.0.0 release notes</a>
-* <a href="https://repose.atlassian.net/browse/REP-5994">REP-5994</a> - Brought the <a href="filters/tenant-culling.html">Tenant Culling Filter</a> into the main filter bundle.
-* <a href="https://repose.atlassian.net/browse/REP-5727">REP-5727</a> - Extracted trace ID logging to its own named logger.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5401">REP-5401</a> - Added support for environment variable substitution in configuration files.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6390">REP-6390</a> - Internal changes to the <a href="filters/keystone-v2.html">Keystone v2 Filter</a> in anticipation of splitting the authorization portion off into it&#8217;s own filter.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6400">REP-6400</a> - Added the new <a href="filters/keystone-v2-authorization.html">Keystone v2 Authorization Filter</a> which captures the authorization functionality of the <a href="filters/keystone-v2.html">Keystone v2 Filter</a>.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6382">REP-6382</a> - Lots of little versioned docs updates.</p>
+</li>
+</ul>
 </div>
-<div class="paragraph">
-<p>+</p>
 </div>
+</div>
+<div class="sect1">
+<h2 id="_8_7_3_0_2017_11_17"><a class="anchor" href="#_8_7_3_0_2017_11_17"></a>8.7.3.0 (2017-11-17)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6159">REP-6159</a> - Added the new <a href="filters/regex-rbac.html">RegEx Role Based Access Control (RBAC) Filter</a>.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6313">REP-6313</a> - Updated <a href="filters/keystone-v2.html">Keystone v2 Filter</a> to automatically ignore configured roles.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6338">REP-6338</a> <a href="https://repose.atlassian.net/browse/REP-6325">REP-6325</a> <a href="https://repose.atlassian.net/browse/REP-6321">REP-6321</a> - Multiple  documentation improvements.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_7_2_0_2017_11_01"><a class="anchor" href="#_8_7_2_0_2017_11_01"></a>8.7.2.0 (2017-11-01)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6294">REP-6294</a> - Updated dependencies:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Attribute Mapper: 2.1.1 → 2.2.0</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/rackerlabs/attributeMapping/blob/attribute-mapper-2.2.0/RELEASE.md">Attribute Mapper v2.2.0 release notes</a></p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_7_1_0_2017_10_25"><a class="anchor" href="#_8_7_1_0_2017_10_25"></a>8.7.1.0 (2017-10-25)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6133">REP-6133</a> - Updated the published Docker images to turn off local logging by default to be more in line with the expectations of a <a href="https://12factor.net/logs">Twelve-Factor App</a>.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6135">REP-6135</a> - Updated the published Docker images to support running the container using an arbitrarily assigned user ID as is expected by the <a href="https://docs.openshift.com/container-platform/3.6/creating_images/guidelines.html#openshift-container-platform-specific-guidelines">OpenShift Container Platform</a>.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6179">REP-6179</a> - Converted more old Wiki Docs over to the new <a href="http://www.openrepose.org/versions/latest/">Versioned Docs</a>.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6186">REP-6186</a> - Updated the automated Release Verification to force the use of Java 8 since some GNU/Linux distributions are already providing Java 9 by default.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6252">REP-6252</a>, <a href="https://repose.atlassian.net/browse/REP-6211">REP-6211</a> - Updated dependencies:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Gradle LinkChecker Plugin: 0.2.0 → 0.3.0</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/rackerlabs/gradle-linkchecker-plugin/blob/0.3.0/RELEASE.adoc">Gradle LinkChecker Plugin v0.3.0 release notes</a></p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>API Checker: 2.4.1 → 2.5.1</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/rackerlabs/api-checker/blob/api-checker-2.5.1/RELEASE.md">API Checker v2.5.1 release notes</a></p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>Attribute Mapper: 2.0.1 → 2.1.1</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/rackerlabs/attributeMapping/blob/attribute-mapper-2.1.1/RELEASE.md">Attribute Mapper v2.1.1 release notes</a></p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>Saxon: 9.7.0-15 → 9.8.0-4</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="http://www.saxonica.com/products/latest.xml">Saxon 9.8.0.4 release notes</a></p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_7_0_2_2017_10_04"><a class="anchor" href="#_8_7_0_2_2017_10_04"></a>8.7.0.2 (2017-10-04)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6162">REP-6162</a> - Updated the Keystone v2 get IDP call to support the field name change from <code>approvedDomains</code> to <code>approvedDomainIds</code>.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_7_0_1_2017_09_28"><a class="anchor" href="#_8_7_0_1_2017_09_28"></a>8.7.0.1 (2017-09-28)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6115">REP-6115</a> - Updated dependencies:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Attribute Mapper: 2.0.0 → 2.0.1</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/rackerlabs/attributeMapping/blob/attribute-mapper-2.0.1/RELEASE.md">Attribute Mapper v2.0.1 release notes</a></p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_7_0_0_2017_09_26"><a class="anchor" href="#_8_7_0_0_2017_09_26"></a>8.7.0.0 (2017-09-26)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5939">REP-5939</a> - Added support for, and began publishing, a CentOS-based Docker image.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5766">REP-5766</a> - Updated Dockerfile to run Repose as the <code>repose</code> user.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5767">REP-5767</a> - Updated Dockerfiles to simplify usage of <code>JAVA_OPTS</code>.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5985">REP-5985</a> - Updated the Jackson version from v2.4.0 to v2.8.9 to correct some library mismatch issues.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5315">REP-5315</a> - Updated Spring-managed bean names in JMX to be consistent with metric beans.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5885">REP-5885</a> - Fixed the bug where an <code>Error</code> during processing would result in a <code>200</code> response from Repose.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6050">REP-6050</a> - Update Contact Us page information across all the documentation.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5261">REP-5261</a> - Confirmed the Translation filter will allow 100,000 Entity Expansions and updated the documentation accordingly.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6098">REP-6098</a> - Updated the SAML Policy Translation filter to allow multiple locations for default values in an effort to support multiple Identity Providers (IDP&#8217;s).</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-6001">REP-6001</a> - Updated dependencies:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>API Checker: 2.3.0 → 2.4.1</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/rackerlabs/api-checker/blob/api-checker-2.4.1/RELEASE.md">API Checker v2.4.1 release notes</a></p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>Attribute Mapper: 1.3.0 → 2.0.0</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/rackerlabs/attributeMapping/blob/attribute-mapper-2.0.0/RELEASE.md">Attribute Mapper v2.0.0 release notes</a></p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5994">REP-5994</a> - Brought the <a href="filters/tenant-culling.html">Tenant Culling Filter</a> into the main filter bundle.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5727">REP-5727</a> - Extracted trace ID logging to its own named logger.</p>
 <div class="admonitionblock note">
 <table>
 <tr>
@@ -983,14 +1194,39 @@ If the <code>org.openrepose.powerfilter.PowerFilter.trace-id-logging</code> Logg
 </tr>
 </table>
 </div>
-<div class="paragraph">
-<p>== 8.6.3.0 (2017-08-15)
-* <a href="https://repose.atlassian.net/browse/REP-5737">REP-5737</a> - Updated the following filters to correct a typo that would prevent proper configuration schema validation.
-<strong> <a href="filters/ip-user.html">IP User Filter</a>
-</strong> <a href="filters/keystone-v2-basic-auth.html">Keystone v2 Basic Auth Filter</a>
-<strong> <a href="filters/openstack-identity-v3.html">Openstack Identity v3 Filter</a>
-</strong> <a href="filters/rackspace-auth-user.html">Rackspace Auth User Filter</a>
-** <a href="filters/saml-policy.html">SAML Policy Translation Filter</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_6_3_0_2017_08_15"><a class="anchor" href="#_8_6_3_0_2017_08_15"></a>8.6.3.0 (2017-08-15)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5737">REP-5737</a> - Updated the following filters to correct a typo that would prevent proper configuration schema validation.</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="filters/ip-user.html">IP User Filter</a></p>
+</li>
+<li>
+<p><a href="filters/keystone-v2-basic-auth.html">Keystone v2 Basic Auth Filter</a></p>
+</li>
+<li>
+<p><a href="filters/openstack-identity-v3.html">Openstack Identity v3 Filter</a></p>
+</li>
+<li>
+<p><a href="filters/rackspace-auth-user.html">Rackspace Auth User Filter</a></p>
+</li>
+<li>
+<p><a href="filters/saml-policy.html">SAML Policy Translation Filter</a></p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
 </div>
 <div class="admonitionblock important">
 <table>
@@ -1015,7 +1251,7 @@ If the <code>org.openrepose.powerfilter.PowerFilter.trace-id-logging</code> Logg
 <p><a href="https://repose.atlassian.net/browse/REP-5823">REP-5823</a> - Updated the <a href="filters/keystone-v2.html">Keystone v2 Filter</a> to support multiple <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Java Regular Expressions</a> for URI tenant extraction.</p>
 </li>
 <li>
-<p><a href="https://repose.atlassian.net/browse/REP-5853">REP-5853</a> - Updated the <a href="filters/saml-policy.html">SAML Policy Translation Filter</a> and <a href="filters/attribute-mapping-policy-validation.html">Attribute Mapping Policy Validation Filter</a> to recover support for XML and JSON (which was removed in <a href="#8.6.2.0 (2017-06-13)">[8.6.2.0 (2017-06-13)]</a>).</p>
+<p><a href="https://repose.atlassian.net/browse/REP-5853">REP-5853</a> - Updated the <a href="filters/saml-policy.html">SAML Policy Translation Filter</a> and <a href="filters/attribute-mapping-policy-validation.html">Attribute Mapping Policy Validation Filter</a> to recover support for XML and JSON (which was removed in <a href="#_8_6_2_0_2017_06_13">8.6.2.0 (2017-06-13)</a>).</p>
 </li>
 <li>
 <p><a href="https://repose.atlassian.net/browse/REP-5617">REP-5617</a> - Updated the the internal HTTP Servlet Response Wrapper to log a WARNING when addHeader, addIntHeader, addDateHeader, or appendHeader is called after the response has been committed.</p>
@@ -1061,42 +1297,106 @@ If the <code>org.openrepose.powerfilter.PowerFilter.trace-id-logging</code> Logg
 </li>
 </ul>
 </div>
-<div class="paragraph">
-<p>== 8.6.2.0 (2017-06-13)
-* <a href="https://repose.atlassian.net/browse/REP-5757">REP-5757</a> - Updated the <a href="filters/saml-policy.html">SAML Policy Translation Filter</a> to utilize YAML policy files.
-** Updated the <code>attribute-mapper</code> library from v1.1.1 to v1.2.0 to bring in the YAML updates made in <a href="https://repose.atlassian.net/browse/REP-5632">REP-5632</a>
-* <a href="https://repose.atlassian.net/browse/REP-5592">REP-5592</a> - Updated the <a href="filters/attribute-mapping-policy-validation.html">Attribute Mapping Policy Validation Filter</a> to only work for YAML bodies.
-* <a href="https://repose.atlassian.net/browse/REP-5694">REP-5694</a> - Updated the <a href="filters/valkyrie-authorization.html">Valkyrie Authorization Filter</a> versioned docs to point to the current Valkyrie service documentation.</p>
 </div>
-<div class="paragraph">
-<p>== 8.6.1.1 (2017-06-08)
-* <a href="https://repose.atlassian.net/browse/REP-5520">REP-5520</a> - Updated the <a href="filters/keystone-v2.html">Keystone v2 Filter</a> to provide the token cache key, and to generally handle <code>401</code> - <em>Unauthroized</em> responses.
-* <a href="https://repose.atlassian.net/browse/REP-5347">REP-5347</a> - Updated the Attribute Mapping library from v1.0.2 to v1.1.1.
-* <a href="https://repose.atlassian.net/browse/REP-5595">REP-5595</a> - Updated the <a href="filters/attribute-mapping-policy-validation.html">Attribute Mapping Policy Validation Filter</a> to utilize new Attribute Mapping library features for cleaner JSON validation.</p>
 </div>
-<div class="paragraph">
-<p>== 8.6.0.0 (2017-06-02)
-* <a href="https://repose.atlassian.net/browse/REP-5234">REP-5234</a> - Added the new <a href="services/datastores.html#_remote_datastore">Remote Datastore service</a> which allows the Distributed Datastore service concept to work in dynamic containerized environments like OpenShift.
-* <a href="https://repose.atlassian.net/browse/REP-5343">REP-5343</a> - Updated the Keystone v2 Filter to support the new Apply RCN Roles feature of Rackspace Keystone v2 Identity.
-Converted the <a href="https://repose.atlassian.net/wiki/display/REPOSE/Keystone+v2+filter">old Keystone v2 Filter documentation</a> over to the <a href="filters/keystone-v2.html">new versioned docs</a>.
-* <a href="https://repose.atlassian.net/browse/REP-5345">REP-5345</a> - The <a href="filters/attribute-mapping-policy-validation.html">Attribute Mapping Policy Validation Filter</a> has been released!
-* <a href="https://repose.atlassian.net/browse/REP-5523">REP-5523</a> - The <a href="recipes/functional-test-framework.html">Repose Functional Test Framework</a> has been released!
-* <a href="https://repose.atlassian.net/browse/REP-5221">REP-5221</a> - Updated the API Checker library from v2.1.1 to v2.2.1.
-** This brings the bulk metadata feature to the <a href="filters/api-validator.html">API Validator filter</a>.</p>
+<div class="sect1">
+<h2 id="_8_6_2_0_2017_06_13"><a class="anchor" href="#_8_6_2_0_2017_06_13"></a>8.6.2.0 (2017-06-13)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5757">REP-5757</a> - Updated the <a href="filters/saml-policy.html">SAML Policy Translation Filter</a> to utilize YAML policy files.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Updated the <code>attribute-mapper</code> library from v1.1.1 to v1.2.0 to bring in the YAML updates made in <a href="https://repose.atlassian.net/browse/REP-5632">REP-5632</a></p>
+</li>
+</ul>
 </div>
-<div class="paragraph">
-<p>== 8.5.0.1 (2017-04-14)
-* <a href="https://repose.atlassian.net/browse/REP-4024">REP-4024</a> - The <a href="filters/header-normalization.html">Header Normalization Filter</a> updated to include removing headers on the Response.
-* <a href="https://repose.atlassian.net/browse/REP-3901">REP-3901</a> - The Debian and RPM Repose Valve and WAR artifacts will now create the <code>repose</code> user and group even if the configuration files are already present.
-* <a href="https://repose.atlassian.net/browse/REP-5130">REP-5130</a> - <a href="filters/rackspace-auth-user.html">Rackspace Auth User Filter</a> now gives a more specific and quieter log message when it runs into a non-xml or non-json content type.
-* <a href="https://repose.atlassian.net/browse/REP-4754">REP-4754</a> - The <a href="filters/rate-limiting.html">Rate Limiting Filter</a> now returns a 406 if a user requests limits with an unsupported media type in the <code>Accept</code> header.
-* <a href="https://repose.atlassian.net/browse/REP-4725">REP-4725</a> - Repose will no longer add a <code>Server</code> header to responses from neither the main endpoint nor the Dist-Datastore endpoint.
-* <a href="https://repose.atlassian.net/browse/REP-5204">REP-5204</a> - The <a href="services/metrics.html">Metrics Service</a> library has been updated from Yammer v2.2.0 to Dropwizard v3.2.0.
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5592">REP-5592</a> - Updated the <a href="filters/attribute-mapping-policy-validation.html">Attribute Mapping Policy Validation Filter</a> to only work for YAML bodies.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5694">REP-5694</a> - Updated the <a href="filters/valkyrie-authorization.html">Valkyrie Authorization Filter</a> versioned docs to point to the current Valkyrie service documentation.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_6_1_1_2017_06_08"><a class="anchor" href="#_8_6_1_1_2017_06_08"></a>8.6.1.1 (2017-06-08)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5520">REP-5520</a> - Updated the <a href="filters/keystone-v2.html">Keystone v2 Filter</a> to provide the token cache key, and to generally handle <code>401</code> - <em>Unauthroized</em> responses.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5347">REP-5347</a> - Updated the Attribute Mapping library from v1.0.2 to v1.1.1.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5595">REP-5595</a> - Updated the <a href="filters/attribute-mapping-policy-validation.html">Attribute Mapping Policy Validation Filter</a> to utilize new Attribute Mapping library features for cleaner JSON validation.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_6_0_0_2017_06_02"><a class="anchor" href="#_8_6_0_0_2017_06_02"></a>8.6.0.0 (2017-06-02)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5234">REP-5234</a> - Added the new <a href="services/datastores.html#_remote_datastore">Remote Datastore service</a> which allows the Distributed Datastore service concept to work in dynamic containerized environments like OpenShift.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5343">REP-5343</a> - Updated the Keystone v2 Filter to support the new Apply RCN Roles feature of Rackspace Keystone v2 Identity.
+Converted the <a href="https://repose.atlassian.net/wiki/display/REPOSE/Keystone+v2+filter">old Keystone v2 Filter documentation</a> over to the <a href="filters/keystone-v2.html">new versioned docs</a>.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5345">REP-5345</a> - The <a href="filters/attribute-mapping-policy-validation.html">Attribute Mapping Policy Validation Filter</a> has been released!</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5523">REP-5523</a> - The <a href="recipes/functional-test-framework.html">Repose Functional Test Framework</a> has been released!</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5221">REP-5221</a> - Updated the API Checker library from v2.1.1 to v2.2.1.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>This brings the bulk metadata feature to the <a href="filters/api-validator.html">API Validator filter</a>.</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_5_0_1_2017_04_14"><a class="anchor" href="#_8_5_0_1_2017_04_14"></a>8.5.0.1 (2017-04-14)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4024">REP-4024</a> - The <a href="filters/header-normalization.html">Header Normalization Filter</a> updated to include removing headers on the Response.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-3901">REP-3901</a> - The Debian and RPM Repose Valve and WAR artifacts will now create the <code>repose</code> user and group even if the configuration files are already present.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5130">REP-5130</a> - <a href="filters/rackspace-auth-user.html">Rackspace Auth User Filter</a> now gives a more specific and quieter log message when it runs into a non-xml or non-json content type.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4754">REP-4754</a> - The <a href="filters/rate-limiting.html">Rate Limiting Filter</a> now returns a 406 if a user requests limits with an unsupported media type in the <code>Accept</code> header.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4725">REP-4725</a> - Repose will no longer add a <code>Server</code> header to responses from neither the main endpoint nor the Dist-Datastore endpoint.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5204">REP-5204</a> - The <a href="services/metrics.html">Metrics Service</a> library has been updated from Yammer v2.2.0 to Dropwizard v3.2.0.
 The service interface has also been modified to provide a simpler, more flexible experience.</p>
-</div>
-<div class="paragraph">
-<p>+</p>
-</div>
 <div class="admonitionblock important">
 <table>
 <tr>
@@ -1114,8 +1414,7 @@ See <a href="services/metrics.html">Metrics Service</a> for details on the metri
 </tr>
 </table>
 </div>
-<div class="ulist">
-<ul>
+</li>
 <li>
 <p><a href="https://repose.atlassian.net/browse/REP-5214">REP-5214</a> - The <code>Via</code> header configuration has been expanded in a backwards compatible way.
 However, there were some internal contract changes with the Via and Location header builders, but they should not affect any custom filters.</p>
@@ -1125,36 +1424,92 @@ However, there were some internal contract changes with the Via and Location hea
 </li>
 </ul>
 </div>
-<div class="paragraph">
-<p>== 8.4.1.0 (2017-02-24)
-* <a href="https://repose.atlassian.net/browse/REP-5101">REP-5101</a> - <a href="filters/saml-policy.html">SAML Policy Translation Filter</a> now allows un-encoded <code>application/xml</code> requests in addition to the previous <code>application/x-www-form-urlencoded</code> requests.</p>
-</div>
-<div class="paragraph">
-<p>== 8.4.0.2 (2017-02-21)
-* <a href="https://repose.atlassian.net/browse/REP-5100">REP-5100</a> - <a href="filters/rate-limiting.html">Rate Limiting Filter</a> was mistakenly getting the full parameter map, and not just the query parameters.
-* <a href="https://repose.atlassian.net/browse/REP-5071">REP-5071</a> - Repose is now using Attribute Mapping v1.0.2.</p>
-</div>
-<div class="paragraph">
-<p>== 8.4.0.1 (2017-02-04)
-* <a href="https://repose.atlassian.net/browse/REP-4795">REP-4795</a> <a href="https://repose.atlassian.net/browse/REP-4831">REP-4831</a> - the <a href="filters/saml-policy.html">SAML Policy Translation Filter</a> has been released!
-* <a href="https://repose.atlassian.net/browse/REP-4653">REP-4653</a> - The <a href="filters/rackspace-auth-user.html">Rackspace Auth User Filter</a> updated to read request body of Forgot Password request to get the username and the <a href="filters/herp.html">Highly Efficient Record Processor (HERP) Filter</a> was updated to get <code>X-User-Name</code> from response headers.
-* <a href="https://repose.atlassian.net/browse/REP-4928">REP-4928</a> - The <a href="filters/keystone-v2.html">Keystone v2 Filter</a> will now return a 401 if self-validating tokens are being used and the Identity service responds with a 401.
-* <a href="https://repose.atlassian.net/browse/REP-4841">REP-4841</a> - A more unique ID will be used for User Access Events (UAE) in support of Cloud Auditing Data Federation (CADF).
-* <a href="https://repose.atlassian.net/browse/REP-4867">REP-4867</a> - The <a href="filters/valkyrie-authorization.html">Valkyrie Authorization Filter</a> now supports multiple Character Encoding schemes.
-* <a href="https://repose.atlassian.net/browse/REP-4954">REP-4954</a> - Added support for Form Encoded requests (<code>Content-Type: application/x-www-form-urlencoded</code>).
-* <a href="https://repose.atlassian.net/browse/REP-4880">REP-4880</a> - Internal utility classes JCharSequence and MessageDigester were removed.
-* <a href="https://repose.atlassian.net/browse/REP-4892">REP-4892</a> - Versioned searching of these docs has been fixed.
-* <a href="https://repose.atlassian.net/browse/REP-4999">REP-4999</a> - Leading and trailing whitespace in directory values in the container.cfg.xml file are now ignored.</p>
-</div>
-<div class="paragraph">
-<p>== 8.3.0.1 (2016-12-13)
-* <a href="https://repose.atlassian.net/browse/REP-4764">REP-4764</a> - <code>sendError</code> in the response wrapper will now call <code>sendError</code> on the underlying response when appropriate.</p>
-</div>
-<div class="paragraph">
-<p>== Prior Releases
-* <a href="https://repose.atlassian.net/wiki/display/REPOSE/Repose+Release+Notes">Legacy Release Notes</a></p>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_8_4_1_0_2017_02_24"><a class="anchor" href="#_8_4_1_0_2017_02_24"></a>8.4.1.0 (2017-02-24)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5101">REP-5101</a> - <a href="filters/saml-policy.html">SAML Policy Translation Filter</a> now allows un-encoded <code>application/xml</code> requests in addition to the previous <code>application/x-www-form-urlencoded</code> requests.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_4_0_2_2017_02_21"><a class="anchor" href="#_8_4_0_2_2017_02_21"></a>8.4.0.2 (2017-02-21)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5100">REP-5100</a> - <a href="filters/rate-limiting.html">Rate Limiting Filter</a> was mistakenly getting the full parameter map, and not just the query parameters.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-5071">REP-5071</a> - Repose is now using Attribute Mapping v1.0.2.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_4_0_1_2017_02_04"><a class="anchor" href="#_8_4_0_1_2017_02_04"></a>8.4.0.1 (2017-02-04)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4795">REP-4795</a> <a href="https://repose.atlassian.net/browse/REP-4831">REP-4831</a> - the <a href="filters/saml-policy.html">SAML Policy Translation Filter</a> has been released!</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4653">REP-4653</a> - The <a href="filters/rackspace-auth-user.html">Rackspace Auth User Filter</a> updated to read request body of Forgot Password request to get the username and the <a href="filters/herp.html">Highly Efficient Record Processor (HERP) Filter</a> was updated to get <code>X-User-Name</code> from response headers.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4928">REP-4928</a> - The <a href="filters/keystone-v2.html">Keystone v2 Filter</a> will now return a 401 if self-validating tokens are being used and the Identity service responds with a 401.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4841">REP-4841</a> - A more unique ID will be used for User Access Events (UAE) in support of Cloud Auditing Data Federation (CADF).</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4867">REP-4867</a> - The <a href="filters/valkyrie-authorization.html">Valkyrie Authorization Filter</a> now supports multiple Character Encoding schemes.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4954">REP-4954</a> - Added support for Form Encoded requests (<code>Content-Type: application/x-www-form-urlencoded</code>).</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4880">REP-4880</a> - Internal utility classes JCharSequence and MessageDigester were removed.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4892">REP-4892</a> - Versioned searching of these docs has been fixed.</p>
+</li>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4999">REP-4999</a> - Leading and trailing whitespace in directory values in the container.cfg.xml file are now ignored.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_8_3_0_1_2016_12_13"><a class="anchor" href="#_8_3_0_1_2016_12_13"></a>8.3.0.1 (2016-12-13)</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/browse/REP-4764">REP-4764</a> - <code>sendError</code> in the response wrapper will now call <code>sendError</code> on the underlying response when appropriate.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_prior_releases"><a class="anchor" href="#_prior_releases"></a>Prior Releases</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://repose.atlassian.net/wiki/display/REPOSE/Repose+Release+Notes">Legacy Release Notes</a></p>
+</li>
+</ul>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Release notes for 8.8.1.0 are currently really messed up.
http://www.openrepose.org/versions/8.8.1.0/release-notes.html

I fixed the asciidoc locally (which will be in another PR), generated the HTML, and copied the file over this one (minus the version number and "last updated" date in the footer).
