### PR TITLE
Fixing 8.8.1.0 release notes formatting

### DIFF
--- a/repose-aggregator/src/docs/asciidoc/release-notes.adoc
+++ b/repose-aggregator/src/docs/asciidoc/release-notes.adoc
@@ -3,7 +3,6 @@
 == 8.8.1.0 (2018-02-15)
 * https://repose.atlassian.net/browse/REP-6447[REP-6447] - Added multi-tenant support in the <<filters/keystone-v2.adoc#, Keystone v2>> and <<filters/keystone-v2-authorization.adoc#, Keystone v2 Authorization>> filters.
 * https://repose.atlassian.net/browse/REP-6578[REP-6578] - Updated <<filters/tenant-culling#, Tenant Culling>> filter to utilize the tenant to roles map now being populated by the <<filters/keystone-v2.adoc#, Keystone v2>> filter.
-=======
 * https://repose.atlassian.net/browse/REP-6470[REP-6470] - Updated dependencies:
 ** API Checker: 2.5.1 → 2.6.0
 *** https://github.com/rackerlabs/api-checker/blob/api-checker-2.6.0/RELEASE.md[API Checker v2.6.0 release notes]


### PR DESCRIPTION
Removed extraneous line that's messing up the formatting of the release notes.