### PR TITLE
REP-7272 Fixing typos

### DIFF
--- a/repose-aggregator/docs/src/asciibinder/architecture/filter-chain.adoc
+++ b/repose-aggregator/docs/src/asciibinder/architecture/filter-chain.adoc
@@ -97,7 +97,7 @@ And it will do this before each filter and the origin service allowing you to se
 This can be expensive in both time and disk space and is intended only as a debugging tool, not for full time use.
 ====
 
-For more troubleshooting help see our <<../troubleshooting.adoc#, guide>>.
+For more troubleshooting help see our <<../welcome/troubleshooting.adoc#, guide>>.
 
 == Metrics ==
 
@@ -106,7 +106,7 @@ If you wish to see these numbers or exfiltrate them to another tool look into th
 They are listed under `org.openrepose.core.FilterProcessingTime.Delay` with an entry for each filter by name.
 
 If you are curious about the numbers for a specific request you can add the `X-Trace-Request` header to the request.
-See <<../troubleshooting.adoc#_time_spent_in_each_filter,Time Spent in Each Filter>> for more details.
+See <<../welcome/troubleshooting.adoc#_time_spent_in_each_filter,Time Spent in Each Filter>> for more details.
 
 We also start an *OpenTracing* span for each filter that is ran.
 If you'd like to get this data look into the <<../services/open-tracing.adoc#, OpenTracing Service>>.

--- a/repose-aggregator/docs/src/asciibinder/architecture/filter-chain.adoc
+++ b/repose-aggregator/docs/src/asciibinder/architecture/filter-chain.adoc
@@ -97,19 +97,19 @@ And it will do this before each filter and the origin service allowing you to se
 This can be expensive in both time and disk space and is intended only as a debugging tool, not for full time use.
 ====
 
-For more troubleshooting help see our <<../troubleshooting.adoc, guide>>.
+For more troubleshooting help see our <<../troubleshooting.adoc#, guide>>.
 
 == Metrics ==
 
 *Repose* automatically records metrics on how long each request spends within a filter.
-If you wish to see these numbers or exfiltrate them to another tool look into the <<../services/metrics.adoc, Metrics Service>>.
+If you wish to see these numbers or exfiltrate them to another tool look into the <<../services/metrics.adoc#, Metrics Service>>.
 They are listed under `org.openrepose.core.FilterProcessingTime.Delay` with an entry for each filter by name.
 
 If you are curious about the numbers for a specific request you can add the `X-Trace-Request` header to the request.
 See <<../troubleshooting.adoc#_time_spent_in_each_filter,Time Spent in Each Filter>> for more details.
 
 We also start an *OpenTracing* span for each filter that is ran.
-If you'd like to get this data look into the <<../services/open-tracing.adoc, OpenTracing Service>>.
+If you'd like to get this data look into the <<../services/open-tracing.adoc#, OpenTracing Service>>.
 
 == Bypass URI ==
 

--- a/repose-aggregator/docs/src/asciibinder/filters/url-extractor-to-header.adoc
+++ b/repose-aggregator/docs/src/asciibinder/filters/url-extractor-to-header.adoc
@@ -13,7 +13,7 @@ This filter does not require any request headers.
 
 === Required Preceding Filters
 While this filter doesn't require any preceding filter, it's headers are added to any existing values.
-If you desire to only get the new values you should use the <<header-normalization.adoc, header normalization filter>>.
+If you desire to only get the new values you should use the <<header-normalization.adoc#, header normalization filter>>.
 
 === Request Headers Created
 This filter will create whatever headers you configure it to.

--- a/repose-aggregator/docs/src/asciibinder/recipes/getting-started.adoc
+++ b/repose-aggregator/docs/src/asciibinder/recipes/getting-started.adoc
@@ -109,15 +109,15 @@ See <<performance-best-practices.adoc#,Performance Best Practices>> for more det
 For further information on common configuration scenarios, visit our <<index.adoc#,Recipes>> page.
 
 ==== Troubleshooting
-For details on common troubleshooting techniques, visit our <<../troubleshooting.adoc#,Troubleshooting>> page.
+For details on common troubleshooting techniques, visit our <<../welcome/troubleshooting.adoc#,Troubleshooting>> page.
 
 ==== FAQs
-For a list of frequently asked questions and answers, visit our <<../faq.adoc#,FAQ>> page.
+For a list of frequently asked questions and answers, visit our <<../welcome/faq.adoc#,FAQ>> page.
 
 == Need More Information About Repose?
 http://www.openrepose.org/#contact-us[Contact us]! We would be happy to address any questions, comments, or concerns with anything having to do with *Repose*!
 
 [TIP]
 ====
