### PR TITLE
REP-7966 Url encoding of Headers

### DIFF
--- a/repose-aggregator/core/repose-core-api/src/main/java/org/openrepose/core/systemmodel/config/DestinationList.java
+++ b/repose-aggregator/core/repose-core-api/src/main/java/org/openrepose/core/systemmodel/config/DestinationList.java
@@ -23,6 +23,7 @@ import lombok.Data;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -36,4 +37,6 @@ import java.util.List;
 public class DestinationList
     implements Serializable {
     private List<Destination> endpoint = new ArrayList<>();
+    @XmlAttribute(name = "url-encode-headers")
+    private String urlEncodeHeaders;
 }

--- a/repose-aggregator/core/repose-core-api/src/main/resources/META-INF/schema/system-model/system-model.xsd
+++ b/repose-aggregator/core/repose-core-api/src/main/resources/META-INF/schema/system-model/system-model.xsd
@@ -447,6 +447,14 @@
             <xs:element name="endpoint" type="mod:Destination" minOccurs="1" maxOccurs="unbounded"/>
         </xs:sequence>
 
+        <xs:attribute name="url-encode-headers" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>A comma separated list of the headers that should url encoded before being passed on to the origin service</html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
         <xs:assert vc:minVersion="1.1"
                    test="count(mod:*[xs:boolean(@default) = true()]) eq 1"
                    xerces:message="There should be one and only one default destination"

--- a/repose-aggregator/core/repose-core/src/main/scala/org/openrepose/powerfilter/ReposeRoutingServlet.scala
+++ b/repose-aggregator/core/repose-core/src/main/scala/org/openrepose/powerfilter/ReposeRoutingServlet.scala
@@ -68,6 +68,7 @@ class ReposeRoutingServlet @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_V
   private var localNode: Node = _
   private var defaultDestination: Destination = _
   private var destinations: Map[String, Destination] = Map.empty
+  private var urlEncodeHeaders: List[String] = List.empty
   private var rewriteHostHeader: Boolean = _
   private var initialized = false
 
@@ -104,6 +105,8 @@ class ReposeRoutingServlet @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_V
       .map(it => it.getId -> it)
       .toMap
     rewriteHostHeader = configurationObject.isRewriteHostHeader
+
+    urlEncodeHeaders = Option(configurationObject.getDestinations.getUrlEncodeHeaders).map(_.split(",").map(_.toLowerCase).toList).getOrElse(List.empty)
 
     //Build a list of the destinations in this cluster, just so we know what we're doing
     val destStrings = destinations
@@ -244,6 +247,7 @@ class ReposeRoutingServlet @Inject()(@Value(ReposeSpringProperties.CORE.REPOSE_V
       servletRequest,
       target.url.toURI,
       rewriteHostHeader,
+      urlEncodeHeaders.asJava,
       target.chunkedEncoding)
   }
 

--- a/repose-aggregator/core/repose-core/src/test/java/org/openrepose/nodeservice/httpcomponent/HttpComponentRequestProcessorTest.java
+++ b/repose-aggregator/core/repose-core/src/test/java/org/openrepose/nodeservice/httpcomponent/HttpComponentRequestProcessorTest.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -60,6 +61,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         assertThat(clientRequest.getMethod(), equalTo(request.getMethod()));
@@ -75,6 +77,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080" + targetPath),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         assertThat(clientRequest.getURI().getPath(), equalTo(targetPath));
@@ -90,6 +93,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         assertThat(clientRequest.getURI().toString(), allOf(containsString("param1%5B%5D=value1"), containsString("param2=value21"), containsString("param2=value22")));
@@ -101,12 +105,30 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         List<String> header1Values = Arrays.stream(clientRequest.getHeaders("header1")).map(NameValuePair::getValue).collect(Collectors.toList());
         List<String> header2Values = Arrays.stream(clientRequest.getHeaders("header2")).map(NameValuePair::getValue).collect(Collectors.toList());
 
         assertThat(header1Values, contains(values1));
+        assertThat(header2Values, contains(values2));
+    }
+
+    @Test
+    public void shouldEncodeConfiguredHeaders() throws Exception {
+        request.addHeader("Header1", "バナナ");
+        HttpUriRequest clientRequest = HttpComponentRequestProcessor.process(
+            request,
+            URI.create("http://www.openrepose.org:8080"),
+            true,
+            Collections.singletonList("header1"),
+            ChunkedEncoding.TRUE);
+
+        List<String> header1Values = Arrays.stream(clientRequest.getHeaders("header1")).map(NameValuePair::getValue).collect(Collectors.toList());
+        List<String> header2Values = Arrays.stream(clientRequest.getHeaders("header2")).map(NameValuePair::getValue).collect(Collectors.toList());
+
+        assertThat(header1Values, hasItem("%E3%83%90%E3%83%8A%E3%83%8A"));
         assertThat(header2Values, contains(values2));
     }
 
