### PR TITLE
Resolving the remote datastore health check service issue

### DIFF
--- a/repose-aggregator/components/services/datastore-service/datastore-service-impl/src/main/java/org/openrepose/nodeservice/remote/RemoteDatastoreLauncherService.java
+++ b/repose-aggregator/components/services/datastore-service/datastore-service-impl/src/main/java/org/openrepose/nodeservice/remote/RemoteDatastoreLauncherService.java
@@ -134,6 +134,10 @@ public class RemoteDatastoreLauncherService {
                 } else if (!listed && isRunning) {
                     //any health check problems are resolved when we stop it
                     destroyRemoteDatastore();
+                } else if (!listed) {
+                    //Resolve the health check issue -- the user no longer wants to use this service, so
+                    //it does not matter that this service is not in a working state
+                    healthCheckServiceProxy.resolveIssue(REMOTE_DATASTORE_SERVICE_CONFIG_ISSUE);
                 }
             }
         }


### PR DESCRIPTION
This change will make it so that if the remote datastore service is removed from the services in the system model, its health check issues will also be removed. Without this change, Repose would continue returning 503s because of the reported health check issue even though the service is not being used.

This PR needs a story. I have opened a PR first since I already had the change in place from looking into the issue.

Note that services as first class citizens may also solve this issue (assuming health check issues are resolved when services are unloaded due to removal from the system model).

**EDIT:** The `dist-datastore` is also affected by this issue.