### PR TITLE
REP-6674 Switching from LazyLogging to StrictLogging

### DIFF
--- a/repose-aggregator/artifacts/valve/src/main/scala/org/openrepose/valve/spring/ValveRunner.scala
+++ b/repose-aggregator/artifacts/valve/src/main/scala/org/openrepose/valve/spring/ValveRunner.scala
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference
 import javax.inject.{Inject, Named}
 import javax.management.{InstanceNotFoundException, ObjectName}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.core.container.config.ContainerConfiguration
 import org.openrepose.core.services.config.ConfigurationService
@@ -44,7 +44,7 @@ import org.springframework.beans.factory.DisposableBean
 @Named
 class ValveRunner @Inject()(
                              configService: ConfigurationService
-                             ) extends DisposableBean with LazyLogging {
+                             ) extends DisposableBean with StrictLogging {
 
   private val systemModelXsdURL = getClass.getResource("/META-INF/schema/system-model/system-model.xsd")
   private val containerXsdUrl = getClass.getResource("/META-INF/schema/container/container-configuration.xsd")

--- a/repose-aggregator/artifacts/valve/src/test/scala/org/openrepose/valve/spring/ValveTestModeRunnerTest.scala
+++ b/repose-aggregator/artifacts/valve/src/test/scala/org/openrepose/valve/spring/ValveTestModeRunnerTest.scala
@@ -22,7 +22,7 @@ package org.openrepose.valve.spring
 import java.lang.management.ManagementFactory
 import javax.management.{JMX, ObjectName}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.junit.runner.RunWith
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.core.container.config.ContainerConfiguration
@@ -39,7 +39,7 @@ import scala.concurrent.{Await, Future}
 
 
 @RunWith(classOf[JUnitRunner])
-class ValveTestModeRunnerTest extends FunSpec with Matchers with LazyLogging with Eventually {
+class ValveTestModeRunnerTest extends FunSpec with Matchers with StrictLogging with Eventually {
   val log = LoggerFactory.getLogger(this.getClass)
 
   val fakeConfigService = new FakeConfigService()

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/jmx/JmxObjectNameFactory.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/jmx/JmxObjectNameFactory.scala
@@ -22,14 +22,14 @@ package org.openrepose.commons.utils.jmx
 import java.util
 import javax.management.{MalformedObjectNameException, ObjectName}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 
 import scala.util.Try
 
 /**
   * A standard utility to generate [[ObjectName]] instances.
   */
-object JmxObjectNameFactory extends LazyLogging {
+object JmxObjectNameFactory extends StrictLogging {
   private val NameKey = "name"
   private val KeySegmentDelimiter = "\\."
   private val KeyFormat = "%03d"

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/logging/TracingHeaderHelper.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/logging/TracingHeaderHelper.scala
@@ -26,13 +26,13 @@ import java.util
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.commons.codec.binary.Base64
 import org.slf4j.MDC
 
 import scala.collection.JavaConverters._
 
-object TracingHeaderHelper extends LazyLogging {
+object TracingHeaderHelper extends StrictLogging {
 
   // JSON parsing
   private val ObjectMapper = new ObjectMapper(new JsonFactory)

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/opentracing/HttpRequestCarrier.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/opentracing/HttpRequestCarrier.scala
@@ -21,14 +21,13 @@ package org.openrepose.commons.utils.opentracing
 
 import java.util
 
-import com.typesafe.scalalogging.slf4j.StrictLogging
 import io.opentracing.propagation.TextMap
 import javax.servlet.http.HttpServletRequest
 
 import scala.Function.tupled
 import scala.collection.JavaConverters._
 
-class HttpRequestCarrier(httpServletRequest: HttpServletRequest) extends TextMap with StrictLogging {
+class HttpRequestCarrier(httpServletRequest: HttpServletRequest) extends TextMap {
 
   val headers: Map[String, List[String]] = Option(httpServletRequest).map(request =>
     request.getHeaderNames.asScala

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/opentracing/HttpRequestCarrier.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/opentracing/HttpRequestCarrier.scala
@@ -21,14 +21,14 @@ package org.openrepose.commons.utils.opentracing
 
 import java.util
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import io.opentracing.propagation.TextMap
 import javax.servlet.http.HttpServletRequest
 
 import scala.Function.tupled
 import scala.collection.JavaConverters._
 
-class HttpRequestCarrier(httpServletRequest: HttpServletRequest) extends TextMap with LazyLogging {
+class HttpRequestCarrier(httpServletRequest: HttpServletRequest) extends TextMap with StrictLogging {
 
   val headers: Map[String, List[String]] = Option(httpServletRequest).map(request =>
     request.getHeaderNames.asScala

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletResponseWrapper.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/HttpServletResponseWrapper.scala
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse
 import javax.servlet.{ServletOutputStream, ServletResponse}
 import javax.ws.rs.core.HttpHeaders
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.http.client.utils.DateUtils
 import org.slf4j.LoggerFactory
 
@@ -81,7 +81,7 @@ class HttpServletResponseWrapper(originalResponse: HttpServletResponse,
                                  desiredOutputStream: ServletOutputStream)
   extends javax.servlet.http.HttpServletResponseWrapper(originalResponse)
     with HeaderInteractor
-    with LazyLogging {
+    with StrictLogging {
 
   private val headerWarningLogger = LoggerFactory.getLogger(s"${classOf[HttpServletResponseWrapper].getName}.headerWarning")
 

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/MutableServletOutputStream.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/MutableServletOutputStream.scala
@@ -20,14 +20,14 @@
 package org.openrepose.commons.utils.servlet.http
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
-import javax.servlet.ServletOutputStream
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import javax.servlet.ServletOutputStream
 import org.apache.commons.io.IOUtils
 
 class MutableServletOutputStream(servletOutputStream: ServletOutputStream)
   extends ExtendedServletOutputStream
-    with LazyLogging {
+    with StrictLogging {
 
   private val byteArrayOutputStream = new ByteArrayOutputStream()
 

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/PassthroughServletOutputStream.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/PassthroughServletOutputStream.scala
@@ -20,13 +20,13 @@
 package org.openrepose.commons.utils.servlet.http
 
 import java.io.InputStream
-import javax.servlet.ServletOutputStream
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import javax.servlet.ServletOutputStream
 
 class PassthroughServletOutputStream(servletOutputStream: ServletOutputStream)
   extends ExtendedServletOutputStream
-    with LazyLogging  {
+    with StrictLogging {
 
   override def write(b: Int): Unit = servletOutputStream.write(b)
 

--- a/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/ReadOnlyServletOutputStream.scala
+++ b/repose-aggregator/commons/commons-utilities/src/main/scala/org/openrepose/commons/utils/servlet/http/ReadOnlyServletOutputStream.scala
@@ -20,13 +20,13 @@
 package org.openrepose.commons.utils.servlet.http
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
-import javax.servlet.ServletOutputStream
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
+import javax.servlet.ServletOutputStream
 
 class ReadOnlyServletOutputStream(servletOutputStream: ServletOutputStream)
   extends ExtendedServletOutputStream
-    with LazyLogging {
+    with StrictLogging {
 
   private val byteArrayOutputStream = new ByteArrayOutputStream()
 

--- a/repose-aggregator/components/filters/add-header-filter/src/main/scala/org/openrepose/filters/addheader/AddHeaderFilter.scala
+++ b/repose-aggregator/components/filters/add-header-filter/src/main/scala/org/openrepose/filters/addheader/AddHeaderFilter.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletResponse, HttpServletRequest}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.servlet.http.ResponseMode._
 import org.openrepose.commons.utils.servlet.http.{HeaderInteractor, HttpServletResponseWrapper, HttpServletRequestWrapper}
@@ -35,7 +35,7 @@ import scala.collection.JavaConverters._
 
 @Named
 class AddHeaderFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[AddHeadersConfig] with LazyLogging {
+  extends Filter with UpdateListener[AddHeadersConfig] with StrictLogging {
 
   import AddHeaderFilter._
 

--- a/repose-aggregator/components/filters/attribute-mapping-policy-validation-filter/src/main/scala/org/openrepose/filters/attributemapping/AttributeMappingPolicyValidationFilter.scala
+++ b/repose-aggregator/components/filters/attribute-mapping-policy-validation-filter/src/main/scala/org/openrepose/filters/attributemapping/AttributeMappingPolicyValidationFilter.scala
@@ -29,7 +29,7 @@ import javax.xml.transform.stream.StreamSource
 
 import com.fasterxml.jackson.core.{JsonParseException, JsonProcessingException}
 import com.rackspace.identity.components.{AttributeMapper, XSDEngine}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import net.sf.saxon.s9api.SaxonApiException
 import org.apache.commons.io.input.CloseShieldInputStream
 import org.openrepose.commons.utils.io.stream.ServletInputStreamWrapper
@@ -38,7 +38,7 @@ import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 import scala.util.{Failure, Success, Try}
 
 @Named
-class AttributeMappingPolicyValidationFilter extends Filter with LazyLogging {
+class AttributeMappingPolicyValidationFilter extends Filter with StrictLogging {
 
   import AttributeMappingPolicyValidationFilter._
 

--- a/repose-aggregator/components/filters/body-patcher-filter/src/main/scala/org/openrepose/filters/bodypatcher/BodyPatcherFilter.scala
+++ b/repose-aggregator/components/filters/body-patcher-filter/src/main/scala/org/openrepose/filters/bodypatcher/BodyPatcherFilter.scala
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import com.fasterxml.jackson.core.JsonParseException
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import gnieh.diffson.playJson._
 import org.openrepose.commons.utils.io.stream.ServletInputStreamWrapper
 import org.openrepose.commons.utils.servlet.http.ResponseMode.{MUTABLE, PASSTHROUGH}
@@ -48,7 +48,7 @@ import scala.util.{Failure, Success, Try}
   */
 @Named
 class BodyPatcherFilter @Inject()(configurationService: ConfigurationService)
-  extends AbstractConfiguredFilter[BodyPatcherConfig](configurationService) with RegexStringOperators with LazyLogging {
+  extends AbstractConfiguredFilter[BodyPatcherConfig](configurationService) with RegexStringOperators with StrictLogging {
   import BodyPatcherFilter._
 
   override val DEFAULT_CONFIG: String = "body-patcher.cfg.xml"

--- a/repose-aggregator/components/filters/compression-filter/src/main/scala/org/openrepose/filters/compression/CompressionFilter.scala
+++ b/repose-aggregator/components/filters/compression-filter/src/main/scala/org/openrepose/filters/compression/CompressionFilter.scala
@@ -26,7 +26,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.HttpServletResponse
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.core.filter.FilterConfigHelper
 import org.openrepose.core.services.config.ConfigurationService
@@ -40,7 +40,7 @@ import scala.util.{Failure, Success, Try}
 
 @Named
 class CompressionFilter @Inject()(configurationService: ConfigurationService, compressingFilterFactory: CompressingFilterFactory)
-  extends Filter with UpdateListener[ContentCompressionConfig] with LazyLogging {
+  extends Filter with UpdateListener[ContentCompressionConfig] with StrictLogging {
 
   import CompressionFilter._
   import CompressionParameters._

--- a/repose-aggregator/components/filters/cors-filter/src/main/scala/org/openrepose/filters/cors/CorsFilter.scala
+++ b/repose-aggregator/components/filters/cors-filter/src/main/scala/org/openrepose/filters/cors/CorsFilter.scala
@@ -28,7 +28,7 @@ import javax.ws.rs.HttpMethod
 import javax.ws.rs.core.{HttpHeaders, MediaType}
 
 import com.google.common.net.InetAddresses
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.http.client.utils.URIBuilder
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.{CommonHttpHeader, CorsHttpHeader}
@@ -44,7 +44,7 @@ import scala.util.{Failure, Success, Try}
 
 @Named
 class CorsFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[CorsConfig] with LazyLogging {
+  extends Filter with UpdateListener[CorsConfig] with StrictLogging {
 
   import CorsFilter._
 

--- a/repose-aggregator/components/filters/derp-filter/src/main/scala/org/openrepose/filters/derp/DerpFilter.scala
+++ b/repose-aggregator/components/filters/derp-filter/src/main/scala/org/openrepose/filters/derp/DerpFilter.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.ws.rs.core.MediaType
 
 import com.rackspace.httpdelegation._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success}
@@ -36,7 +36,7 @@ import scala.util.{Failure, Success}
  * This filter is header quality aware; the delegation header with the highest quality will be used to formulate a
  * response.
  */
-class DerpFilter extends Filter with HttpDelegationManager with LazyLogging {
+class DerpFilter extends Filter with HttpDelegationManager with StrictLogging {
 
   override def init(filterConfig: FilterConfig): Unit = {
     logger.trace("DeRP filter initialized")

--- a/repose-aggregator/components/filters/destination-router-filter/src/main/scala/org/openrepose/filters/destinationrouter/DestinationRouterFilter.scala
+++ b/repose-aggregator/components/filters/destination-router-filter/src/main/scala/org/openrepose/filters/destinationrouter/DestinationRouterFilter.scala
@@ -26,7 +26,7 @@ import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import com.codahale.metrics.MetricRegistry
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.CommonRequestAttributes
 import org.openrepose.commons.utils.servlet.http.RouteDestination
@@ -37,7 +37,7 @@ import org.openrepose.filters.routing.servlet.config.DestinationRouterConfigurat
 
 @Named
 class DestinationRouterFilter @Inject()(configurationService: ConfigurationService, optMetricsService: Optional[MetricsService])
-  extends Filter with UpdateListener[DestinationRouterConfiguration] with LazyLogging {
+  extends Filter with UpdateListener[DestinationRouterConfiguration] with StrictLogging {
 
   private final val DefaultConfigFileName = "destination-router.cfg.xml"
   private final val SchemaFilePath = "/META-INF/schema/config/destination-router-configuration.xsd"

--- a/repose-aggregator/components/filters/forwarded-proto-filter/src/main/scala/org/openrepose/filters/forwardedproto/ForwardedProtoFilter.scala
+++ b/repose-aggregator/components/filters/forwarded-proto-filter/src/main/scala/org/openrepose/filters/forwardedproto/ForwardedProtoFilter.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,14 +22,14 @@ package org.openrepose.filters.forwardedproto
 import javax.servlet._
 import javax.servlet.http.HttpServletRequest
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 
 /**
  * The sole purpose of this filter is to add the X-Forwarded-Proto header to a request with a value which
  * corresponds to the protocol of the request (e.g. http or https).
  */
-class ForwardedProtoFilter extends Filter with LazyLogging {
+class ForwardedProtoFilter extends Filter with StrictLogging {
 
   private final val X_FORWARDED_PROTO = "X-Forwarded-Proto"
 

--- a/repose-aggregator/components/filters/header-normalization-filter/src/main/scala/org/openrepose/filters/headernormalization/HeaderNormalizationFilter.scala
+++ b/repose-aggregator/components/filters/header-normalization-filter/src/main/scala/org/openrepose/filters/headernormalization/HeaderNormalizationFilter.scala
@@ -26,7 +26,7 @@ import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import com.codahale.metrics.MetricRegistry
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.servlet.http.ResponseMode.{MUTABLE, PASSTHROUGH}
 import org.openrepose.commons.utils.servlet.http.{HttpServletRequestWrapper, HttpServletResponseWrapper}
@@ -41,7 +41,7 @@ import scala.collection.JavaConverters._
 
 @Named
 class HeaderNormalizationFilter @Inject()(configurationService: ConfigurationService, optMetricsService: Optional[MetricsService])
-  extends Filter with UpdateListener[HeaderNormalizationConfig] with LazyLogging {
+  extends Filter with UpdateListener[HeaderNormalizationConfig] with StrictLogging {
 
   private final val NormalizationMetricPrefix = MetricRegistry.name(classOf[HeaderNormalizationFilter], "Normalization")
   private final val RequestNormalizationMetricPrefix = MetricRegistry.name(NormalizationMetricPrefix, "request")

--- a/repose-aggregator/components/filters/header-translation-filter/src/main/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilter.scala
+++ b/repose-aggregator/components/filters/header-translation-filter/src/main/scala/org/openrepose/filters/headertranslation/HeaderTranslationFilter.scala
@@ -23,7 +23,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 import org.openrepose.core.filter.FilterConfigHelper
@@ -34,7 +34,7 @@ import scala.collection.JavaConversions._
 
 @Named
 class HeaderTranslationFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[HeaderTranslationType] with LazyLogging {
+  extends Filter with UpdateListener[HeaderTranslationType] with StrictLogging {
 
   import HeaderTranslationFilter._
 

--- a/repose-aggregator/components/filters/header-user-filter/src/main/scala/org/openrepose/filters/headeruser/HeaderUserFilter.scala
+++ b/repose-aggregator/components/filters/header-user-filter/src/main/scala/org/openrepose/filters/headeruser/HeaderUserFilter.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ package org.openrepose.filters.headeruser
 import java.util.concurrent.atomic.AtomicReference
 import javax.servlet.http.{HttpServletResponse, HttpServletRequest}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.PowerApiHeader
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
@@ -39,7 +39,7 @@ import collection.JavaConversions._
 
 @Named
 class HeaderUserFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[HeaderUserConfig] with LazyLogging {
+  extends Filter with UpdateListener[HeaderUserConfig] with StrictLogging {
 
   import HeaderUserFilter._
 

--- a/repose-aggregator/components/filters/herp-filter/src/main/scala/org/openrepose/filters/herp/HerpFilter.scala
+++ b/repose-aggregator/components/filters/herp-filter/src/main/scala/org/openrepose/filters/herp/HerpFilter.scala
@@ -30,7 +30,7 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import com.github.jknack.handlebars.{Handlebars, Helper, Options, Template}
 import com.rackspace.httpdelegation._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.http.HttpHeaders
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.{CommonHttpHeader, OpenStackServiceHeader}
@@ -53,7 +53,7 @@ import scala.util.matching.Regex
 class HerpFilter @Inject()(configurationService: ConfigurationService,
                            @Value(ReposeSpringProperties.NODE.CLUSTER_ID) clusterId: String,
                            @Value(ReposeSpringProperties.NODE.NODE_ID) nodeId: String)
-  extends Filter with HttpDelegationManager with UpdateListener[HerpConfig] with LazyLogging {
+  extends Filter with HttpDelegationManager with UpdateListener[HerpConfig] with StrictLogging {
   private final val DEFAULT_CONFIG = "highly-efficient-record-processor.cfg.xml"
   private final val X_PROJECT_ID = "X-Project-ID"
   private final val X_METHOD_LABEL: String = "X-METHOD-LABEL"

--- a/repose-aggregator/components/filters/ip-user-filter/src/main/scala/org/openrepose/filters/ipuser/IpUserFilter.scala
+++ b/repose-aggregator/components/filters/ip-user-filter/src/main/scala/org/openrepose/filters/ipuser/IpUserFilter.scala
@@ -25,7 +25,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import edazdarevic.commons.net.CIDRUtils
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.CommonHttpHeader
@@ -36,13 +36,13 @@ import org.openrepose.filters.ipuser.config.IpUserConfig
 
 @Named
 class IpUserFilter @Inject()(configurationService: ConfigurationService) extends Filter
-  with LazyLogging
+  with StrictLogging
   with UpdateListener[IpUserConfig] {
 
   private final val DEFAULT_CONFIG = "ip-user.cfg.xml"
 
   private val cidrList: AtomicReference[List[LabeledCIDR]] = new AtomicReference[List[LabeledCIDR]]()
-  
+
   private var initialized = false
   private var configName: String = _
   private var groupHeaderName: String = _

--- a/repose-aggregator/components/filters/iri-validator-filter/src/main/scala/org/openrepose/filters/irivalidator/IriValidatorFilter.scala
+++ b/repose-aggregator/components/filters/iri-validator-filter/src/main/scala/org/openrepose/filters/irivalidator/IriValidatorFilter.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,13 +22,13 @@ package org.openrepose.filters.irivalidator
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.jena.iri.{IRIException, IRIFactory}
 
 /**
  * This filter validates that the request URI is a valid IRI.
  */
-class IriValidatorFilter extends Filter with LazyLogging {
+class IriValidatorFilter extends Filter with StrictLogging {
 
   override def init(filterConfig: FilterConfig): Unit = {
     logger.trace("IRI validator filter initialized")

--- a/repose-aggregator/components/filters/keystone-v2-basic-auth-filter/src/main/scala/org/openrepose/filters/keystonev2basicauth/KeystoneV2BasicAuthFilter.scala
+++ b/repose-aggregator/components/filters/keystone-v2-basic-auth-filter/src/main/scala/org/openrepose/filters/keystonev2basicauth/KeystoneV2BasicAuthFilter.scala
@@ -28,7 +28,7 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.ws.rs.core.MediaType
 
 import com.rackspace.httpdelegation.HttpDelegationManager
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.commons.lang3.StringUtils
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.{CommonHttpHeader, HttpDate}
@@ -53,7 +53,7 @@ class KeystoneV2BasicAuthFilter @Inject()(configurationService: ConfigurationSer
     with UpdateListener[KeystoneV2BasicAuthConfig]
     with HttpDelegationManager
     with BasicAuthUtils
-    with LazyLogging {
+    with StrictLogging {
 
   private final val DEFAULT_CONFIG = "keystone-v2-basic-auth.cfg.xml"
   private final val TOKEN_ENDPOINT = "/v2.0/tokens"

--- a/repose-aggregator/components/filters/keystone-v2-basic-auth-filter/src/test/scala/org/openrepose/filters/keystonev2basicauth/KeystoneV2BasicAuthFilterTest.scala
+++ b/repose-aggregator/components/filters/keystone-v2-basic-auth-filter/src/test/scala/org/openrepose/filters/keystonev2basicauth/KeystoneV2BasicAuthFilterTest.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ package org.openrepose.filters.keystonev2basicauth
 import javax.servlet.{FilterChain, FilterConfig}
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.test.appender.ListAppender
@@ -44,7 +44,7 @@ import org.springframework.mock.web.MockHttpServletRequest
 import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
-class KeystoneV2BasicAuthFilterTest extends FunSpec with BeforeAndAfterEach with Matchers with MockitoSugar with LazyLogging {
+class KeystoneV2BasicAuthFilterTest extends FunSpec with BeforeAndAfterEach with Matchers with MockitoSugar with StrictLogging {
 
   var listAppender: ListAppender = _
   var filterChain: FilterChain = _

--- a/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/AbstractKeystoneV2Filter.scala
+++ b/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/AbstractKeystoneV2Filter.scala
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletResponse._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import com.rackspace.httpdelegation.HttpDelegationManager
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.utils.http.{IdentityStatus, OpenStackServiceHeader}
 import org.openrepose.commons.utils.servlet.http.ResponseMode.{MUTABLE, PASSTHROUGH}
 import org.openrepose.commons.utils.servlet.http.{HttpServletRequestWrapper, HttpServletResponseWrapper}
@@ -39,7 +39,7 @@ import scala.util.{Failure, Success, Try}
 abstract class AbstractKeystoneV2Filter[T <: KeystoneV2Config: ClassTag](configurationService: ConfigurationService)
   extends AbstractConfiguredFilter[T](configurationService)
     with HttpDelegationManager
-    with LazyLogging {
+    with StrictLogging {
 
   import AbstractKeystoneV2Filter._
 

--- a/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/KeystoneRequestHandler.scala
+++ b/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/KeystoneRequestHandler.scala
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse._
 import javax.ws.rs.core.{HttpHeaders, MediaType}
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.http.client.utils.DateUtils
 import org.joda.time.format.ISODateTimeFormat
 import org.openrepose.commons.utils.http.{CommonHttpHeader, ServiceClientResponse}
@@ -42,7 +42,7 @@ import scala.util.{Failure, Success, Try}
   * Contains the functions which interact with the Keystone API.
   */
 class KeystoneRequestHandler(identityServiceUri: String, akkaServiceClient: AkkaServiceClient, traceId: Option[String])
-  extends LazyLogging {
+  extends StrictLogging {
 
   import KeystoneRequestHandler._
 

--- a/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/KeystoneV2Authorization.scala
+++ b/repose-aggregator/components/filters/keystone-v2-filter/src/main/scala/org/openrepose/filters/keystonev2/KeystoneV2Authorization.scala
@@ -21,7 +21,7 @@ package org.openrepose.filters.keystonev2
 
 import javax.servlet.http.HttpServletResponse.{SC_FORBIDDEN, SC_UNAUTHORIZED}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 import org.openrepose.filters.keystonev2.AbstractKeystoneV2Filter.{KeystoneV2Result, Reject}
 import org.openrepose.filters.keystonev2.KeystoneV2Common._
@@ -30,7 +30,7 @@ import org.openrepose.filters.keystonev2.config._
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
-object KeystoneV2Authorization extends LazyLogging {
+object KeystoneV2Authorization extends StrictLogging {
 
   val handleFailures: PartialFunction[Try[Unit.type], KeystoneV2Result] = {
     case Failure(e: InvalidTenantException) => Reject(SC_UNAUTHORIZED, Some(e.getMessage))

--- a/repose-aggregator/components/filters/merge-header-filter/src/main/scala/org/openrepose/filters/mergeheader/MergeHeaderFilter.scala
+++ b/repose-aggregator/components/filters/merge-header-filter/src/main/scala/org/openrepose/filters/mergeheader/MergeHeaderFilter.scala
@@ -23,7 +23,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 import org.openrepose.core.filter.FilterConfigHelper
@@ -33,7 +33,7 @@ import scala.collection.JavaConversions._
 
 @Named
 class MergeHeaderFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[MergeHeaderConfig] with LazyLogging {
+  extends Filter with UpdateListener[MergeHeaderConfig] with StrictLogging {
 
   private final val DEFAULT_CONFIG = "merge-header.cfg.xml"
 

--- a/repose-aggregator/components/filters/openstack-identity-v3-filter/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Filter.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3-filter/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Filter.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.servlet.filter.FilterAction
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
@@ -48,7 +48,7 @@ class OpenStackIdentityV3Filter @Inject()(configurationService: ConfigurationSer
                                           atomFeedService: AtomFeedService,
                                           httpClientService: HttpClientService,
                                           akkaServiceClientFactory: AkkaServiceClientFactory)
-  extends Filter with UpdateListener[OpenstackIdentityV3Config] with LazyLogging {
+  extends Filter with UpdateListener[OpenstackIdentityV3Config] with StrictLogging {
 
   private final val DEFAULT_CONFIG = "openstack-identity-v3.cfg.xml"
 

--- a/repose-aggregator/components/filters/openstack-identity-v3-filter/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Handler.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3-filter/src/main/scala/org/openrepose/filters/openstackidentityv3/OpenStackIdentityV3Handler.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletResponse
 import javax.servlet.http.HttpServletResponse._
 
 import com.rackspace.httpdelegation.HttpDelegationManager
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.commons.codec.binary.Base64
 import org.openrepose.commons.utils.http._
 import org.openrepose.commons.utils.servlet.filter.FilterAction
@@ -39,7 +39,7 @@ import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 
 class OpenStackIdentityV3Handler(identityConfig: OpenstackIdentityV3Config, identityAPI: OpenStackIdentityV3API)
-  extends HttpDelegationManager with LazyLogging {
+  extends HttpDelegationManager with StrictLogging {
 
   private val identityServiceUri = identityConfig.getOpenstackIdentityService.getUri
   private val forwardGroups = identityConfig.isForwardGroups

--- a/repose-aggregator/components/filters/openstack-identity-v3-filter/src/main/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3API.scala
+++ b/repose-aggregator/components/filters/openstack-identity-v3-filter/src/main/scala/org/openrepose/filters/openstackidentityv3/utilities/OpenStackIdentityV3API.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@ import java.util.{Calendar, GregorianCalendar}
 import javax.servlet.http.HttpServletResponse._
 import javax.ws.rs.core.MediaType
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.http.Header
 import org.joda.time.DateTime
 import org.openrepose.commons.utils.http.{CommonHttpHeader, HttpDate, ServiceClientResponse}
@@ -43,7 +43,7 @@ import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 class OpenStackIdentityV3API(config: OpenstackIdentityV3Config, datastore: Datastore, akkaServiceClient: AkkaServiceClient)
-  extends LazyLogging {
+  extends StrictLogging {
 
   private final val SC_TOO_MANY_REQUESTS = 429
   private final val TOKEN_ENDPOINT = "/v3/auth/tokens"

--- a/repose-aggregator/components/filters/rackspace-auth-user-filter/src/main/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilter.scala
+++ b/repose-aggregator/components/filters/rackspace-auth-user-filter/src/main/scala/org/openrepose/filters/rackspaceauthuser/RackspaceAuthUserFilter.scala
@@ -25,7 +25,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.commons.lang3.StringUtils
 import org.apache.http.HttpHeaders
 import org.openrepose.commons.utils.http.{OpenStackServiceHeader, PowerApiHeader}
@@ -44,7 +44,7 @@ import scala.xml.XML
 
 @Named
 class RackspaceAuthUserFilter @Inject()(configurationService: ConfigurationService, datastoreService: DatastoreService)
-  extends AbstractConfiguredFilter[RackspaceAuthUserConfig](configurationService) with LazyLogging {
+  extends AbstractConfiguredFilter[RackspaceAuthUserConfig](configurationService) with StrictLogging {
   import RackspaceAuthUserFilter._
 
   override final val DEFAULT_CONFIG = "rackspace-auth-user.cfg.xml"

--- a/repose-aggregator/components/filters/regex-rbac-filter/src/main/scala/org/openrepose/filters/regexrbac/RegexRbacFilter.scala
+++ b/repose-aggregator/components/filters/regex-rbac-filter/src/main/scala/org/openrepose/filters/regexrbac/RegexRbacFilter.scala
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import com.rackspace.httpdelegation.HttpDelegationManager
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateFailedException
 import org.openrepose.commons.utils.http.PowerApiHeader.RELEVANT_ROLES
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
@@ -45,7 +45,7 @@ class RegexRbacFilter @Inject()(configurationService: ConfigurationService)
   extends AbstractConfiguredFilter[RegexRbacConfig](configurationService)
     with HttpDelegationManager
     with RegexStringOperators
-    with LazyLogging {
+    with StrictLogging {
 
   override val DEFAULT_CONFIG: String = "regex-rbac.cfg.xml"
   override val SCHEMA_LOCATION: String = "/META-INF/schema/config/regex-rbac.xsd"

--- a/repose-aggregator/components/filters/saml-policy-translation-filter/src/main/scala/org/openrepose/filters/samlpolicy/SamlPolicyTranslationFilter.scala
+++ b/repose-aggregator/components/filters/saml-policy-translation-filter/src/main/scala/org/openrepose/filters/samlpolicy/SamlPolicyTranslationFilter.scala
@@ -49,7 +49,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.rackspace.com.papi.components.checker.util.{ImmutableNamespaceContext, XMLParserPool, XPathExpressionPool}
 import com.rackspace.identity.components.{AttributeMapper, PolicyFormat, XSDEngine}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import net.sf.saxon.s9api.{SaxonApiException, XsltExecutable}
 import org.openrepose.commons.config.manager.{UpdateFailedException, UpdateListener}
 import org.openrepose.commons.utils.http.CommonHttpHeader.TRACE_GUID
@@ -81,7 +81,7 @@ class SamlPolicyTranslationFilter @Inject()(configurationService: ConfigurationS
                                             atomFeedService: AtomFeedService,
                                             @Value(ReposeSpringProperties.CORE.CONFIG_ROOT) configRoot: String)
   extends AbstractConfiguredFilter[SamlPolicyConfig](configurationService)
-    with LazyLogging
+    with StrictLogging
     with AtomFeedListener {
 
   import SamlPolicyTranslationFilter._

--- a/repose-aggregator/components/filters/scripting-filter/src/main/scala/org/openrepose/filters/scripting/ScriptingFilter.scala
+++ b/repose-aggregator/components/filters/scripting-filter/src/main/scala/org/openrepose/filters/scripting/ScriptingFilter.scala
@@ -25,7 +25,7 @@ import javax.script._
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.{UpdateFailedException, UpdateListener}
 import org.openrepose.commons.utils.servlet.http._
 import org.openrepose.core.filter.FilterConfigHelper
@@ -37,7 +37,7 @@ import scala.util.{Failure, Success, Try}
 
 @Named
 class ScriptingFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[ScriptingConfig] with LazyLogging {
+  extends Filter with UpdateListener[ScriptingConfig] with StrictLogging {
 
   // Necessary for Jython, doesn't work with JSR223 without, fails silently!
   Options.importSite = false

--- a/repose-aggregator/components/filters/simple-rbac-filter/src/main/scala/org/openrepose/filters/simplerbac/SimpleRbacFilter.scala
+++ b/repose-aggregator/components/filters/simple-rbac-filter/src/main/scala/org/openrepose/filters/simplerbac/SimpleRbacFilter.scala
@@ -31,7 +31,7 @@ import javax.xml.transform.stream.StreamSource
 import com.rackspace.com.papi.components.checker.handler._
 import com.rackspace.com.papi.components.checker.wadl.WADLException
 import com.rackspace.com.papi.components.checker.{Config, Validator, ValidatorException}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.commons.lang3.StringUtils
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.StringUriUtilities
@@ -50,7 +50,7 @@ class SimpleRbacFilter @Inject()(configurationService: ConfigurationService,
 
   extends Filter
   with UpdateListener[SimpleRbacConfig]
-  with LazyLogging {
+  with StrictLogging {
 
   private final val DEFAULT_CONFIG = "simple-rbac.cfg.xml"
 

--- a/repose-aggregator/components/filters/slf4j-http-logging-filter/src/main/scala/org/openrepose/filters/slf4jlogging/Slf4jHttpLoggingFilter.scala
+++ b/repose-aggregator/components/filters/slf4j-http-logging-filter/src/main/scala/org/openrepose/filters/slf4jlogging/Slf4jHttpLoggingFilter.scala
@@ -24,7 +24,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.logging.apache.HttpLogFormatter
 import org.openrepose.core.filter.FilterConfigHelper
@@ -37,7 +37,7 @@ import scala.collection.mutable
 
 @Named
 class Slf4jHttpLoggingFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[Slf4JHttpLoggingConfig] with LazyLogging {
+  extends Filter with UpdateListener[Slf4JHttpLoggingConfig] with StrictLogging {
 
   private final val DEFAULT_CONFIG: String = "slf4j-http-logging.cfg.xml"
 

--- a/repose-aggregator/components/filters/tenant-culling-filter/src/main/scala/org/openrepose/filters/tenantculling/TenantCullingFilter.scala
+++ b/repose-aggregator/components/filters/tenant-culling-filter/src/main/scala/org/openrepose/filters/tenantculling/TenantCullingFilter.scala
@@ -25,13 +25,13 @@ import javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import com.fasterxml.jackson.core.JsonParseException
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.utils.http.OpenStackServiceHeader.{TENANT_ID, TENANT_ROLES_MAP}
 import org.openrepose.commons.utils.http.PowerApiHeader.RELEVANT_ROLES
 import org.openrepose.commons.utils.json.JsonHeaderHelper
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 
-class TenantCullingFilter extends Filter with LazyLogging {
+class TenantCullingFilter extends Filter with StrictLogging {
 
   import TenantCullingFilter._
 

--- a/repose-aggregator/components/filters/uri-normalization-filter/src/main/scala/org/openrepose/filters/urinormalization/UriNormalizationFilter.scala
+++ b/repose-aggregator/components/filters/uri-normalization-filter/src/main/scala/org/openrepose/filters/urinormalization/UriNormalizationFilter.scala
@@ -26,7 +26,7 @@ import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import com.codahale.metrics.MetricRegistry
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.normal.QueryStringNormalizer
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
@@ -41,7 +41,7 @@ import scala.collection.mutable
 
 @Named
 class UriNormalizationFilter @Inject()(configurationService: ConfigurationService, optMetricsService: Optional[MetricsService])
-  extends Filter with UpdateListener[UriNormalizationConfig] with LazyLogging {
+  extends Filter with UpdateListener[UriNormalizationConfig] with StrictLogging {
 
   private final val DefaultConfig: String = "uri-normalization.cfg.xml"
   private final val NormalizationMetricPrefix = MetricRegistry.name(classOf[UriNormalizationFilter], "Normalization")

--- a/repose-aggregator/components/filters/uri-normalization-filter/src/main/scala/org/openrepose/filters/urinormalization/normalizer/MediaTypeNormalizer.scala
+++ b/repose-aggregator/components/filters/uri-normalization-filter/src/main/scala/org/openrepose/filters/urinormalization/normalizer/MediaTypeNormalizer.scala
@@ -22,14 +22,14 @@ package org.openrepose.filters.urinormalization.normalizer
 import java.util.regex.Pattern
 import javax.ws.rs.core.HttpHeaders
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.utils.http.media.MimeType
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 import org.openrepose.filters.urinormalization.config.MediaType
 
 import scala.language.postfixOps
 
-class MediaTypeNormalizer(configuredMediaTypes: Seq[MediaType]) extends LazyLogging {
+class MediaTypeNormalizer(configuredMediaTypes: Seq[MediaType]) extends StrictLogging {
 
   private final val VariantExtractorRegex = Pattern.compile("((\\.)[^\\d][\\w]*)")
   private final val VariantExtensionGroup = 1

--- a/repose-aggregator/components/filters/uri-stripper-filter/src/main/scala/org/openrepose/filters/uristripper/UriStripperFilter.scala
+++ b/repose-aggregator/components/filters/uri-stripper-filter/src/main/scala/org/openrepose/filters/uristripper/UriStripperFilter.scala
@@ -33,7 +33,7 @@ import javax.xml.transform.stream._
 import _root_.io.gatling.jsonpath.AST.{Field, RootNode}
 import _root_.io.gatling.jsonpath.Parser
 import com.rackspace.cloud.api.wadl.Converters._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import net.sf.saxon.{Controller, TransformerFactoryImpl}
 import org.apache.http.HttpHeaders
 import org.openrepose.commons.config.manager.UpdateListener
@@ -56,7 +56,7 @@ import scala.util.{Failure, Success, Try}
 
 @Named
 class UriStripperFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[UriStripperConfig] with RegexStringOperators with LazyLogging {
+  extends Filter with UpdateListener[UriStripperConfig] with RegexStringOperators with StrictLogging {
 
   import UriStripperFilter._
 

--- a/repose-aggregator/components/filters/uri-user-filter/src/main/scala/org/openrepose/filters/uriuser/UriUserFilter.scala
+++ b/repose-aggregator/components/filters/uri-user-filter/src/main/scala/org/openrepose/filters/uriuser/UriUserFilter.scala
@@ -26,7 +26,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.PowerApiHeader
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
@@ -38,7 +38,7 @@ import scala.collection.JavaConversions._
 
 @Named
 class UriUserFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[UriUserConfig] with LazyLogging {
+  extends Filter with UpdateListener[UriUserConfig] with StrictLogging {
 
   import UriUserFilter._
 

--- a/repose-aggregator/components/filters/url-extractor-to-header-filter/src/main/scala/org/openrepose/filters/urlextractortoheader/UrlExtractorToHeaderFilter.scala
+++ b/repose-aggregator/components/filters/url-extractor-to-header-filter/src/main/scala/org/openrepose/filters/urlextractortoheader/UrlExtractorToHeaderFilter.scala
@@ -24,7 +24,7 @@ import javax.inject.{Inject, Named}
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.servlet.http.HttpServletRequestWrapper
 import org.openrepose.core.filter.FilterConfigHelper
@@ -36,7 +36,7 @@ import scala.util.matching.Regex
 
 @Named
 class UrlExtractorToHeaderFilter @Inject()(configurationService: ConfigurationService)
-  extends Filter with UpdateListener[UrlExtractorToHeaderConfig] with LazyLogging {
+  extends Filter with UpdateListener[UrlExtractorToHeaderConfig] with StrictLogging {
 
   import UrlExtractorToHeaderFilter._
 

--- a/repose-aggregator/components/filters/valkyrie-authorization-filter/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
+++ b/repose-aggregator/components/filters/valkyrie-authorization-filter/src/main/scala/org/openrepose/filters/valkyrieauthorization/ValkyrieAuthorizationFilter.scala
@@ -32,7 +32,7 @@ import javax.ws.rs.core.HttpHeaders.RETRY_AFTER
 import com.fasterxml.jackson.core.JsonParseException
 import com.josephpconley.jsonpath.JSONPath
 import com.rackspace.httpdelegation.HttpDelegationManager
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import io.gatling.jsonpath.AST.{Field, PathToken, RootNode}
 import io.gatling.jsonpath.Parser
 import org.openrepose.commons.utils.http.CommonHttpHeader.{AUTH_TOKEN, TRACE_GUID}
@@ -62,7 +62,7 @@ class ValkyrieAuthorizationFilter @Inject()(configurationService: ConfigurationS
   extends AbstractConfiguredFilter[ValkyrieAuthorizationConfig](configurationService)
     with HttpDelegationManager
     with RegexStringOperators
-    with LazyLogging {
+    with StrictLogging {
 
   import org.openrepose.filters.valkyrieauthorization.ValkyrieAuthorizationFilter._
 

--- a/repose-aggregator/components/filters/versioning-filter/src/main/scala/org/openrepose/filters/versioning/VersioningFilter.scala
+++ b/repose-aggregator/components/filters/versioning-filter/src/main/scala/org/openrepose/filters/versioning/VersioningFilter.scala
@@ -27,7 +27,7 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.xml.bind.JAXBElement
 
 import com.codahale.metrics.MetricRegistry
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.http.HttpHeaders
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.commons.utils.http.CommonRequestAttributes
@@ -54,7 +54,7 @@ class VersioningFilter @Inject()(@Value(ReposeSpringProperties.NODE.CLUSTER_ID) 
                                  configurationService: ConfigurationService,
                                  healthCheckService: HealthCheckService,
                                  optMetricsService: Optional[MetricsService])
-  extends Filter with LazyLogging {
+  extends Filter with StrictLogging {
 
   private final val SystemModelConfigFileName = "system-model.cfg.xml"
   private final val DefaultVersioningConfigFileName = "versioning.cfg.xml"

--- a/repose-aggregator/components/services/akka-http-client-service/akka-http-client-service-impl/src/test/scala/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientImplTest.scala
+++ b/repose-aggregator/components/services/akka-http-client-service/akka-http-client-service-impl/src/test/scala/org/openrepose/core/services/serviceclient/akka/impl/AkkaServiceClientImplTest.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ import java.io.StringWriter
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.ws.rs.core.{HttpHeaders, MediaType}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.apache.commons.io.IOUtils
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.DefaultHttpClient
@@ -49,7 +49,7 @@ import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
 import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
-class AkkaServiceClientImplTest extends FunSpec with BeforeAndAfterEach with Matchers with MockitoSugar with LazyLogging {
+class AkkaServiceClientImplTest extends FunSpec with BeforeAndAfterEach with Matchers with MockitoSugar with StrictLogging {
   val HEADER_SLEEP = "Origin-Sleep"
   val HEADER_LOG = "Origin-Log"
   val AUTH_TOKEN_HEADER = "X-Auth-Token"

--- a/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/src/main/scala/org/openrepose/nodeservice/atomfeed/impl/AtomFeedServiceImpl.scala
+++ b/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/src/main/scala/org/openrepose/nodeservice/atomfeed/impl/AtomFeedServiceImpl.scala
@@ -23,7 +23,7 @@ import javax.annotation.{PostConstruct, PreDestroy}
 import javax.inject.{Inject, Named}
 
 import akka.actor._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import io.opentracing.Tracer
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.core.filter.SystemModelInterrogator
@@ -54,7 +54,7 @@ class AtomFeedServiceImpl @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_VE
                                     configurationService: ConfigurationService,
                                     applicationContext: ApplicationContext,
                                     tracer: Tracer)
-  extends AtomFeedService with LazyLogging {
+  extends AtomFeedService with StrictLogging {
 
   import AtomFeedServiceImpl._
 

--- a/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/src/main/scala/org/openrepose/nodeservice/atomfeed/impl/actors/FeedReader.scala
+++ b/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/src/main/scala/org/openrepose/nodeservice/atomfeed/impl/actors/FeedReader.scala
@@ -23,7 +23,7 @@ import java.io.{IOException, StringWriter}
 import java.net.{URI, UnknownServiceException}
 
 import akka.actor._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import io.opentracing.Tracer
 import io.opentracing.tag.Tags
 import org.apache.abdera.Abdera
@@ -89,7 +89,7 @@ class FeedReader(feedURIString: String,
                  pollingFrequency: Int,
                  order: EntryOrderType,
                  reposeVersion: String)
-  extends Actor with LazyLogging {
+  extends Actor with StrictLogging {
 
   import FeedReader._
 

--- a/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/src/main/scala/org/openrepose/nodeservice/atomfeed/impl/actors/NotifierManager.scala
+++ b/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/src/main/scala/org/openrepose/nodeservice/atomfeed/impl/actors/NotifierManager.scala
@@ -20,7 +20,7 @@
 package org.openrepose.nodeservice.atomfeed.impl.actors
 
 import akka.actor.{Actor, ActorRef, PoisonPill}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.nodeservice.atomfeed.AtomFeedListener
 import org.openrepose.nodeservice.atomfeed.impl.actors.FeedReader.{CancelScheduledReading, ScheduleReading}
 import org.openrepose.nodeservice.atomfeed.impl.actors.Notifier._
@@ -44,7 +44,7 @@ object NotifierManager {
 
 }
 
-class NotifierManager extends Actor with LazyLogging {
+class NotifierManager extends Actor with StrictLogging {
 
   import NotifierManager._
 

--- a/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/src/main/scala/org/openrepose/nodeservice/atomfeed/impl/auth/OpenStackIdentityV2AuthenticatedRequestFactory.scala
+++ b/repose-aggregator/components/services/atom-feed-service/atom-feed-service-impl/src/main/scala/org/openrepose/nodeservice/atomfeed/impl/auth/OpenStackIdentityV2AuthenticatedRequestFactory.scala
@@ -25,7 +25,7 @@ import javax.inject.Inject
 import javax.servlet.http.HttpServletResponse._
 import javax.ws.rs.core.{HttpHeaders, MediaType}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.utils.http.CommonHttpHeader
 import org.openrepose.commons.utils.logging.TracingHeaderHelper
 import org.openrepose.core.services.serviceclient.akka.{AkkaServiceClient, AkkaServiceClientFactory}
@@ -48,7 +48,7 @@ object OpenStackIdentityV2AuthenticatedRequestFactory {
 class OpenStackIdentityV2AuthenticatedRequestFactory @Inject()(feedConfig: AtomFeedConfigType,
                                                                authConfig: OpenStackIdentityV2AuthenticationType,
                                                                akkaServiceClientFactory: AkkaServiceClientFactory)
-  extends AuthenticatedRequestFactory with LazyLogging {
+  extends AuthenticatedRequestFactory with StrictLogging {
 
   import OpenStackIdentityV2AuthenticatedRequestFactory._
 

--- a/repose-aggregator/components/services/container-configuration-service/impl/src/main/scala/org/openrepose/nodeservice/containerconfiguration/ContainerConfigurationServiceImpl.scala
+++ b/repose-aggregator/components/services/container-configuration-service/impl/src/main/scala/org/openrepose/nodeservice/containerconfiguration/ContainerConfigurationServiceImpl.scala
@@ -24,7 +24,7 @@ import java.util.Optional
 import javax.annotation.{PostConstruct, PreDestroy}
 import javax.inject.{Inject, Named}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.core.container.config.{ContainerConfiguration, DeploymentConfiguration}
 import org.openrepose.core.services.config.ConfigurationService
@@ -36,7 +36,7 @@ import scala.collection.JavaConversions._
 @Named
 class ContainerConfigurationServiceImpl @Inject()(@Value(ReposeSpringProperties.NODE.CLUSTER_ID) clusterId: String,
                                                   configurationService: ConfigurationService)
-  extends ContainerConfigurationService with UpdateListener[ContainerConfiguration] with LazyLogging {
+  extends ContainerConfigurationService with UpdateListener[ContainerConfiguration] with StrictLogging {
 
   import ContainerConfigurationServiceImpl._
 

--- a/repose-aggregator/components/services/open-tracing-service/src/main/scala/org/openrepose/core/services/opentracing/OpenTracingServiceImpl.scala
+++ b/repose-aggregator/components/services/open-tracing-service/src/main/scala/org/openrepose/core/services/opentracing/OpenTracingServiceImpl.scala
@@ -22,7 +22,7 @@ package org.openrepose.core.services.opentracing
 import javax.annotation.{PostConstruct, PreDestroy}
 import javax.inject.{Inject, Named}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import com.uber.jaeger.Configuration
 import com.uber.jaeger.Configuration.{SamplerConfiguration, SenderConfiguration}
 import com.uber.jaeger.samplers.{ConstSampler, ProbabilisticSampler, RateLimitingSampler}
@@ -39,7 +39,7 @@ import org.openrepose.core.services.config.ConfigurationService
   */
 @Named
 class OpenTracingServiceImpl @Inject()(configurationService: ConfigurationService, reposeTracer: DelegatingTracer)
-  extends UpdateListener[OpenTracingConfig] with LazyLogging {
+  extends UpdateListener[OpenTracingConfig] with StrictLogging {
 
   import OpenTracingServiceImpl._
 

--- a/repose-aggregator/components/services/phone-home-service/src/main/scala/org/openrepose/core/services/phonehome/PhoneHomeService.scala
+++ b/repose-aggregator/components/services/phone-home-service/src/main/scala/org/openrepose/core/services/phonehome/PhoneHomeService.scala
@@ -25,7 +25,7 @@ import javax.annotation.PostConstruct
 import javax.inject.{Inject, Named}
 import javax.ws.rs.core.MediaType
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import io.opentracing.tag.Tags
 import io.opentracing.{Scope, Tracer}
 import org.openrepose.commons.config.manager.UpdateListener
@@ -60,7 +60,7 @@ class PhoneHomeService @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_VERSI
                                  tracer: Tracer,
                                  configurationService: ConfigurationService,
                                  akkaServiceClientFactory: AkkaServiceClientFactory)
-  extends LazyLogging {
+  extends StrictLogging {
 
   import PhoneHomeService._
 

--- a/repose-aggregator/core/repose-core-api/src/main/scala/org/openrepose/core/filter/AbstractConfiguredFilter.scala
+++ b/repose-aggregator/core/repose-core-api/src/main/scala/org/openrepose/core/filter/AbstractConfiguredFilter.scala
@@ -23,7 +23,7 @@ import java.net.URL
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.commons.config.manager.UpdateListener
 import org.openrepose.core.services.config.ConfigurationService
 
@@ -36,7 +36,7 @@ import scala.reflect.{ClassTag, _}
   * @tparam T the config class
   */
 abstract class AbstractConfiguredFilter[T: ClassTag](val configurationService: ConfigurationService)
-  extends Filter with LazyLogging with UpdateListener[T] {
+  extends Filter with StrictLogging with UpdateListener[T] {
 
   /**
     * The default configuration file name for the filter.

--- a/repose-aggregator/core/repose-core/src/main/scala/org/openrepose/core/opentracing/ReposeTracer.scala
+++ b/repose-aggregator/core/repose-core/src/main/scala/org/openrepose/core/opentracing/ReposeTracer.scala
@@ -19,7 +19,7 @@
  */
 package org.openrepose.core.opentracing
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import io.opentracing.noop.{NoopTracer, NoopTracerFactory}
 import io.opentracing.propagation.Format
 import io.opentracing.util.GlobalTracer
@@ -35,7 +35,7 @@ import javax.inject.Named
   *  - allows for registration of a new Tracer at any time.
   */
 @Named
-class ReposeTracer extends DelegatingTracer with LazyLogging {
+class ReposeTracer extends DelegatingTracer with StrictLogging {
 
   private var tracer: Tracer = NoopTracerFactory.create()
 

--- a/repose-aggregator/src/docs/asciidoc/release-notes.adoc
+++ b/repose-aggregator/src/docs/asciidoc/release-notes.adoc
@@ -2,6 +2,7 @@
 
 == 8.8.3.0 (2018-03-30)
 * https://repose.atlassian.net/browse/REP-6654[REP-6654] - Added OpenTracing support.
+* https://repose.atlassian.net/browse/REP-6674[REP-6674] - Switching usages of `LazyLogging` over to `StrictLogging`.
 
 == 8.8.2.0 (2018-03-23)
 * https://repose.atlassian.net/browse/REP-6588[REP-6588] - Updated the `commitToResponse` method of the `HttpServletResponseWrapper` to avoid writing headers or the body when an error has been sent.

--- a/repose-aggregator/tests/test-bundles/filter-five/src/main/scala/org/openrepose/filters/core/filterfive/FilterFive.scala
+++ b/repose-aggregator/tests/test-bundles/filter-five/src/main/scala/org/openrepose/filters/core/filterfive/FilterFive.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,14 +22,14 @@ package org.openrepose.filters.core.filterfive
 import javax.inject.Named
 import javax.servlet._
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.others.SimplicityDivine
 
 /**
  * Created by dimi5963 on 1/6/15.
  */
 @Named
-class FilterFive extends Filter with LazyLogging {
+class FilterFive extends Filter with StrictLogging {
   override def init(p1: FilterConfig): Unit = {
     //Meh?
   }

--- a/repose-aggregator/tests/test-bundles/filter-four/src/main/scala/org/openrepose/filters/core/filterfour/FilterFour.scala
+++ b/repose-aggregator/tests/test-bundles/filter-four/src/main/scala/org/openrepose/filters/core/filterfour/FilterFour.scala
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,14 +22,14 @@ package org.openrepose.filters.core.filterfour
 import javax.inject.Named
 import javax.servlet._
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import org.openrepose.others.SimplicityDivine
 
 /**
  * Created by dimi5963 on 1/6/15.
  */
 @Named
-class FilterFour extends Filter with LazyLogging {
+class FilterFour extends Filter with StrictLogging {
   override def init(p1: FilterConfig): Unit = {
     //Meh?
   }


### PR DESCRIPTION
The one thing that I want to call out here is that I intentionally did not switch the following classes to `StrictLogging`:

- `MutableServletOutputStream`
- `PassthroughServletOutputStream`
- `ReadOnlyServletOutputStream`

The reason being that we create those classes quite frequently, and each class will create a reference to a logger for itself, but those loggers will not log anything in most cases.

Although, thinking about it, we may just want to create a logger in a companion object for those classes (and still use `StrictLogging`?).

I'd love thoughts on the subject if anyone has them!