### PR TITLE
REP-7663 Fixing EAR Unpacking (CRC)

### DIFF
--- a/repose-aggregator/core/repose-core/src/main/scala/org/openrepose/commons/utils/classloader/EarClassProvider.scala
+++ b/repose-aggregator/core/repose-core/src/main/scala/org/openrepose/commons/utils/classloader/EarClassProvider.scala
@@ -19,15 +19,14 @@
  */
 package org.openrepose.commons.utils.classloader
 
-import java.io.{File, FileInputStream, FileOutputStream, IOException}
+import java.io._
 import java.net.{URL, URLClassLoader}
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
-import java.util.zip.{ZipFile, ZipInputStream}
+import java.util.zip.{CRC32, ZipFile, ZipInputStream}
 
 import com.oracle.javaee6.{ApplicationType, FilterType, ObjectFactory, WebFragmentType}
 import javax.xml.bind.JAXBContext
-import org.apache.commons.io.FileUtils.checksumCRC32
 import org.openrepose.commons.config.parser.jaxb.JaxbConfigurationParser
 import org.openrepose.commons.config.resource.impl.BufferedURLConfigurationResource
 import org.slf4j.LoggerFactory
@@ -40,9 +39,10 @@ object EarClassProvider {
 }
 
 class EarClassProvider(earFile: File, val outputDir: File) {
+
   /**
-   * Calls unpack, and gets you a new classloader for all the items in this ear file
-   */
+    * Calls unpack, and gets you a new classloader for all the items in this ear file
+    */
   private lazy val computeClassLoader: ClassLoader = {
     unpack()
 
@@ -82,8 +82,8 @@ class EarClassProvider(earFile: File, val outputDir: File) {
       name <- Option(a.getApplicationName)
       value <- Option(name.getValue) if !value.trim.isEmpty
     } yield {
-        value
-      }
+      value
+    }
     val appName = optionName getOrElse (throw new EarProcessingException(s"Unable to parse Application Name from ear file ${earFile.getName}!"))
 
     //Load the WebFragment data out of the ear file
@@ -132,42 +132,61 @@ class EarClassProvider(earFile: File, val outputDir: File) {
         outputDir.mkdir()
       }
 
-      //Make sure it's actually a zip file, so we can fail with some kind of exception
-      new ZipFile(earFile)
+      // Verify that the EAR is a valid ZIP file, throw an exception if not
+      new ZipFile(earFile).close()
 
-      val zis = new ZipInputStream(new FileInputStream(earFile))
+      val earInputStream = new ZipInputStream(new FileInputStream(earFile))
 
-      val buffer = new Array[Byte](1024)
-      Stream.continually(zis.getNextEntry).takeWhile(_ != null) foreach { entry =>
+      Stream.continually(earInputStream.getNextEntry).takeWhile(_ != null).foreach { entry =>
         val entryFile = new File(outputDir, entry.getName)
         if (entry.isDirectory) {
           entryFile.mkdir()
         } else {
-          val ofs = new FileOutputStream(entryFile)
+          // Creates the file if it does not already exist
+          val randomAccessEntryFile = new RandomAccessFile(entryFile, "rw")
           try {
+            val entryFileChannel = randomAccessEntryFile.getChannel
+
             log.trace("Obtaining file lock on: {}", entryFile)
-            val lock = ofs.getChannel.lock()
-            try {
-              if (!entryFile.exists() || entry.getCrc != checksumCRC32(entryFile)) {
-                log.trace("Unpacking: {}", entryFile)
-                Stream.continually(zis.read(buffer)).takeWhile(_ != -1).foreach(count => ofs.write(buffer, 0, count))
-              } else {
-                log.trace("File already exists in a valid condition. Skipping: {}", entryFile)
-              }
-            } finally {
-              log.trace("Releasing file lock on: {}", entryFile)
-              lock.release()
+            entryFileChannel.lock()
+
+            if (entry.getCrc != checksumCRC32(randomAccessEntryFile)) {
+              log.trace("Unpacking: {}", entryFile)
+              // Clear the current contents of the file
+              entryFileChannel.truncate(0)
+              // Write the zip entry contents to the file
+              actionOnRead(earInputStream.read(_), randomAccessEntryFile.write(_, _, _))
+              // Force the contents to be written to disk
+              entryFileChannel.force(false)
+            } else {
+              log.trace("File already exists in a valid condition. Skipping: {}", entryFile)
             }
           } finally {
-            ofs.close()
+            log.trace("Releasing file lock on: {}", entryFile)
+            // Closing the file also closes the channel and releases the file lock
+            randomAccessEntryFile.close()
           }
         }
       }
-      zis.close()
+      earInputStream.close()
     } catch {
       case e: Exception =>
         log.warn("Error during ear extraction! Partial extraction at {}", outputDir.getAbsolutePath)
         throw new EarProcessingException("Unable to fully extract file", e);
     }
+  }
+
+  private def checksumCRC32(file: RandomAccessFile): Long = {
+    val crc = new CRC32()
+    actionOnRead(file.read(_), crc.update(_, _, _))
+    crc.getValue
+  }
+
+  private def actionOnRead(read: Array[Byte] => Integer, action: (Array[Byte], Integer, Integer) => Unit): Unit = {
+    val bufferSize = 2048
+    val buffer = new Array[Byte](bufferSize)
+    Stream.continually(read(buffer))
+      .takeWhile(_ != -1)
+      .foreach(action(buffer, 0, _))
   }
 }

--- a/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
+++ b/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
@@ -17,6 +17,7 @@
 *** Jython: 2.7.0 → 2.7.1
 *** Scala Reflect: Undetermined → 2.11.12
 *** Spring: 4.1.4.RELEASE → 4.3.21.RELEASE
+* https://repose.atlassian.net/browse/REP-7663[REP-7663] - Fixed a file contention issue between Repose processes in the EAR unpacking logic.
 
 == 9.0.0.0 (2019-01-31)
 <<ver-9-upgrade-notes.adoc#, Upgrade Notes>>


### PR DESCRIPTION
This replaces the `FileOutputStream` we were using with a `RandomAccessFile` and replaces the Apache Commons checksum function with our own. Doing so fixes two outstanding issues.

The first issue was that the `FileOutputStream` was not set to append mode, which caused the `FileOutputStream` to truncate its underlying file on instantiation. As a result, there may have been times where the file on disk was assumed to be valid when actually it was in a partially written state.

The second issue was that the `checksumCRC32` function would read the file using a `FileInputStream` that the function instantiated itself. After calculating the checksum, that function would close the `FileInputStream` which would release the lock we acquired from the channel underlying our `FileOutputStream`. Since we would not have written our file by the time that lock was released, the opportunity arose for other processes to obtain the lock and write the same file at the same time. This would lead to files being left in bad states.

For good measure, I am also calling the `force(...)` method on the underlying channel to ensure that the content we write makes it to disk before we release our lock. Without that call, it seems like there was the potential for our content to be buffered but not written when we release the lock. It is difficult for me to say whether or not I saw this issue in practice since there were other outstanding issues that may have looked similar, but I figure that this is a better safe than sorry situation.

I should also note that many parts of the Java IO APIs are system-dependent. For example, that `force(...)`  call may effectively be called when `RandomAccessFile.close()` is called on some systems, but it is not a guarantee for all systems.

See also:
#2033 
#2041