@@ -118,6 +140,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         assertThat(clientRequest.getFirstHeader("Host").getValue(), equalTo("www.openrepose.org"));
@@ -131,6 +154,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         assertThat(clientRequest.getFirstHeader("Host").getValue(), equalTo("www.openrepose.org:8080"));
@@ -146,6 +170,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
     }
 
@@ -159,6 +184,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
     }
 
@@ -172,6 +198,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
     }
 
@@ -185,6 +212,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
     }
 
@@ -198,6 +226,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org:8080"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         String clientRequestContent = EntityUtils.toString(clientRequest.getEntity());
@@ -214,6 +243,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         assertThat(clientRequest.getEntity().getContentLength(), lessThan(0L));
@@ -229,6 +259,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.FALSE);
 
         assertThat(clientRequest.getEntity().getContentLength(), equalTo((long) servletRequestContent.length()));
@@ -245,6 +276,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.AUTO);
 
         assertThat(clientRequest.getEntity().getContentLength(), lessThan(0L));
@@ -260,6 +292,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.FALSE);
 
         assertThat(clientRequest.getEntity().getContentLength(), equalTo((long) servletRequestContent.length()));
@@ -274,6 +307,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
     }
 
@@ -288,6 +322,7 @@ public class HttpComponentRequestProcessorTest {
             request,
             URI.create("http://www.openrepose.org"),
             true,
+            Collections.emptyList(),
             ChunkedEncoding.TRUE);
 
         assertThat(clientRequest.getEntity().getContentLength(), lessThan(0L));

--- a/repose-aggregator/docs/src/asciibinder/architecture/system-model.adoc
+++ b/repose-aggregator/docs/src/asciibinder/architecture/system-model.adoc
@@ -150,11 +150,11 @@ If set to localhost, any physical node will match and run the *Repose* node.
      In this case, no services are being used.
 <12> Defines the required one default endpoint.
 
-==== Streaming Request Body to the Origin Service
+=== Streaming Request Body to the Origin Service
 Streaming a request body to the origin service is accomplished by using the `chunked` transfer encoding.
 
 [source,xml]
-.partial http-connection-pool.cfg
+.system-model.cfg.xml
 ----
 <system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
   <nodes>
@@ -184,6 +184,28 @@ Setting the `chunked-encoding` attribute to `false` may cause *Repose* to read a
 This will cause some performance degradation as request body is no longer always streamed through.
 It is recommended that users leave this value as `true` unless their service does not support chunked encoding.
 ====
+
+=== Header Encoding
+If headers got added to the request while processing through *Repose* that contain characters that are valid by the HTTP spec this allows them to be encoded before being sent to the origin service.
+
+[source,xml]
+.system-model.cfg.xml
+----
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+  <nodes>
+    <node id="repose_node" hostname="localhost" http-port="8080"/>
+  </nodes>
+
+  <filters/>
+
+  <destinations url-encode-headers="x-header-1,x-header-2"> <!--1-->
+    <endpoint id="origin_service" default="true" protocol="http" port="80"
+              chunked-encoding="auto"/>
+  </destinations>
+</system-model>
+----
+<1> This is a comma separated list of all the headers that should be URL Encoded.
+    Default: empty
 
 === Nova-API Localhost Deployment
 *IN PROGRESS*

--- a/repose-aggregator/docs/src/asciibinder/recipes/index.adoc
+++ b/repose-aggregator/docs/src/asciibinder/recipes/index.adoc
@@ -67,3 +67,6 @@ Details how to make version 9.0+ of *Repose* split headers like earlier versions
 
 == <<reason-phrase-normalization.adoc#, Reason Phrase Normalization>>
 Details how to normalize the reason phrase on the status line of an HTTP response.
+
+== <<project-karate.adoc#, Problematic Header Handling>>
+Details what to do if *Repose* adds headers that might have non-legal values, that you can't otherwise change your configuration to remove (like if they are needed for rate limiting).

