### PR TITLE
REP-5461 Build DEB artifacts used by the performance tests once

### DIFF
--- a/repose-aggregator/tests/performance-tests/Jenkinsfile
+++ b/repose-aggregator/tests/performance-tests/Jenkinsfile
@@ -23,6 +23,20 @@ stage("Determine performance tests to run") {
     }
 }
 
+stage("Build Repose DEB Artifacts") {
+    // note: we always use a build node to build the artifacts, so legacy build artifacts are currently not supported
+    node("build") {
+        checkout scm
+        // note: we only build the deb artifacts, so the Redhat family of OSes are currently not supported
+        sh './gradlew ' +
+                ':repose-aggregator:artifacts:experimental-filter-bundle:buildDeb ' +
+                ':repose-aggregator:artifacts:extensions-filter-bundle:buildDeb ' +
+                ':repose-aggregator:artifacts:filter-bundle:buildDeb ' +
+                ':repose-aggregator:artifacts:valve:buildDeb'
+        archiveArtifacts artifacts: 'repose-aggregator/artifacts/**/build/distributions/*.deb', fingerprint: true
+    }
+}
+
 stage("Performance Test") {
     def performanceJenkinsJob = "performance-test"
     def cleanupJenkinsJob = "performance-test-cleanup"

--- a/repose-aggregator/tests/performance-tests/Jenkinsfile
+++ b/repose-aggregator/tests/performance-tests/Jenkinsfile
@@ -23,20 +23,6 @@ stage("Determine performance tests to run") {
     }
 }
 
-stage("Build Repose DEB Artifacts") {
-    // note: we always use a build node to build the artifacts, so legacy build artifacts are currently not supported
-    node("build") {
-        checkout scm
-        // note: we only build the deb artifacts, so the Redhat family of OSes are currently not supported
-        sh './gradlew ' +
-                ':repose-aggregator:artifacts:experimental-filter-bundle:buildDeb ' +
-                ':repose-aggregator:artifacts:extensions-filter-bundle:buildDeb ' +
-                ':repose-aggregator:artifacts:filter-bundle:buildDeb ' +
-                ':repose-aggregator:artifacts:valve:buildDeb'
-        archiveArtifacts artifacts: 'repose-aggregator/artifacts/**/build/distributions/*.deb', fingerprint: true
-    }
-}
-
 stage("Performance Test") {
     def performanceJenkinsJob = "performance-test"
     def cleanupJenkinsJob = "performance-test-cleanup"
@@ -68,6 +54,9 @@ stage("Performance Test") {
         }
     }
 
-    // starts the list of jobs to build in parallel
+    // builds the Repose artifacts for performance test jobs to use
+    build("repose-gradle-package")
+
+    // starts the list of performance test jobs in parallel
     parallel(jobsToRun)
 }

--- a/repose-aggregator/tests/performance-tests/Jenkinsfile
+++ b/repose-aggregator/tests/performance-tests/Jenkinsfile
@@ -41,15 +41,15 @@ stage("Performance Test") {
                     build(job: performanceJenkinsJob,
                             quietPeriod: random.nextInt(tenMinutesInSeconds),
                             parameters: [
-                                    [$class: "StringParameterValue", name: performanceTestParam, value: perfTest],
-                                    [$class: "StringParameterValue", name: extraOptionsParam, value: params.extraOptions]])
+                                    string(name: performanceTestParam, value: perfTest),
+                                    string(name: extraOptionsParam, value: params.extraOptions)])
                 }
             } finally {
                 build(job: cleanupJenkinsJob,
                       quietPeriod: 0,
                       parameters: [
-                                [$class: "StringParameterValue", name: performanceTestParam, value: perfTest],
-                                [$class: "StringParameterValue", name: extraOptionsParam, value: params.extraOptions]])
+                                string(name: performanceTestParam, value: perfTest),
+                                string(name: extraOptionsParam, value: params.extraOptions)])
             }
         }
     }

--- a/repose-aggregator/tests/performance-tests/roles/repose/tasks/install_repose.yml
+++ b/repose-aggregator/tests/performance-tests/roles/repose/tasks/install_repose.yml
@@ -39,11 +39,50 @@
   pip: name=requests
   become: yes
 
+- name: Determine if Repose packages exist locally
+  local_action:
+    module: find
+    paths: "{{ role_path }}/files/packages"
+    patterns: '*.deb'
+  register: repose_packages
+  become: no
+
+- name: Create packages directory
+  file:
+    path: /tmp/repose
+    state: directory
+  when: repose_packages.matched|int != 0
+
+- name: Copy the Repose packages
+  copy:
+    src: packages/{{ item.path | basename }}
+    dest: /tmp/repose/{{ item.path | basename }}
+  when: repose_packages.matched|int != 0
+  with_items: "{{ repose_packages.files }}"
+
+# Note: Valve must be installed first since the other packages depend on it
+# Note: We also cannot trust the apt module to install repose_packages in the correct order
+# Node: See: https://github.com/ansible/ansible-modules-core/issues/1178
+- name: Install Repose Valve from a local package
+  apt:
+    deb: /tmp/repose/{{ repose_packages.files | map(attribute='path') | select('match','.*valve.*') | list | first | basename }}
+  when: repose_packages.matched|int != 0
+
+- name: Install Repose bundles from local packages
+  command: dpkg --force-confold --force-confdef -i /tmp/repose/{{ item.path | basename }}
+  # todo: replace the command module with the apt module
+  # todo: the current issue is that the apt module does not believe that the repose virtual package dependency is
+  # todo: satisfied, even though it should be
+  #  apt:
+  #    deb: /tmp/repose/{{ item.path | basename }}
+  when: repose_packages.matched|int != 0
+  with_items: "{{ repose_packages.files }}"
+
 - name: Install Repose
   repose:
     state: installed
     release: "{{ repose.install.release | default('') }}"
-  when: repose.install.release is defined
+  when: repose_packages.matched|int == 0 and repose.install.release is defined
   async: 1200
   poll: 30
 
@@ -54,6 +93,6 @@
     git_repo: "{{ repose.install.git.repo }}"
     git_branch: "{{ repose.install.git.branch }}"
     build_tool: "{{ repose.install.git.build_tool }}"
-  when: repose.install.release is not defined
+  when: repose_packages.matched|int == 0 and repose.install.release is not defined and repose.install.git is defined
   async: 1200
   poll: 30


### PR DESCRIPTION
Note: this work is actually accompanied by some work in Jenkins. The Jenkins work actually builds and copies the artifacts. See the following jobs:
https://jenkins.openrepose.org/job/repose-gradle-package/
https://jenkins.openrepose.org/job/performance-test/

