### PR TITLE
REP-6932 Collecting GC and Thread Data from Performance Tests

### DIFF
--- a/repose-aggregator/tests/performance-tests/roles/jmxtrans/templates/influxdb.json.j2
+++ b/repose-aggregator/tests/performance-tests/roles/jmxtrans/templates/influxdb.json.j2
@@ -26,7 +26,10 @@
         {
           "obj": "java.lang:type=Threading",
           "attr": [
-            "ThreadCount"
+            "DaemonThreadCount",
+            "PeakThreadCount",
+            "ThreadCount",
+            "TotalStartedThreadCount"
           ],
           "resultAlias": "threads",
           "outputWriters": [

--- a/repose-aggregator/tests/performance-tests/roles/jmxtrans/templates/influxdb.json.j2
+++ b/repose-aggregator/tests/performance-tests/roles/jmxtrans/templates/influxdb.json.j2
@@ -1,20 +1,29 @@
 {
-  "servers" : [ {
-    "host" : "{{ jmxtrans.jmx.host }}",
-    "port" : "{{ jmxtrans.jmx.port }}",
-    "runPeriodSeconds": 1,
-    "queries" : [ {
-      "obj" : "java.lang:type=Memory",
-      "attr" : [ "HeapMemoryUsage", "NonHeapMemoryUsage" ],
-      "resultAlias": "memory",
-      "outputWriters" : [ {
-        "@class" : "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
-        "rootPrefix": "jmxtrans.{{ repose_version|replace('.', '-') }}.{{ gatling.test.id|default(gatling.test.name) }}",
-        "host" : "{{ jmxtrans.graphite_writer.host }}",
-        "port" : "{{ jmxtrans.graphite_writer.port }}",
-        "flushStrategy" : "timeBased",
-        "flushDelayInSeconds": 10
-      } ]
-    } ]
-  } ]
+  "servers": [
+    {
+      "host": "{{ jmxtrans.jmx.host }}",
+      "port": "{{ jmxtrans.jmx.port }}",
+      "runPeriodSeconds": 1,
+      "queries": [
+        {
+          "obj": "java.lang:type=Memory",
+          "attr": [
+            "HeapMemoryUsage",
+            "NonHeapMemoryUsage"
+          ],
+          "resultAlias": "memory",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
+              "rootPrefix": "jmxtrans.{{ repose_version|replace('.', '-') }}.{{ gatling.test.id|default(gatling.test.name) }}",
+              "host": "{{ jmxtrans.graphite_writer.host }}",
+              "port": "{{ jmxtrans.graphite_writer.port }}",
+              "flushStrategy": "timeBased",
+              "flushDelayInSeconds": 10
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/repose-aggregator/tests/performance-tests/roles/jmxtrans/templates/influxdb.json.j2
+++ b/repose-aggregator/tests/performance-tests/roles/jmxtrans/templates/influxdb.json.j2
@@ -39,6 +39,24 @@
               "flushDelayInSeconds": 10
             }
           ]
+        },
+        {
+          "obj": "java.lang:type=GarbageCollector,name=*",
+          "attr": [
+            "CollectionCount",
+            "CollectionTime"
+          ],
+          "resultAlias": "gc",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
+              "rootPrefix": "jmxtrans.{{ repose_version|replace('.', '-') }}.{{ gatling.test.id|default(gatling.test.name) }}",
+              "host": "{{ jmxtrans.graphite_writer.host }}",
+              "port": "{{ jmxtrans.graphite_writer.port }}",
+              "flushStrategy": "timeBased",
+              "flushDelayInSeconds": 10
+            }
+          ]
         }
       ]
     }

--- a/repose-aggregator/tests/performance-tests/roles/jmxtrans/templates/influxdb.json.j2
+++ b/repose-aggregator/tests/performance-tests/roles/jmxtrans/templates/influxdb.json.j2
@@ -22,6 +22,23 @@
               "flushDelayInSeconds": 10
             }
           ]
+        },
+        {
+          "obj": "java.lang:type=Threading",
+          "attr": [
+            "ThreadCount"
+          ],
+          "resultAlias": "threads",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
+              "rootPrefix": "jmxtrans.{{ repose_version|replace('.', '-') }}.{{ gatling.test.id|default(gatling.test.name) }}",
+              "host": "{{ jmxtrans.graphite_writer.host }}",
+              "port": "{{ jmxtrans.graphite_writer.port }}",
+              "flushStrategy": "timeBased",
+              "flushDelayInSeconds": 10
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Data from a test run can be viewed as various graphs under the `JMX` panel on the [Grafana performance test dashboard](http://grafana.openrepose.org/d/000000005/performance-tests?orgId=1&from=1529677818996&to=1529679467580&var-testName=ScriptingFilterJavascriptSimulation&var-endpoint=Repose&var-requests=allRequests).