### PR TITLE
REP-7355 Adding a Slack notification message on performance test failure

### DIFF
--- a/repose-aggregator/tests/performance-tests/Jenkinsfile
+++ b/repose-aggregator/tests/performance-tests/Jenkinsfile
@@ -57,6 +57,14 @@ stage("Performance Test") {
     // builds the Repose artifacts for performance test jobs to use
     build("repose-gradle-package")
 
-    // starts the list of performance test jobs in parallel
-    parallel(jobsToRun)
+    try {
+        // starts the list of performance test jobs in parallel
+        parallel(jobsToRun)
+    } catch (t) {
+        try {
+            slackSend(color: 'danger', message: "One or more performance test has failed to run during build <${BUILD_URL}|${BUILD_TAG}>")
+        } finally {
+            throw t
+        }
+    }
 }


### PR DESCRIPTION
For what information is available to use here, see: 
https://jenkins.io/doc/book/pipeline/getting-started/#global-variable-reference