### PR TITLE
Adding CSS styling for release note tags

### DIFF
--- a/repose-aggregator/docs/src/asciibinder/_templates/page.html.erb
+++ b/repose-aggregator/docs/src/asciibinder/_templates/page.html.erb
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
   <link rel="stylesheet" href="/_stylesheets/asciibinder.css" >
   <link rel="stylesheet" href="/_stylesheets/repose.css" >
+  <link rel="stylesheet" href="/_stylesheets/release-note-categories.css" >
 
    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
+++ b/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
@@ -3,19 +3,19 @@
 == 9.0.0.0 (2018-??-??)
 <<ver-9-upgrade-notes.adoc, Upgrade Notes>>
 
-* *Added* | https://repose.atlassian.net/browse/REP-6603[REP-6603] - Added support for multiple capture groups to the <<../filters/url-extractor-to-header.adoc#, URL Extractor to Header Filter>>.
-* *Added* | https://repose.atlassian.net/browse/REP-7386[REP-7386] - Added support for the `upgrade_account` account-level permission in the <<../filters/valkyrie-authorization.adoc#, Valkyrie Authorization Filter>>.
-* *Added* | https://repose.atlassian.net/browse/REP-7519[REP-7519] - Added support for proxies to the <<../services/http-client.adoc#, HTTP Client Service>>.
-* *Updated* | https://repose.atlassian.net/browse/REP-6379[REP-6379] - Updated the recommended SSL Protocol and Cipher lists and clarified this in the in the <<../architecture/container.adoc#, Container>> documentation.
-* *Updated* | https://repose.atlassian.net/browse/REP-7534[REP-7534] - Updated all repository references to the new location.
+* [.release-note-tag .added-tag]#Added# | https://repose.atlassian.net/browse/REP-6603[REP-6603] - Added support for multiple capture groups to the <<../filters/url-extractor-to-header.adoc#, URL Extractor to Header Filter>>.
+* [.release-note-tag .added-tag]#Added# | https://repose.atlassian.net/browse/REP-7386[REP-7386] - Added support for the `upgrade_account` account-level permission in the <<../filters/valkyrie-authorization.adoc#, Valkyrie Authorization Filter>>.
+* [.release-note-tag .added-tag]#Added# | https://repose.atlassian.net/browse/REP-7519[REP-7519] - Added support for proxies to the <<../services/http-client.adoc#, HTTP Client Service>>.
+* [.release-note-tag .updated-tag]#Added# | https://repose.atlassian.net/browse/REP-6379[REP-6379] - Updated the recommended SSL Protocol and Cipher lists and clarified this in the in the <<../architecture/container.adoc#, Container>> documentation.
+* [.release-note-tag .updated-tag]#Added# | https://repose.atlassian.net/browse/REP-7534[REP-7534] - Updated all repository references to the new location.
 
-* *Bug Fix* | *Updated* | https://repose.atlassian.net/browse/REP-7310[REP-7310] - Fixing the `IllegalArgumentException` thrown by the <<../filters/herp.adoc#, HERP Filter>> when incorrectly attempting to decode query parameters.
-* *Bug Fix* | *Updated* | https://repose.atlassian.net/browse/REP-7387[REP-7387] - The <<../filters/ip-user.adoc#, IP User>> filter now returns a `400` when the X-Forwarded-For header contains a bad value.
+* [.release-note-tag .bug-updated-tag]#Updated# |  https://repose.atlassian.net/browse/REP-7310[REP-7310] - Fixing the `IllegalArgumentException` thrown by the <<../filters/herp.adoc#, HERP Filter>> when incorrectly attempting to decode query parameters.
+* [.release-note-tag .bug-updated-tag]#Updated# | https://repose.atlassian.net/browse/REP-7387[REP-7387] - The <<../filters/ip-user.adoc#, IP User>> filter now returns a `400` when the X-Forwarded-For header contains a bad value.
 
