### PR TITLE
REP-7720: Specify repose heap size for tests

### DIFF
--- a/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveLauncher.groovy
+++ b/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveLauncher.groovy
@@ -47,6 +47,8 @@ class ReposeValveLauncher extends ReposeLauncher {
     def debugPort = null
     def classPaths = []
     def additionalEnvironment = [:]
+    def xmx = "1536M"
+    def xms = "1024M"
 
     ReposeConfigurationProvider configurationProvider
 
@@ -86,6 +88,12 @@ class ReposeValveLauncher extends ReposeLauncher {
         boolean waitOnJmxAfterStarting = true
         if (params.containsKey("waitOnJmxAfterStarting")) {
             waitOnJmxAfterStarting = params.waitOnJmxAfterStarting
+        }
+        if (params.containsKey("reposeXmx")) {
+            xmx = params.reposeXmx
+        }
+        if (params.containsKey("reposeXms")) {
+            xms = params.reposeXms
         }
 
         String nodeId = params.get('nodeId', "")
@@ -156,7 +164,7 @@ class ReposeValveLauncher extends ReposeLauncher {
         //TODO: possibly add a -Dlog4j.configurationFile to the guy so that we can load a different log4j config for early logging
 
         //Prepended the JUL logging manager from log4j2 so I can capture JUL logs, which are things in the JVM (like JMX)
-        def cmd = "java -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Xmx1536M -Xms1024M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/dump-${debugPort}.hprof $classPath $debugProps $jmxprops $jacocoProps $javaArgs -jar $reposeJar -c $configDir"
+        def cmd = "java -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Xmx${xmx} -Xms${xms} -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/dump-${debugPort}.hprof $classPath $debugProps $jmxprops $jacocoProps $javaArgs -jar $reposeJar -c $configDir"
         println("Starting repose: $cmd")
 
         def th = new Thread({

--- a/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveLauncher.groovy
+++ b/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveLauncher.groovy
@@ -47,8 +47,8 @@ class ReposeValveLauncher extends ReposeLauncher {
     def debugPort = null
     def classPaths = []
     def additionalEnvironment = [:]
-    def xmx = "1536M"
-    def xms = "1024M"
+    def xmx = "1024M"
+    def xms = "512M"
 
     ReposeConfigurationProvider configurationProvider
 

--- a/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveLauncher.groovy
+++ b/repose-aggregator/tests/functional-test-framework/src/main/groovy/org/openrepose/framework/test/ReposeValveLauncher.groovy
@@ -47,8 +47,9 @@ class ReposeValveLauncher extends ReposeLauncher {
     def debugPort = null
     def classPaths = []
     def additionalEnvironment = [:]
-    def xmx = "1024M"
-    def xms = "512M"
+
+    static def DEFAULT_REPOSE_XMX = "1024M"
+    static def DEFAULT_REPOSE_XMS = "512M"
 
     ReposeConfigurationProvider configurationProvider
 
@@ -89,16 +90,12 @@ class ReposeValveLauncher extends ReposeLauncher {
         if (params.containsKey("waitOnJmxAfterStarting")) {
             waitOnJmxAfterStarting = params.waitOnJmxAfterStarting
         }
-        if (params.containsKey("reposeXmx")) {
-            xmx = params.reposeXmx
-        }
-        if (params.containsKey("reposeXms")) {
-            xms = params.reposeXms
-        }
 
         String nodeId = params.get('nodeId', "")
 
-        start(killOthersBeforeStarting, waitOnJmxAfterStarting, nodeId)
+        def reposeXmx = params.get('reposeXmx', DEFAULT_REPOSE_XMX)
+        def reposeXms = params.get('reposeXms', DEFAULT_REPOSE_XMS)
+        start(killOthersBeforeStarting, waitOnJmxAfterStarting, nodeId, reposeXmx, reposeXms)
     }
 
     /**
@@ -106,7 +103,7 @@ class ReposeValveLauncher extends ReposeLauncher {
      * @param killOthersBeforeStarting
      * @param waitOnJmxAfterStarting
      */
-    void start(boolean killOthersBeforeStarting, boolean waitOnJmxAfterStarting, String nodeId) {
+    void start(boolean killOthersBeforeStarting, boolean waitOnJmxAfterStarting, String nodeId, String xmx = DEFAULT_REPOSE_XMX, String xms = DEFAULT_REPOSE_XMS) {
 
         File jarFile = new File(reposeJar)
         if (!jarFile.exists() || !jarFile.isFile()) {


### PR DESCRIPTION
This PR adds the ability to specify the repose heap size for individual tests.

- Decreased the default values in ReposeValveLauncher from 1536M and 1024M to 1024M and 512M
- To specify the heap size, replace 
`repose.start()` with 
`repose.start([reposeXmx:"<xmx>",reposeXms:"<xms>"])` 
where xmx is the max heap size, and xms is the min heap size. 
Ex: `repose.start([reposeXmx:"1536M",reposeXms:"1024M"])`
- Pull the values from the params to repose start if they are there, and insert them into the command to start repose.

Right now all the tests still use the default values. 