### PR TITLE
REP-7663 Fixing the RemoteDatastoreServiceTest

### DIFF
--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/services/datastore/remote/container.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/services/datastore/remote/container.cfg.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<repose-container xmlns='http://docs.openrepose.org/repose/container/v2.0'>
+    <deployment-config>
+        <deployment-directory auto-clean="true">
+            ${repose.home}/${subName}
+        </deployment-directory>
+        <artifact-directory check-interval="1000">
+            ${repose.home}/artifacts
+        </artifact-directory>
+        <logging-configuration href="file://${repose.config.directory}/log4j2-test.xml"/>
+    </deployment-config>
+</repose-container>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/services/datastore/RemoteDatastoreServiceTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/services/datastore/RemoteDatastoreServiceTest.groovy
@@ -90,7 +90,7 @@ class RemoteDatastoreServiceTest extends Specification {
         reposeLogSearch.cleanLog()
 
         def type = client ? "client" : "datastore"
-        def params = testProperties.getDefaultTemplateParams() + [datastorePort: datastorePort]
+        def params = testProperties.getDefaultTemplateParams() + [datastorePort: datastorePort, subName: subName]
         reposeValveLauncher.configurationProvider.cleanConfigDirectory()
         reposeValveLauncher.configurationProvider.applyConfigs("common", params)
         reposeValveLauncher.configurationProvider.applyConfigs("features/services/datastore/remote", params)


### PR DESCRIPTION
By separating deployment directories.

This fixes the test, but does not address the underlying issue with EAR unpacking.

See also:
#2033 
#2042