### PR TITLE
Updated EarClassProviderTest to pass regularly.

### DIFF
--- a/repose-aggregator/core/repose-core/src/test/scala/org/openrepose/commons/utils/classloader/EarClassProviderTest.scala
+++ b/repose-aggregator/core/repose-core/src/test/scala/org/openrepose/commons/utils/classloader/EarClassProviderTest.scala
@@ -366,7 +366,7 @@ class EarClassProviderTest extends FunSpec with Matchers {
       val artifactModificationTime2 = artifactFile.lastModified()
 
       artifactFile should exist
-      artifactModificationTime shouldEqual artifactModificationTime2
+      artifactModificationTime2 shouldEqual artifactModificationTime +- 1000
     }
   }
 }


### PR DESCRIPTION
 The new locking mechanism seems to reset the `lastModified` time, which in turn is being reported by the os with only second resolution. This is why when the test failed it was always off by exactly 1000 milliseconds.