-* *Breaking Change* | *Added* | https://repose.atlassian.net/browse/REP-6663[REP-6663] - Added support for forwarding the response status line reason phrase from the origin service.
-* *Breaking Change* | *Updated* | https://repose.atlassian.net/browse/REP-5147[REP-5147] - The <<../filters/header-normalization.adoc#, Header Normalization>> filter now evaluates all targets not just the first to match.
-* *Breaking Change* | *Updated* | https://repose.atlassian.net/browse/REP-3589[REP-3589] - Rewrote the <<../services/http-client.adoc#, HTTP Client Service>>.
-* *Breaking Change* | *Updated* | https://repose.atlassian.net/browse/REP-7231[REP-7231] - Switching over to new filter, filter chain, and servlet classes.
+* [.release-note-tag .breaking-added-tag]#Added# | https://repose.atlassian.net/browse/REP-6663[REP-6663] - Added support for forwarding the response status line reason phrase from the origin service.
+* [.release-note-tag .breaking-updated-tag]#Updated# | https://repose.atlassian.net/browse/REP-5147[REP-5147] - The <<../filters/header-normalization.adoc#, Header Normalization>> filter now evaluates all targets not just the first to match.
+* [.release-note-tag .breaking-updated-tag]#Updated# | https://repose.atlassian.net/browse/REP-3589[REP-3589] - Rewrote the <<../services/http-client.adoc#, HTTP Client Service>>.
+* [.release-note-tag .breaking-updated-tag]#Updated# | https://repose.atlassian.net/browse/REP-7231[REP-7231] - Switching over to new filter, filter chain, and servlet classes.
 ** Many unused and deprecated classes have been removed.
 ** The <<../filters/scripting.adoc#, Scripting Filter>> has been moved from the `repose-experimental-filter-bundle` to the `repose-filter-bundle`.
 ** Removed support for the <<../services/response-message.adoc#, Response Messaging Service>>.
@@ -39,20 +39,20 @@
 ** Moved the HTTP request method check to the beginning of processing rather than just before proxying the request.
    As a result, *Repose* will reject requests with an unsupported HTTP method before any filter processing can occur.
 *** Updated the HTTP response status code returned for a request with an unsupported method from a `500` to a `405`.
-* *Breaking Change* | *Updated* | https://repose.atlassian.net/browse/REP-7490[REP-7490] - Cleaning up some log messages in pursuit of more meaningful logging.
+* [.release-note-tag .breaking-updated-tag]#Updated# | https://repose.atlassian.net/browse/REP-7490[REP-7490] - Cleaning up some log messages in pursuit of more meaningful logging.
 ** Changing the `org.eclipse.jetty` logger level from `off` to `warn` in the default `log4j2.xml` configuration file.
 ** Removing a log event with a message including `Repose Devs might care about this trace` by the `org.openrepose.commons.config.parser.jaxb.JaxbConfigurationParser` logger.
 ** Changing the log level of events relating to unpacking artifacts by the `org.openrepose.commons.utils.classloader.EarClassProvider` logger from `debug` to `trace`.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-4992[REP-4992] - Removed ambiguous setting for chunked encoding options on <<../services/http-client.adoc, HTTP Client/Connection Pool Service>>.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7201[REP-7201] - The Rackspace Auth User, SAML Policy Translation, and Attribute Mapping Policy Validation filters were removed and placed in their own bundle.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-5326[REP-5326] - Removed the deprecated via attribute from the <<../architecture/container.adoc#, Container configuration>>.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7338[REP-7338] - The WAR deployment was removed as an option.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-4990[REP-4990] - Removed deprecated cache attributes from the <<../filters/openstack-identity-v3.adoc#, OpenStack Identity v3 Filter>>.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-4992[REP-4992] - Removed ambiguous setting for chunked encoding options on <<../services/http-client.adoc, HTTP Client/Connection Pool Service>>.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-7201[REP-7201] - The Rackspace Auth User, SAML Policy Translation, and Attribute Mapping Policy Validation filters were removed and placed in their own bundle.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-5326[REP-5326] - Removed the deprecated via attribute from the <<../architecture/container.adoc#, Container configuration>>.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-7338[REP-7338] - The WAR deployment was removed as an option.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-4990[REP-4990] - Removed deprecated cache attributes from the <<../filters/openstack-identity-v3.adoc#, OpenStack Identity v3 Filter>>.
 ** Cache timeouts are now defined in seconds rather than milliseconds.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7428[REP-7428] - Removed support for URI-based tenant validation in the <<../filters/keystone-v2-authorization.adoc#, Keystone v2 Authorization Filter>> and <<../filters/keystone-v2.adoc#, Keystone v2 Filter>>.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-4993[REP-4993] - Flush output filter was removed.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7314[REP-7314] - Removed support for <<../architecture/system-model.adoc#,system model>> clusters.
-* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7486[REP-7486] - Removed the Response Messaging Service itself and documented a replacement solution.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-7428[REP-7428] - Removed support for URI-based tenant validation in the <<../filters/keystone-v2-authorization.adoc#, Keystone v2 Authorization Filter>> and <<../filters/keystone-v2.adoc#, Keystone v2 Filter>>.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-4993[REP-4993] - Flush output filter was removed.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-7314[REP-7314] - Removed support for <<../architecture/system-model.adoc#,system model>> clusters.
+* [.release-note-tag .breaking-removed-tag]#Removed# | https://repose.atlassian.net/browse/REP-7486[REP-7486] - Removed the Response Messaging Service itself and documented a replacement solution.
 
 == 8.10.0.0 (2018-08-27)
 * https://repose.atlassian.net/browse/REP-6969[REP-6969] - Added support for more expressive filter determination in the <<../architecture/system-model.adoc#,System Model>> using boolean operators.

--- a/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
+++ b/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
@@ -3,8 +3,27 @@
 == 9.0.0.0 (2018-??-??)
 <<ver-9-upgrade-notes.adoc, Upgrade Notes>>
 
-* https://repose.atlassian.net/browse/REP-4992[REP-4992] - Removed ambiguous setting for chunked encoding options on <<../services/http-client.adoc, HTTP Client/Connection Pool Service>>.
-* https://repose.atlassian.net/browse/REP-3589[REP-3589] - Rewrote the <<../services/http-client.adoc#, HTTP Client Service>>.
+* *Added* | https://repose.atlassian.net/browse/REP-6603[REP-6603] - Added support for multiple capture groups to the <<../filters/url-extractor-to-header.adoc#, URL Extractor to Header Filter>>.
+* *Added* | https://repose.atlassian.net/browse/REP-7386[REP-7386] - Added support for the `upgrade_account` account-level permission in the <<../filters/valkyrie-authorization.adoc#, Valkyrie Authorization Filter>>.
+* *Added* | https://repose.atlassian.net/browse/REP-7519[REP-7519] - Added support for proxies to the <<../services/http-client.adoc#, HTTP Client Service>>.
+* *Updated* | https://repose.atlassian.net/browse/REP-6379[REP-6379] - Updated the recommended SSL Protocol and Cipher lists and clarified this in the in the <<../architecture/container.adoc#, Container>> documentation.
+* *Updated* | https://repose.atlassian.net/browse/REP-7534[REP-7534] - Updated all repository references to the new location.
+
+* *Bug Fix* | *Updated* | https://repose.atlassian.net/browse/REP-7310[REP-7310] - Fixing the `IllegalArgumentException` thrown by the <<../filters/herp.adoc#, HERP Filter>> when incorrectly attempting to decode query parameters.
+* *Bug Fix* | *Updated* | https://repose.atlassian.net/browse/REP-7387[REP-7387] - The <<../filters/ip-user.adoc#, IP User>> filter now returns a `400` when the X-Forwarded-For header contains a bad value.
+
+* *Breaking Change* | *Added* | https://repose.atlassian.net/browse/REP-6663[REP-6663] - Added support for forwarding the response status line reason phrase from the origin service.
+* *Breaking Change* | *Updated* | https://repose.atlassian.net/browse/REP-5147[REP-5147] - The <<../filters/header-normalization.adoc#, Header Normalization>> filter now evaluates all targets not just the first to match.
+* *Breaking Change* | *Updated* | https://repose.atlassian.net/browse/REP-3589[REP-3589] - Rewrote the <<../services/http-client.adoc#, HTTP Client Service>>.
+* *Breaking Change* | *Updated* | https://repose.atlassian.net/browse/REP-7231[REP-7231] - Switching over to new filter, filter chain, and servlet classes.
+** Many unused and deprecated classes have been removed.
+** The <<../filters/scripting.adoc#, Scripting Filter>> has been moved from the `repose-experimental-filter-bundle` to the `repose-filter-bundle`.
+** Removed support for the <<../services/response-message.adoc#, Response Messaging Service>>.
+** Headers are no longer automatically split.
+** Headers with an empty value are now supported and will not be removed from requests/responses.
+*** When querying rate limits via the the <<../filters/rate-limiting.adoc#, Rate Limiting Filter>>, an `Accept` header with an empty value will now result in a `406` response rather than a response of the default `Content-Type: application/json`.
+** A bug causing multiple OpenTracing headers (i.e., `uber-trace-id`) with potentially different values to be forwarded on the request to the origin service has been fixed.
+   Now only a single OpenTracing header will be forwarded.
 ** Redesigned the <<../services/http-client.adoc#, HTTP Client Service>> API.
 ** Moved the `chunked-encoding` configuration from the <<../services/http-client.adoc#configuration, HTTP Client Service configuration>> to the <<../architecture/system-model.adoc#configuration, System Model configuration>>.
 ** Updated HTTP Components dependencies:
