### PR TITLE
Ability to support x-forwarded-for header for x-pp-groups in ip-user filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ task('release', description: 'Release the project and publish to all repos.', gr
 
 allprojects {
     group = 'org.openrepose'
-    def baseVersion = '8.9.1.0'
+    def baseVersion = '8.9.0.1'
     version = project.hasProperty('release') ? baseVersion : "$baseVersion-SNAPSHOT"
 
     apply plugin: 'idea'

--- a/repose-aggregator/components/filters/ip-user-filter/src/main/scala/org/openrepose/filters/ipuser/IpUserFilter.scala
+++ b/repose-aggregator/components/filters/ip-user-filter/src/main/scala/org/openrepose/filters/ipuser/IpUserFilter.scala
@@ -74,13 +74,14 @@ class IpUserFilter @Inject()(configurationService: ConfigurationService) extends
       logger.trace("IP User filter handling request...")
       val request = new HttpServletRequestWrapper(servletRequest.asInstanceOf[HttpServletRequest])
 
-      getClassificationLabel(servletRequest.getRemoteAddr).foreach { label =>
+      val clientIpAddress = request.getSplittableHeaderScala(CommonHttpHeader.X_FORWARDED_FOR)
+        .headOption.getOrElse(servletRequest.getRemoteAddr)
+
+      getClassificationLabel(clientIpAddress).foreach { label =>
         request.addHeader(groupHeaderName, label, groupHeaderQuality)
       }
 
       //Always set the user header name to the current IP address
-      val clientIpAddress = request.getSplittableHeaderScala(CommonHttpHeader.X_FORWARDED_FOR)
-        .headOption.getOrElse(servletRequest.getRemoteAddr)
       request.addHeader(userHeaderName, clientIpAddress, userHeaderQuality)
 
       logger.trace("IP User filter passing request...")

--- a/repose-aggregator/src/docs/asciidoc/filters/ip-user.adoc
+++ b/repose-aggregator/src/docs/asciidoc/filters/ip-user.adoc
@@ -20,8 +20,12 @@ However, due to the nature of this filter it is typically placed early in the fi
 === Request Headers Created
 * `X-PP-User` - Will be set to the source IP of the request.
   If this header already exists, then the source IP will be added as a value, but existing values will not be removed.
+  By default, the value will be set to the caller's IP address; however, it can be overwritten with `X-Forwarded-For`
+  header. Only the first value of the header will be taken if more than one value is specified.
 * `X-PP-Groups` - Will be set to the name the first group with a matching Classless Inter-Domain Routing (CIDR) address.
   If this header already exists, then the matching group name will be added as a value, but existing values will not be removed.
+  By default, the value will be set to the caller's IP address; however, it can be overwritten with `X-Forwarded-For`
+  header. Only the first value of the header will be taken if more than one value is specified.
 ** IF there is not a match, THEN this header will not be added.
 
 [NOTE]

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/ipuser/x-forwarded-for/ip-user.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/filters/ipuser/x-forwarded-for/ip-user.cfg.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+  Repose
+  _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  Copyright (C) 2010 - 2015 Rackspace US, Inc.
+  _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+  -->
+
+<ip-user xmlns="http://docs.openrepose.org/repose/ip-user/v1.0">
+    <group name="local-group">
+        <cidr-ip>127.0.0.1/32</cidr-ip>
+    </group>
+    <group name="random-group">
+        <cidr-ip>192.25.25.15/32</cidr-ip>
+    </group>
+</ip-user>


### PR DESCRIPTION
Currently, only source IP from the calling service is matched against the CIDR
list in ip-user filter.  This is a limitation for those products that use a
load balancer in front of repose since that load balancer's ip is used instead
of the calling service's ip.  This change will mimic the behavior for x-pp-user
header population in the same filter by supporting x-forwarded-for header used
to overwrite the source ip.