--- a/repose-aggregator/docs/src/asciibinder/recipes/project-karate.adoc
+++ b/repose-aggregator/docs/src/asciibinder/recipes/project-karate.adoc
@@ -1,0 +1,74 @@
+= Problematic Header Handling
+
+This recipe is meant to provide solutions if *Repose*'s header enrichment is creating headers with non-legal characters.
+The ideal solution is to turn off the generation of the problem headers, but there are situations where that may not be possible because they are needed downstream in the orign service or are required for internal *Repose* usage (like rate limiting).
+
+If the origin service doesn't need any of the problematic headers that *Repose* adds, you can use <<Header Normalization>>.
+If the origin service does use the added headers you'll need to use <<Header Encoding>>.
+
+== Header Normalization
+This solution will remove the problematic headers before sending the request onto the origin service
+
+=== Update the System Model
+The first step is to update your system model and add another <<../filters/header-normalization.adoc#, header normalization filter>> to the end of your filter chain.
+
+[source,xml]
+.partial system-model.cfg.xml
+----
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+
+  <!-- Node definition -->
+
+  <filters>
+    <!-- Other filters in chain -->
+    <filter="header-normalization" configuration="karate-headers.cfg.xml"/> <!--1-->
+  </filters>
+
+  <!-- Rest of system model -->
+
+</system-model>
+----
+<1> Specifies a new header noramilzation filter and tells it to look for its configuration in `karate-headers.cfg.xml`.
+
+=== Add the Header Normalization Config
+Create a new header normalization config named `karate-header.cfg.xml`.
+
+[source,xml]
+.karate-headers.cfg.xml
+----
+<header-normalization xmlns='http://docs.openrepose.org/repose/header-normalization/v1.0'>
+    <target>
+        <request>
+            <blacklist>
+                <header id="X-User-Name"/> <!--1-->
+                <header id="X-PP-User"/> <!--2-->
+                <header id="x-catalog"/> <!--3-->
+            </blacklist>
+        </request>
+    </target>
+</header-normalization>
+----
+<1> When using the <<../filters/keystone-v2.adoc#, Keystone v2 Filter>> this header is populated with the users username.
+<2> This header is populated at the same time with the same value and is used for rate limiting.
+<3> This header is also created at the same time, and contains a significant part of the identity response which may contain bad characters.
+
+== Header Encoding
+This solution is for when your origin service depends on the header values that might have some bad characters.
+
+=== Update the System Model
+The only step in this solution is to update the system model with the header you want encoded.
+
+[source,xml]
+.partial system-model.cfg.xml
+----
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+
+  <!-- Rest of system model -->
+
+  <destinations url-encode-headers="X-User-Name,X-PP-User,x-catalog"> <!--1-->
+    <endpoint id="origin_service" default="true" protocol="http" port="80"
+              chunked-encoding="auto"/>
+  </destinations>
+</system-model>
+----
+<1> This is the list of headers populated by <<../filters/keystone-v2.adoc#, Keystone v2 Filter>> that are known to possibly end up with bad characters.

--- a/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
+++ b/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
@@ -1,6 +1,7 @@
 = Release Notes
 
 == In Progress
+* [.enhancement-tag]#Enhancement# | https://repose.atlassian.net/browse/REP-7966[REP-7966] - Added option to <<../architecture/system-model.adoc#, System Model>> to allow a header value to be URL encoded before being sent to the origin service.
 * [.enhancement-tag]#Enhancement# | https://repose.atlassian.net/browse/REP-7954[REP-7954] - Updated dependencies:
 ** Jackson Databind: 2.9.9 → 2.9.9.3
 

--- a/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
+++ b/repose-aggregator/docs/src/asciibinder/welcome/release-notes.adoc
@@ -3,7 +3,7 @@
 == In Progress
 * [.enhancement-tag]#Enhancement# | https://repose.atlassian.net/browse/REP-7966[REP-7966] - Added option to <<../architecture/system-model.adoc#, System Model>> to allow a header value to be URL encoded before being sent to the origin service.
 * [.enhancement-tag]#Enhancement# | https://repose.atlassian.net/browse/REP-7954[REP-7954] - Updated dependencies:
-** Jackson Databind: 2.9.9 → 2.9.9.3
+** Jackson: 2.9.9 → 2.9.10
 
 == 9.0.1.0 (2019-06-24)
 * [.new-tag]#New# | https://repose.atlassian.net/browse/REP-7786[REP-7786] - Added the <<../services/http-logging.adoc#, HTTP Logging Service>>.