@@ -20,38 +39,20 @@
 ** Moved the HTTP request method check to the beginning of processing rather than just before proxying the request.
    As a result, *Repose* will reject requests with an unsupported HTTP method before any filter processing can occur.
 *** Updated the HTTP response status code returned for a request with an unsupported method from a `500` to a `405`.
-* https://repose.atlassian.net/browse/REP-7201[REP-7201] - The Rackspace Auth User, SAML Policy Translation, and Attribute Mapping Policy Validation filters were removed and placed in their own bundle.
-* https://repose.atlassian.net/browse/REP-5147[REP-5147] - The <<../filters/header-normalization.adoc#, Header Normalization>> filter now evaluates all targets not just the first to match.
-* https://repose.atlassian.net/browse/REP-5326[REP-5326] - Removed the deprecated via attribute from the <<../architecture/container.adoc#, Container configuration>>.
-* https://repose.atlassian.net/browse/REP-7338[REP-7338] - The WAR deployment was removed as an option.
-* https://repose.atlassian.net/browse/REP-6603[REP-6603] - Added support for multiple capture groups to the <<../filters/url-extractor-to-header.adoc#, URL Extractor to Header Filter>>.
-* https://repose.atlassian.net/browse/REP-4990[REP-4990] - Removed deprecated cache attributes from the <<../filters/openstack-identity-v3.adoc#, OpenStack Identity v3 Filter>>.
-** Cache timeouts are now defined in seconds rather than milliseconds.
-* https://repose.atlassian.net/browse/REP-6663[REP-6663] - Added support for forwarding the response status line reason phrase from the origin service.
-* https://repose.atlassian.net/browse/REP-7428[REP-7428] - Removed support for URI-based tenant validation in the <<../filters/keystone-v2-authorization.adoc#, Keystone v2 Authorization Filter>> and <<../filters/keystone-v2.adoc#, Keystone v2 Filter>>.
-* https://repose.atlassian.net/browse/REP-6379[REP-6379] - Updated the recommended SSL Protocol and Cipher lists and clarified this in the in the <<../architecture/container.adoc#, Container>> documentation.
-* https://repose.atlassian.net/browse/REP-4993[REP-4993] - Flush output filter was removed.
-* https://repose.atlassian.net/browse/REP-7231[REP-7231] - Switching over to new filter, filter chain, and servlet classes.
-** Many unused and deprecated classes have been removed.
-** The <<../filters/scripting.adoc#, Scripting Filter>> has been moved from the `repose-experimental-filter-bundle` to the `repose-filter-bundle`.
-** Removed support for the <<../services/response-message.adoc#, Response Messaging Service>>.
-** Headers are no longer automatically split.
-** Headers with an empty value are now supported and will not be removed from requests/responses.
-*** When querying rate limits via the the <<../filters/rate-limiting.adoc#, Rate Limiting Filter>>, an `Accept` header with an empty value will now result in a `406` response rather than a response of the default `Content-Type: application/json`.
-** A bug causing multiple OpenTracing headers (i.e., `uber-trace-id`) with potentially different values to be forwarded on the request to the origin service has been fixed.
-   Now only a single OpenTracing header will be forwarded.
-* https://repose.atlassian.net/browse/REP-7314[REP-7314] - Removed support for <<../architecture/system-model.adoc#,system model>> clusters.
-* https://repose.atlassian.net/browse/REP-7310[REP-7310] - Fixing the `IllegalArgumentException` thrown by the <<../filters/herp.adoc#, HERP Filter>> when incorrectly attempting to decode query parameters.
-* https://repose.atlassian.net/browse/REP-7387[REP-7387] - The <<../filters/ip-user.adoc#, IP User>> filter now returns a `400` when the X-Forwarded-For header contains a bad value.
-* https://repose.atlassian.net/browse/REP-7386[REP-7386] - Added support for the `upgrade_account` account-level permission in the <<../filters/valkyrie-authorization.adoc#, Valkyrie Authorization Filter>>.
-* https://repose.atlassian.net/browse/REP-7486[REP-7486] - Documented removal and replacement solution for the Response Messaging Service.
-* https://repose.atlassian.net/browse/REP-7490[REP-7490] - Cleaning up some log messages in pursuit of more meaningful logging.
+* *Breaking Change* | *Updated* | https://repose.atlassian.net/browse/REP-7490[REP-7490] - Cleaning up some log messages in pursuit of more meaningful logging.
 ** Changing the `org.eclipse.jetty` logger level from `off` to `warn` in the default `log4j2.xml` configuration file.
 ** Removing a log event with a message including `Repose Devs might care about this trace` by the `org.openrepose.commons.config.parser.jaxb.JaxbConfigurationParser` logger.
 ** Changing the log level of events relating to unpacking artifacts by the `org.openrepose.commons.utils.classloader.EarClassProvider` logger from `debug` to `trace`.
