### PR TITLE
REP-7776 Upgrading okhttp to resolve CVE-2018-20200

### DIFF
--- a/repose-aggregator/components/services/open-tracing-service/build.gradle
+++ b/repose-aggregator/components/services/open-tracing-service/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile "org.springframework:spring-beans"
     compile "io.opentracing:opentracing-api"
     compile "io.opentracing:opentracing-util"
+    compile 'com.squareup.okhttp3:okhttp' // Forces the version used by jaeger-core.
     compile 'org.apache.thrift:libthrift' // Forces the version used by jaeger-core.
     compile "io.jaegertracing:jaeger-core"
 

--- a/repose-aggregator/core/repose-core/build.gradle
+++ b/repose-aggregator/core/repose-core/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     compile "javax.ws.rs:javax.ws.rs-api"
     compile "io.opentracing:opentracing-api"
     compile "io.opentracing:opentracing-util"
+    compile 'com.squareup.okhttp3:okhttp' // Forces the version used by jaeger-core.
     compile 'org.apache.thrift:libthrift' // Forces the version used by jaeger-core.
     compile "io.jaegertracing:jaeger-core"
 

--- a/repose-aggregator/tests/functional-test-framework/build.gradle
+++ b/repose-aggregator/tests/functional-test-framework/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile 'javax.ws.rs:javax.ws.rs-api'
     compile 'joda-time:joda-time'
     compile 'org.linkedin:org.linkedin.util-groovy'
+    compile 'com.squareup.okhttp3:okhttp' // Forces the version used by jaeger-core.
     compile 'org.apache.thrift:libthrift' // Forces the version used by jaeger-core.
     compile 'io.jaegertracing:jaeger-core'
 }

--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,7 @@ com.sun.xml.bind:jaxb-impl=$jaxbVersion
 com.typesafe:config=1.2.1
 akkaVersion=2.4.20
 com.rackspace.cloud.api:wadl-tools_2.11=1.0.32
+com.squareup.okhttp3:okhttp=3.12.1
 com.typesafe.akka:akka-actor_2.11=$akkaVersion
 com.typesafe.akka:akka-testkit_2.11=$akkaVersion
 com.typesafe.akka:akka-http-core-experimental_2.11=1.0


### PR DESCRIPTION
The dependency check plugin is flagging an issue with our transitive dependency on `okhttp` (via `jaeger-core`).

Unfortunately, upgrading `jaeger-core` does not resolve this issue for us at this time. So instead we upgrade the library directly, preferring that to suppressing the issue.