### PR TITLE
Gradle Build Release Property Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -400,7 +400,9 @@ subprojects {
         publications {
             nebula(MavenPublication) {
                 if(project.hasProperty('release')) {
-                    artifact source: signArchives.singleSignature, extension: 'asc'
+                    signArchives.signatures.each {
+                        artifact source: it, extension: 'asc'
+                    }
                 }
 
                 //when we include the signature it tries to switch the packaging in the pom to pom,


### PR DESCRIPTION
This fixes Gradle configuration issues that arise when running with the `release` property.

The change itself no longer assumes that projects have a single signature for publication, and instead will publish every signature available. This accounts for the possibility of `configurations` being added to projects and `artifacts` being associated with them. A choice was made here to allow all artifacts to be signed and to publish all signatures. Note, however, that this configuration is merely the default publishing configuration, and that some projects (e.g., `valve`) override it.