-* https://repose.atlassian.net/browse/REP-7519[REP-7519] - Added support for proxies to the <<../services/http-client.adoc#, HTTP Client Service>>.
-* https://repose.atlassian.net/browse/REP-7534[REP-7534] - Updated all repository references to the new location.
-* https://repose.atlassian.net/browse/REP-4996[REP-4996] - Replaced `PowerFilter` with the `ReposeFilter`.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-4992[REP-4992] - Removed ambiguous setting for chunked encoding options on <<../services/http-client.adoc, HTTP Client/Connection Pool Service>>.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7201[REP-7201] - The Rackspace Auth User, SAML Policy Translation, and Attribute Mapping Policy Validation filters were removed and placed in their own bundle.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-5326[REP-5326] - Removed the deprecated via attribute from the <<../architecture/container.adoc#, Container configuration>>.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7338[REP-7338] - The WAR deployment was removed as an option.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-4990[REP-4990] - Removed deprecated cache attributes from the <<../filters/openstack-identity-v3.adoc#, OpenStack Identity v3 Filter>>.
+** Cache timeouts are now defined in seconds rather than milliseconds.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7428[REP-7428] - Removed support for URI-based tenant validation in the <<../filters/keystone-v2-authorization.adoc#, Keystone v2 Authorization Filter>> and <<../filters/keystone-v2.adoc#, Keystone v2 Filter>>.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-4993[REP-4993] - Flush output filter was removed.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7314[REP-7314] - Removed support for <<../architecture/system-model.adoc#,system model>> clusters.
+* *Breaking Change* | *Removed* | https://repose.atlassian.net/browse/REP-7486[REP-7486] - Removed the Response Messaging Service itself and documented a replacement solution.
 
 == 8.10.0.0 (2018-08-27)
 * https://repose.atlassian.net/browse/REP-6969[REP-6969] - Added support for more expressive filter determination in the <<../architecture/system-model.adoc#,System Model>> using boolean operators.

--- a/repose-aggregator/docs/src/resources/_stylesheets/release-note-categories.css
+++ b/repose-aggregator/docs/src/resources/_stylesheets/release-note-categories.css
@@ -1,0 +1,47 @@
+/* Styling for release note tags */
+
+.release-note-tag {
+    color: black;
+    background-color: #5cb85c;
+    border-radius: 3px;
+    display: inline;
+    font-weight: bold;
+    padding: 2px 6px;
+    text-align: center;
+}
+
+.added-tag {
+    background-color: #4caf50;
+}
+
+.bug-added-tag {
+    background-color: #ffeb3b;
+}
+
+.breaking-added-tag {
+    background-color: #d9534f;
+}
+
+.updated-tag {
+    background-color: #4caf50;
+}
+
+.bug-updated-tag {
+    background-color: #ffeb3b;
+}
+
+.breaking-updated-tag {
+    background-color: #d9534f;
+}
+
+.removed-tag {
+    background-color: #4caf50;
+}
+
+.bug-removed-tag {
+    background-color: #ffeb3b;
+}
+
+.breaking-removed-tag {
+    background-color: #d9534f;
+}


### PR DESCRIPTION
I opted to continue using words over symbols here, but that would be an easy change. Colors would also be an easy change.

Ideally, the tags would be aligned, but that is a less easy change.

I like that CSS allows us to easily change the look and feel of these tags (e.g., size, color, symbols vs words). It's all just text. That also plays well with version control. Of course, so would SVG images, but not image formats that are stored as binary data.

Here is what the current changes would look like:
<img width="1599" alt="screen shot 2019-01-29 at 4 41 51 pm" src="https://user-images.githubusercontent.com/1923408/51945680-f4e9f600-23e4-11e9-8084-9e69815f2e2b.png">