-If you wonder what we've been working on lately, visit our <<../release-notes.adoc#,release notes>>.
+If you wonder what we've been working on lately, visit our <<../welcome/release-notes.adoc#,release notes>>.
 ====

--- a/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
+++ b/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
@@ -1,7 +1,7 @@
 = Release Notes
 
 == 9.0.0.0 (2018-01-31)
-<<ver-9-upgrade-notes.adoc, Upgrade Notes>>
+<<ver-9-upgrade-notes.adoc#, Upgrade Notes>>
 
 * [.bug-tag]#Bug Fix# |  https://repose.atlassian.net/browse/REP-7310[REP-7310] - Fixing the `IllegalArgumentException` thrown by the <<../filters/herp.adoc#, HERP Filter>> when incorrectly attempting to decode query parameters.
 * [.bug-tag]#Bug Fix# | https://repose.atlassian.net/browse/REP-7387[REP-7387] - The <<../filters/ip-user.adoc#, IP User>> filter now returns a `400` when the X-Forwarded-For header contains a bad value.
@@ -40,7 +40,7 @@
 ** Changing the `org.eclipse.jetty` logger level from `off` to `warn` in the default `log4j2.xml` configuration file.
 ** Removing a log event with a message including `Repose Devs might care about this trace` by the `org.openrepose.commons.config.parser.jaxb.JaxbConfigurationParser` logger.
 ** Changing the log level of events relating to unpacking artifacts by the `org.openrepose.commons.utils.classloader.EarClassProvider` logger from `debug` to `trace`.
-* [.breaking-tag]#Breaking Change# | https://repose.atlassian.net/browse/REP-4992[REP-4992] - Removed ambiguous setting for chunked encoding options on <<../services/http-client.adoc, HTTP Client/Connection Pool Service>>.
+* [.breaking-tag]#Breaking Change# | https://repose.atlassian.net/browse/REP-4992[REP-4992] - Removed ambiguous setting for chunked encoding options on <<../services/http-client.adoc#, HTTP Client/Connection Pool Service>>.
 * [.breaking-tag]#Breaking Change# | https://repose.atlassian.net/browse/REP-7201[REP-7201] - The Rackspace Auth User, SAML Policy Translation, and Attribute Mapping Policy Validation filters were removed and placed in their own bundle.
 * [.breaking-tag]#Breaking Change# | https://repose.atlassian.net/browse/REP-5326[REP-5326] - Removed the deprecated via attribute from the <<../architecture/container.adoc#, Container configuration>>.
 * [.breaking-tag]#Breaking Change# | https://repose.atlassian.net/browse/REP-7338[REP-7338] - The WAR deployment was removed as an option.

--- a/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
+++ b/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
@@ -1,6 +1,6 @@
 = Release Notes
 
-== 9.0.0.0 (2018-01-31)
+== 9.0.0.0 (2019-01-31)
 <<ver-9-upgrade-notes.adoc#, Upgrade Notes>>
 
 * [.bug-tag]#Bug Fix# |  https://repose.atlassian.net/browse/REP-7310[REP-7310] - Fixing the `IllegalArgumentException` thrown by the <<../filters/herp.adoc#, HERP Filter>> when incorrectly attempting to decode query parameters.

--- a/repose-aggregator/docs/src/asciibinder/welcome/ver-9-upgrade-notes.adoc
+++ b/repose-aggregator/docs/src/asciibinder/welcome/ver-9-upgrade-notes.adoc
@@ -98,7 +98,7 @@
   To replicate the previous behavior you need to configure it in the operating system.
 
 == Deployment
-. Support for installing *Repose* into an existing container has been dropped. For help moving to another deployment see <<../recipes/valve-installation.adoc, Valve Installation>> and <<../recipes/quick-start.adoc, Quick Start with Docker>>.
+. Support for installing *Repose* into an existing container has been dropped. For help moving to another deployment see <<../recipes/valve-installation.adoc#, Valve Installation>> and <<../recipes/quick-start.adoc#, Quick Start with Docker>>.
 . The package for valve installation has changed from `repose-valve` to `repose`.
 . The <<../filters/scripting.adoc#, Scripting Filter>> has been moved from the `repose-experimental-filter-bundle` to the `repose-filter-bundle`.
 


### PR DESCRIPTION
Fixed typos in the docs that made external links be interpreted as local anchors.