### PR TITLE
REP-7427 Adding tests to verify that Repose can handle header values with characters allowed by HTTP specification

### DIFF
--- a/repose-aggregator/docs/src/asciibinder/filters/keystone-v2.adoc
+++ b/repose-aggregator/docs/src/asciibinder/filters/keystone-v2.adoc
@@ -65,8 +65,10 @@ If any of this information is provided, then it will be passed in the following 
 * `X-Domain-ID` - The domain ID for the user.
 * `X-Contact-ID` - The Contact ID for the user.
 * `X-Default-Region` - The Default Region for the user.
-* `X-Tenant-ID` - The Tenant ID's for the user.
+* `X-Tenant-ID` - The Tenant ID(s) for the user.
 ** The value of this header is governed by `send-all-tenant-ids` attribute and what is provided by the Keystone v2 Identity service.
+** Tenant IDs containing characters represented by a byte in the range `0x80`-`0xFF` (known as `obs-text`) may not be forwarded correctly.
+   However, tenant IDs containing any other characters allowed by https://tools.ietf.org/html/rfc7230#section-3.2[HTTP/1.1 specification] will be forwarded correctly (i.e., without modification).
 * `X-Tenant-Name` - The Tenant Name for the user.
 * `X-Token-Expires` - The date/time of when the token provided by the Keystone v2 Identity service expires.
 * `X-Auth-Token-Key` - The key for the parsed version of the token response that is contained in the datastore service.

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/core/headers/system-model.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/core/headers/system-model.cfg.xml
@@ -11,8 +11,7 @@
         </filters>
 
         <destinations>
-            <endpoint id="target" protocol="http" hostname="localhost" root-path="/" port="${targetPort}"
-                      default="true"/>
+            <endpoint id="target" protocol="http" port="${targetPort}" default="true"/>
         </destinations>
     </repose-cluster>
 </system-model>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/headers/HeaderPassthroughTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/headers/HeaderPassthroughTest.groovy
@@ -404,7 +404,7 @@ class HeaderPassthroughTest extends ReposeValveTest {
      *  SP = %x20
      *  VCHAR = %x21-7E ; visible (printing) characters
      *
-     *  TODO: Unfortunately, Deproxy's Header representation stores values as a String, and thus does not allow non-printable bytes to be tested
+     *  TODO: Unfortunately, Deproxy's Header representation stores values as a String which prevents non-printable bytes to be tested at this time
      *  TODO: Add tests for obs-fold
      */
     @Unroll("Requests - the following header value should be passed through unchanged: #headerValue")
@@ -434,7 +434,7 @@ class HeaderPassthroughTest extends ReposeValveTest {
             // Start of one byte values
             // All VCHARs
             *(0x21..0x7E).collect { (it as char) as String },
-            // TODO: All obs-text
+            // All obs-text
             // TODO: *(0x80..0xFF).collect { (it as char) as String },
             // End of one byte values
 
@@ -484,7 +484,7 @@ class HeaderPassthroughTest extends ReposeValveTest {
             // Start of one byte values
             // All VCHARs
             *(0x21..0x7E).collect { (it as char) as String },
-            // TODO: All obs-text
+            // All obs-text
             // TODO: *(0x80..0xFF).collect { (it as char) as String },
             // End of one byte values
 


### PR DESCRIPTION
Based off of #1998 since this test was affected by those changes.

There is only a single test failure. That failure is caused by Repose dropping request headers with an empty value. This behavior should not be accepted, but it is a known issue.