### PR TITLE
REP-7228 Functional Test Investigation

### DIFF
--- a/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeLauncher.groovy
+++ b/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeLauncher.groovy
@@ -51,12 +51,12 @@ abstract class ReposeLauncher {
 
     abstract void addToClassPath(String path)
 
-    def waitForNon500FromUrl(url, int timeoutInSeconds = 60, int intervalInSeconds = 2) {
+    def waitForNon500FromUrl(url, int timeoutInSeconds = 90, int intervalInSeconds = 2) {
 
         waitForResponseCodeFromUrl(url, timeoutInSeconds, intervalInSeconds) { code -> code < 500 }
     }
 
-    def waitForDesiredResponseCodeFromUrl(url, desiredCodes, timeoutInSeconds = 60, int intervalInSeconds = 2) {
+    def waitForDesiredResponseCodeFromUrl(url, desiredCodes, timeoutInSeconds = 90, int intervalInSeconds = 2) {
 
         waitForResponseCodeFromUrl(url, timeoutInSeconds, intervalInSeconds) { code -> code in desiredCodes }
     }

--- a/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveLauncher.groovy
+++ b/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveLauncher.groovy
@@ -184,7 +184,7 @@ class ReposeValveLauncher extends ReposeLauncher {
                 print("Waiting for repose auto-guessed node to start: ")
             }
 
-            waitForCondition(clock, '60s', '1s') {
+            waitForCondition(clock, '90s', '1s') {
                 isReposeNodeUp(clusterId, nodeId)
             }
         }

--- a/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveTest.groovy
+++ b/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveTest.groovy
@@ -116,7 +116,7 @@ abstract class ReposeValveTest extends Specification {
             logSearch.cleanLog()
         MessageChain mc
         try {
-            waitForCondition(clock, '35s', '1s', {
+            waitForCondition(clock, '90s', '1s', {
                 if (checkLogMessage &&
                         //TODO: this will not work, because of clusterID/NodeId awareness
                         //This needs to do a bit more regexp


### PR DESCRIPTION
To address the functional test flakiness, I am increasing the default time to wait for Repose to start. I suspect that Repose is taking longer to start now due to the hashing and locking changes we made to our deployment strategy.

It should be noted that the new deployment strategy hashes to prevent writing files that already exist in a good state. The new deployment strategy locks to allow multiple instances of Repose using the same artifacts and deployment directory to run concurrently.