### PR TITLE
REP-6967 Fixing the ReposeJettySSLTest

### DIFF
--- a/repose-aggregator/artifacts/valve/src/test/scala/org/openrepose/valve/ReposeJettySSLTest.scala
+++ b/repose-aggregator/artifacts/valve/src/test/scala/org/openrepose/valve/ReposeJettySSLTest.scala
@@ -302,19 +302,18 @@ class ReposeJettySSLTest extends FunSpec with Matchers with BeforeAndAfterAll {
       "node",
       None,
       httpsPort,
-      sslConfig(excludedCiphers = List(".*TLS.*")),
+      sslConfig(excludedCiphers = List(".*TLS.*128.*")),
       None,
       None
     )
     repose.start()
     try {
-      //All the TLS ciphers should not work
-      val tlsCiphers = allCiphers.filter(_.matches(".*TLS.*"))
-      val sslCiphers = allCiphers.filter(_.matches(".*SSL.*"))
+      val excludedCiphers = defaultEnabledCiphers.filter(_.matches(".*TLS.*128.*"))
+      val includedCiphers = defaultEnabledCiphers.toSet.diff(excludedCiphers.toSet)
       intercept[SSLHandshakeException] {
-        selectiveRequest(ciphers = tlsCiphers.toArray)
+        selectiveRequest(ciphers = excludedCiphers.toArray)
       }
-      selectiveRequest(ciphers = sslCiphers.toArray)
+      selectiveRequest(ciphers = includedCiphers.toArray)
     } finally {
       repose.shutdown()
     }
@@ -327,19 +326,18 @@ class ReposeJettySSLTest extends FunSpec with Matchers with BeforeAndAfterAll {
       "node",
       None,
       httpsPort,
-      sslConfig(includedCiphers = List(".*SSL.*")),
+      sslConfig(includedCiphers = List(".*TLS.*128.*")),
       None,
       None
     )
     repose.start()
     try {
-      //All the TLS ciphers should not work
-      val tlsCiphers = allCiphers.filter(_.matches(".*TLS.*"))
-      val sslCiphers = allCiphers.filter(_.matches(".*SSL.*"))
+      val includedCiphers = defaultEnabledCiphers.filter(_.matches(".*TLS.*128.*"))
+      val excludedCiphers = defaultEnabledCiphers.toSet.diff(includedCiphers.toSet)
       intercept[SSLHandshakeException] {
-        selectiveRequest(ciphers = tlsCiphers.toArray)
+        selectiveRequest(ciphers = excludedCiphers.toArray)
       }
-      selectiveRequest(ciphers = sslCiphers.toArray)
+      selectiveRequest(ciphers = includedCiphers.toArray)
     } finally {
       repose.shutdown()
     }

--- a/repose-aggregator/artifacts/valve/src/test/scala/org/openrepose/valve/ReposeJettySSLTest.scala
+++ b/repose-aggregator/artifacts/valve/src/test/scala/org/openrepose/valve/ReposeJettySSLTest.scala
@@ -309,12 +309,8 @@ class ReposeJettySSLTest extends FunSpec with Matchers with BeforeAndAfterAll {
     repose.start()
     try {
       //All the TLS ciphers should not work
-      val tlsCiphers = defaultEnabledCiphers.collect {
-        case s if s.matches(".*TLS.*") => s
-      }
-      val sslCiphers = defaultEnabledCiphers.collect {
-        case s if s.matches(".*SSL.*") => s
-      }
+      val tlsCiphers = allCiphers.filter(_.matches(".*TLS.*"))
+      val sslCiphers = allCiphers.filter(_.matches(".*SSL.*"))
       intercept[SSLHandshakeException] {
         selectiveRequest(ciphers = tlsCiphers.toArray)
       }
@@ -338,12 +334,8 @@ class ReposeJettySSLTest extends FunSpec with Matchers with BeforeAndAfterAll {
     repose.start()
     try {
       //All the TLS ciphers should not work
-      val tlsCiphers = defaultEnabledCiphers.collect {
-        case s if s.matches(".*TLS.*") => s
-      }
-      val sslCiphers = defaultEnabledCiphers.collect {
-        case s if s.matches(".*SSL.*") => s
-      }
+      val tlsCiphers = allCiphers.filter(_.matches(".*TLS.*"))
+      val sslCiphers = allCiphers.filter(_.matches(".*SSL.*"))
       intercept[SSLHandshakeException] {
         selectiveRequest(ciphers = tlsCiphers.toArray)
       }


### PR DESCRIPTION
So OpenJDK 8 changes its default security policy by disabling SSL ciphers. This PR fixes our SSL test by filtering enabled ciphers rather than disabled ciphers.

I initially thought that Jetty and Apache HttpClient would enable ciphers if they were supported, even if they were disabled by default, but that did not seem to work. So instead, I opted to just use enabled ciphers.

Note that the Java security policy can be edited system-wide by modifying the `java.security` file located somewhere under the JRE installation directory (at least, for both Hotspot and OpenJDK). In this case, we would have been interested in the `jdk.tls.disabledAlgorithms` setting.