--- a/repose-aggregator/src/config/dependency-check/OWASP-Suppression.xml
+++ b/repose-aggregator/src/config/dependency-check/OWASP-Suppression.xml
@@ -122,4 +122,12 @@
         <cve>CVE-2018-1324</cve>
         <cve>CVE-2018-11771</cve>
     </suppress>
+    <suppress>
+       <notes><![CDATA[
+            file name: netty-3.10.6.Final.jar
+            This vulnerability is for when using netty as a server, for us it's being used transitive for flume and even in that capacity it's a client not a server.
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/io\.netty/netty@.*$</packageUrl>
+       <cve>CVE-2019-16869</cve>
+    </suppress>
 </suppressions>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/core/headers/headerencoding/scripting.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/core/headers/headerencoding/scripting.cfg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<scripting xmlns="http://docs.openrepose.org/repose/scripting/v1.0"
+           language="groovy">
+    switch(request.getHeader("Test-Case")) {
+        case "A" :
+            request.addHeader("x-header-two", "banana")
+            break
+        case "B" :
+            request.addHeader("x-header-two", "バナナ")
+            break
+    }
+
+    request.addHeader("x-header-three", "bar")
+    filterChain.doFilter(request, response)
+</scripting>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/core/headers/headerencoding/system-model.cfg.xml
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/configs/features/core/headers/headerencoding/system-model.cfg.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <nodes>
+        <node id="simple-node" hostname="localhost" http-port="${reposePort}"/>
+    </nodes>
+
+    <filters>
+        <filter name="scripting"/>
+    </filters>
+
+    <destinations url-encode-headers="X-Header-Two">
+        <endpoint id="target" protocol="http" port="${targetPort}" default="true"/>
+    </destinations>
+</system-model>

--- a/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/headers/HeaderEncodingTest.groovy
+++ b/repose-aggregator/tests/functional-tests/src/integrationTest/groovy/features/core/headers/HeaderEncodingTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * _=_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=
+ * Repose
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Copyright (C) 2010 - 2015 Rackspace US, Inc.
+ * _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_=_
+ */
+package features.core.headers
+
+import org.junit.experimental.categories.Category
+import org.openrepose.framework.test.ReposeValveTest
+import org.rackspace.deproxy.Deproxy
+import org.rackspace.deproxy.MessageChain
+import scaffold.category.Core
+import spock.lang.Unroll
+
+@Category(Core)
+class HeaderEncodingTest extends ReposeValveTest {
+
+    def setupSpec() {
+        deproxy = new Deproxy()
+        deproxy.addEndpoint(properties.targetPort)
+
+        def params = properties.getDefaultTemplateParams()
+
+        repose.configurationProvider.cleanConfigDirectory()
+        repose.configurationProvider.applyConfigs("common", params)
+        repose.configurationProvider.applyConfigs("features/core/headers/headerencoding", params)
+
+        repose.start()
+    }
+
+    @Unroll
+    def "Should successfully encode values for case #testCase"() {
+        given:
+        def headers = [
+            'Test-Case': testCase,
+            'x-header-one': "foo",
+        ]
+
+        when: "make a request with the given header and value"
+        MessageChain mc = deproxy.makeRequest(url: reposeEndpoint, headers: headers)
+
+        then: "the request should make it to the origin service with the header appropriately split"
+        mc.handlings.size() == 1
+        mc.handlings[0].request.headers.getFirstValue("x-header-one") == "foo"
+        mc.handlings[0].request.headers.getFirstValue("x-header-two") == encodedValue
+        mc.handlings[0].request.headers.getFirstValue("x-header-three") == "bar"
+
+        where:
+        testCase | encodedValue
+        'A'      | "banana"
+        'B'      | "%E3%83%90%E3%83%8A%E3%83%8A"
+    }
+}

--- a/versions.properties
+++ b/versions.properties
@@ -1,9 +1,8 @@
 com.atlassian.oai:swagger-request-validator-core=2.2.2
-jacksonVersion=2.9.9
-jacksonDatabindVersion=2.9.9.3
+jacksonVersion=2.9.10
 com.fasterxml.jackson.core:jackson-annotations=$jacksonVersion
 com.fasterxml.jackson.core:jackson-core=$jacksonVersion
-com.fasterxml.jackson.core:jackson-databind=$jacksonDatabindVersion
+com.fasterxml.jackson.core:jackson-databind=$jacksonVersion
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml=$jacksonVersion
 com.github.jknack:handlebars=2.0.0
 com.github.scopt:scopt_2.11=3.2.0


### PR DESCRIPTION
Allows header values to be url encoded before going to the origin service